### PR TITLE
fix(b0): correct status labels 0x02/0x03 (Idle/Working, not Working/Pause) on subtype zero

### DIFF
--- a/midealan/devices/b0/__init__.py
+++ b/midealan/devices/b0/__init__.py
@@ -38,8 +38,8 @@ class MideaB0Device(MideaDevice):
 
     _status: ClassVar[dict[int, str]] = {
         0x01: "Cancel",
-        0x02: "Working",
-        0x03: "Pause",
+        0x02: "Idle",
+        0x03: "Working",
         0x04: "Finished",
         0x06: "Order",
         0x07: "Save Power",

--- a/tests/devices/b0/device_b0_test.py
+++ b/tests/devices/b0/device_b0_test.py
@@ -144,11 +144,11 @@ class TestMideaB0Device:
         body[24] = 0xFF  # seconds unset
         body[27] = 0x01  # temperature fallback high byte
         body[28] = 44  # temperature fallback low byte
-        body[31] = 0x02  # status "Working"
+        body[31] = 0x02  # status "Idle"
         body[32] = 0x12  # door and water change reminder
         new_status = device.process_message(_build_message(MessageType.query, body))
         assert device.attributes[DeviceAttributes.door] is True
-        assert device.attributes[DeviceAttributes.status] == "Working"
+        assert device.attributes[DeviceAttributes.status] == "Idle"
         assert device.attributes[DeviceAttributes.time_remaining] == 3660
         assert device.attributes[DeviceAttributes.current_temperature] == 300
         assert device.attributes[DeviceAttributes.tank_ejected] is False
@@ -168,11 +168,11 @@ class TestMideaB0Device:
         device = _build_device(0)
         body_01 = bytearray(34)
         body_01[0] = 0x01
-        body_01[31] = 0x02  # status "Working"
+        body_01[31] = 0x02  # status "Idle"
         body_01[32] = 0x00  # door closed, no tank/water flags
         device.process_message(_build_message(MessageType.query, body_01))
         assert device.attributes[DeviceAttributes.door] is False
-        assert device.attributes[DeviceAttributes.status] == "Working"
+        assert device.attributes[DeviceAttributes.status] == "Idle"
         assert device.attributes[DeviceAttributes.tank_ejected] is False
         assert device.attributes[DeviceAttributes.water_shortage] is False
 
@@ -185,22 +185,47 @@ class TestMideaB0Device:
         )
         assert new_status == {}
         assert device.attributes[DeviceAttributes.door] is False
-        assert device.attributes[DeviceAttributes.status] == "Working"
+        assert device.attributes[DeviceAttributes.status] == "Idle"
         assert device.attributes[DeviceAttributes.tank_ejected] is False
         assert device.attributes[DeviceAttributes.water_shortage] is False
+
+    def test_process_message_01_status_working_real_device_sample(self) -> None:
+        """Test status code 0x03 decodes to "Working" on a subtype zero device.
+
+        Captured via debug logs from a real subtype-zero microwave (model
+        70000209) answering an X01/notify1 response mid-heat. Confirms raw
+        status byte 3 - observed continuously across four separate hardware
+        test runs (short heat, defrost, a 100-second uninterrupted full-power
+        run, and a pause/resume/door test) whenever the device was actively
+        cooking, and never on the physical "Pause" button, which instead
+        reports status 2 ("Idle") - decodes to "Working", matching both
+        ``_status31`` (subtype 2 of the same device) and the B1 device's
+        ``_status`` map.
+        """
+        device = _build_device(0)
+        header = bytearray.fromhex("aa46b000000000000004")
+        body = bytearray.fromhex(
+            "0100000000110001010001000affffffffffff000000000100ffffffffffff"
+            "030004000000000000000000000002dc01000100000000000080000021",
+        )
+        new_status = device.process_message(bytes(header + body))
+        assert device.attributes[DeviceAttributes.door] is False
+        assert device.attributes[DeviceAttributes.status] == "Working"
+        assert device.attributes[DeviceAttributes.time_remaining] == 60
+        assert new_status[DeviceAttributes.status.value] == "Working"
 
     def test_process_message_default_body_subtype_zero(self) -> None:
         """Test process message with the default body on subtype zero."""
         device = _build_device(0)
         body = bytearray(17)
-        body[0] = 0x82  # unhandled body type with the door bit set
+        body[0] = 0x82  # unhandled body type with the door bit set, status "Idle"
         body[1] = 0x02  # mode "Baking"
         body[2] = 1  # minutes
         body[3] = 30  # seconds
         body[14] = 5  # raw fire power
         device.process_message(_build_message(MessageType.set, body))
         assert device.attributes[DeviceAttributes.door] is True
-        assert device.attributes[DeviceAttributes.status] == "Working"
+        assert device.attributes[DeviceAttributes.status] == "Idle"
         assert device.attributes[DeviceAttributes.time_remaining] == 90
         assert device.attributes[DeviceAttributes.mode] == "Baking"
         assert device.attributes[DeviceAttributes.fire_power] == 5


### PR DESCRIPTION
Port of midea-lan/midea-local#634, which @chemelli74 merged on 2026-08-12 at 14:02 UTC — after
this repository was split off, so it did not carry over. Re-submitting here as suggested in
wuwentao/midea_ac_lan#989. The change is unmodified apart from the `midealocal` → `midealan`
package rename.

## Problem

For B0 subtype-zero devices (microwave, model 70000209), the `_status` dict has two swapped
labels:
- `0x02` is labeled `"Working"` — it's actually the idle state.
- `0x03` is labeled `"Pause"` — it's actually the actively-running state.

## Evidence

Real hardware testing on a physical subtype-zero unit (debug logs, 4 separate runs covering a
short heat cycle, a defrost cycle, an uninterrupted 100-second full-power run, and a dedicated
pause-button test):

- `status=3` was observed continuously and reliably whenever the device was actively
  heating/cooking, across every mode tested (regular heat, defrost) — never behaved like a
  transient pause.
- `status=2` was observed at rest (door closed, nothing running).
- Pressing the physical Pause button gave `status=2` with `time_remaining` reset to 0 — not
  `0x03`. So `0x03` cannot be "Pause"; the device has no distinct "paused" status code at the
  protocol level at all (Pause behaves the same as Cancel/Off).

This also matches the existing `_status31` dict a few lines below (used for subtype 2 of the same
B0 device), which already has `0x02: "Idle"` / `0x03: "Working"`, and the B1 device's `_status`
dict (same manufacturer, analogous oven device), which does the same.

Both status bytes come from a single field each (`body[31]` in the X01 response, one byte per
reading) — not adjacent/swapped byte offsets.

## Fix

In the subtype-zero `_status` dict only: `0x02: "Working"` → `0x02: "Idle"`,
`0x03: "Pause"` → `0x03: "Working"`. No other entries touched — `0x01`, `0x06`, `0x07`, `0x08`,
`0x09`, `0x0D`, `0x66`, `0xFF` remain unverified and are out of scope for this fix.

## Testing

- Added `test_process_message_01_status_working_real_device_sample`
  (`tests/devices/b0/device_b0_test.py`), replaying a real captured `X01` packet mid-heat.
- Updated existing tests that had the old (wrong) `0x02: "Working"` label baked in as expected
  behavior.
- Full test suite (1546 tests), ruff, ruff-format, mypy and pylint (10.00/10) all clean on this
  repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected device status reporting so `0x02` is shown as **Idle** and `0x03` as **Working**.
  * Updated default status handling for subtype-zero devices.

* **Tests**
  * Added coverage using a real-device sample to verify Working status detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->