### PR TITLE
fix(ed): cancel queued tea bar heating after filling

### DIFF
--- a/midealan/devices/ed/__init__.py
+++ b/midealan/devices/ed/__init__.py
@@ -144,6 +144,7 @@ class MideaEDDevice(MideaDevice):
             },
         )
         if self._is_tea_bar():
+            self._tea_bar_cancel_after_dispensing = False
             self._attributes.update(
                 {
                     DeviceAttributes.current_temperature: None,
@@ -244,6 +245,21 @@ class MideaEDDevice(MideaDevice):
                 heating = new_status[DeviceAttributes.heating]
                 new_status[DeviceAttributes.boiling] = heating
                 self._attributes[DeviceAttributes.boiling] = heating
+            if (
+                self._tea_bar_cancel_after_dispensing
+                and DeviceAttributes.dispensing in new_status
+                and DeviceAttributes.heating in new_status
+                and new_status[DeviceAttributes.dispensing] is False
+            ):
+                self._tea_bar_cancel_after_dispensing = False
+                if new_status[DeviceAttributes.heating] is True:
+                    # Model 63000622 queues heating while it dispenses water.
+                    # Its first heat-stop command is acknowledged but does not
+                    # cancel that queued phase, so repeat the same verified
+                    # command once when the device transitions into heating.
+                    stop_message = MessageNewSet(self._message_protocol_version)
+                    stop_message.heating = False
+                    self.build_send(stop_message)
         return new_status
 
     def _set_tea_bar_attribute(
@@ -283,15 +299,21 @@ class MideaEDDevice(MideaDevice):
                 )
                 raise ValueError(msg)
             self._validate_tea_bar_target(target_temperature)
+            self._tea_bar_cancel_after_dispensing = False
             message.target_temperature = target_temperature
             message.heating = True
             stored_value = target_temperature
         elif attr == DeviceAttributes.boiling:
             boiling = bool(value)
-            # Model 63000622's official App TeaHeat control always sends both
-            # custom_temperature_1=100 and the heat_start toggle. It does not
-            # use the generic ED heat (0x0400) field.
-            message.target_temperature = TEA_BAR_DEFAULT_TARGET_TEMPERATURE
+            # Starting a normal cycle uses the appliance's 100-degree target
+            # together with heat_start. Stopping must send heat_start off on
+            # its own: resending a target while the appliance is filling can
+            # leave that target queued and start heating after filling ends.
+            if boiling:
+                self._tea_bar_cancel_after_dispensing = False
+                message.target_temperature = TEA_BAR_DEFAULT_TARGET_TEMPERATURE
+            elif self._attributes.get(DeviceAttributes.dispensing) is True:
+                self._tea_bar_cancel_after_dispensing = True
             message.heating = boiling
             stored_value = boiling
         elif attr == DeviceAttributes.child_lock:

--- a/tests/devices/ed/device_ed_test.py
+++ b/tests/devices/ed/device_ed_test.py
@@ -338,7 +338,7 @@ class TestMideaEDDevice:
         assert tea_bar.attributes[DeviceAttributes.boiling] is True
 
     def test_tea_bar_heating_switch_uses_official_tea_heat_command(self) -> None:
-        """Use the model-specific App command for normal 100-degree boiling."""
+        """Start at 100 degrees and stop without re-queuing that target."""
         tea_bar = MideaEDDevice(
             name="Tea Bar",
             device_id=2,
@@ -381,12 +381,7 @@ class TestMideaEDDevice:
                 [
                     0x15,
                     0x01,
-                    0x02,
                     0x01,
-                    0x04,
-                    0x64,
-                    0x0A,
-                    0x00,
                     0x05,
                     0x04,
                     0x00,
@@ -394,6 +389,122 @@ class TestMideaEDDevice:
                     0x00,
                 ],
             )
+
+    def test_tea_bar_stop_during_fill_cancels_queued_heating_once(self) -> None:
+        """Repeat the verified stop once after the firmware finishes filling."""
+        tea_bar = MideaEDDevice(
+            name="Tea Bar",
+            device_id=2,
+            ip_address="192.0.2.1",
+            port=6444,
+            token=TEST_AUTH_VALUE,
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=395,
+            customize="",
+        )
+        tea_bar._attributes[DeviceAttributes.dispensing] = True
+
+        with (
+            patch.object(tea_bar, "build_send") as mock_build_send,
+            patch("midealan.devices.ed.MessageEDResponse") as response,
+        ):
+            tea_bar.set_attribute(DeviceAttributes.boiling, False)
+            initial_stop = mock_build_send.call_args.args[0]
+            assert initial_stop.body == bytearray(
+                [0x15, 0x01, 0x01, 0x05, 0x04, 0x00, 0x00, 0x00],
+            )
+
+            message = response.return_value
+            message.dispensing = True
+            message.heating = False
+            tea_bar.process_message(b"")
+            assert mock_build_send.call_count == 1
+
+            message.dispensing = False
+            message.heating = True
+            tea_bar.process_message(b"")
+            assert mock_build_send.call_count == 2
+            repeated_stop = mock_build_send.call_args.args[0]
+            assert repeated_stop.body == bytearray(
+                [0x15, 0x01, 0x01, 0x05, 0x04, 0x00, 0x00, 0x00],
+            )
+
+            tea_bar.process_message(b"")
+            assert mock_build_send.call_count == 2
+
+    def test_tea_bar_cancel_during_fill_clears_without_heating(self) -> None:
+        """Do not repeat stop if the fill finishes without starting heat."""
+        tea_bar = MideaEDDevice(
+            name="Tea Bar",
+            device_id=2,
+            ip_address="192.0.2.1",
+            port=6444,
+            token=TEST_AUTH_VALUE,
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=395,
+            customize="",
+        )
+        tea_bar._attributes[DeviceAttributes.dispensing] = True
+
+        with (
+            patch.object(tea_bar, "build_send") as mock_build_send,
+            patch("midealan.devices.ed.MessageEDResponse") as response,
+        ):
+            tea_bar.set_attribute(DeviceAttributes.boiling, False)
+            message = response.return_value
+            message.dispensing = False
+            message.heating = False
+            tea_bar.process_message(b"")
+            assert mock_build_send.call_count == 1
+
+            message.heating = True
+            tea_bar.process_message(b"")
+            assert mock_build_send.call_count == 1
+
+    @pytest.mark.parametrize(
+        ("attribute", "value"),
+        [
+            (DeviceAttributes.boiling, True),
+            (DeviceAttributes.boil_temperature, 80),
+        ],
+    )
+    def test_tea_bar_new_heat_request_clears_pending_cancel(
+        self,
+        attribute: str,
+        value: bool | int,
+    ) -> None:
+        """A later local heat request supersedes a fill-phase cancellation."""
+        tea_bar = MideaEDDevice(
+            name="Tea Bar",
+            device_id=2,
+            ip_address="192.0.2.1",
+            port=6444,
+            token=TEST_AUTH_VALUE,
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=395,
+            customize="",
+        )
+        tea_bar._attributes[DeviceAttributes.current_temperature] = 20
+        tea_bar._attributes[DeviceAttributes.dispensing] = True
+
+        with (
+            patch.object(tea_bar, "build_send") as mock_build_send,
+            patch("midealan.devices.ed.MessageEDResponse") as response,
+        ):
+            tea_bar.set_attribute(DeviceAttributes.boiling, False)
+            tea_bar.set_attribute(attribute, value)
+            message = response.return_value
+            message.dispensing = False
+            message.heating = True
+            tea_bar.process_message(b"")
+
+        assert mock_build_send.call_count == 2
 
     @pytest.mark.parametrize(("locked", "raw_value"), [(True, 0x01), (False, 0x00)])
     def test_tea_bar_child_lock_uses_official_lua_command(


### PR DESCRIPTION
## Summary

- send the verified heat-stop field without re-sending a target temperature
- remember a local stop request made while model `63000622` / subtype `395` is dispensing
- if the appliance firmware starts its queued heating phase after dispensing ends, repeat the same verified heat-stop command exactly once
- clear the pending cancellation when a later local start or explicit temperature request supersedes it

## Why

Real-device debug logs showed that the appliance acknowledged a heat-stop request during dispensing but still entered heating after dispensing completed, without any second start command from Home Assistant. Re-sending a target together with the stop could also leave that target queued.

This change does not guess or send an unverified water-dispensing stop command. Dispensing is allowed to complete, and only the already verified heat-stop field is used.

The behavior is restricted by the existing exact model/subtype guard, so other ED appliances are unaffected.

## Validation

- `uv run python -m pytest -q tests/devices/ed/device_ed_test.py tests/devices/ed/message_ed_test.py tests/devices/ed/tea_bar_review_regression_test.py`: 127 passed
- `uv run python -m pytest -q ./tests/`: 1545 passed
- `uv run prek run --all-files`: passed
- real device:
  - stopping during dispensing prevented the queued heating phase
  - leaving the cycle on continued from dispensing into normal heating
  - no repeated stop loop was observed

Related: wuwentao/midea_ac_lan#668