### PR TITLE
fix(e2): warn and ignore old-protocol attributes MessageSet cannot carry

### DIFF
--- a/midealan/devices/e2/__init__.py
+++ b/midealan/devices/e2/__init__.py
@@ -235,6 +235,14 @@ class MideaE2Device(MideaDevice):
                 message.power = bool(value)
             elif old_protocol == OldProtocol.true:
                 message = self.make_message_set()
+                if not hasattr(message, str(attr)):
+                    # MessageSet only carries protection, whole_tank_heating,
+                    # target_temperature and variable_heating. setattr() would
+                    # happily create an unused attribute and the message would
+                    # be sent without the requested change, so the command is
+                    # silently lost. Fall back to the new protocol message,
+                    # which carries the remaining attributes.
+                    message = MessageNewProtocolSet(self._message_protocol_version)
                 setattr(message, str(attr), value)
             else:
                 message = MessageNewProtocolSet(self._message_protocol_version)

--- a/midealan/devices/e2/__init__.py
+++ b/midealan/devices/e2/__init__.py
@@ -240,9 +240,16 @@ class MideaE2Device(MideaDevice):
                     # target_temperature and variable_heating. setattr() would
                     # happily create an unused attribute and the message would
                     # be sent without the requested change, so the command is
-                    # silently lost. Fall back to the new protocol message,
-                    # which carries the remaining attributes.
-                    message = MessageNewProtocolSet(self._message_protocol_version)
+                    # silently lost. Ignore it instead, and tell the user how
+                    # to opt in to the new protocol if the device supports it.
+                    _LOGGER.warning(
+                        "[%s] Attribute %s is not supported by the old protocol "
+                        "and was ignored. If your device supports the new "
+                        'protocol, set customize to {"old_protocol": false}.',
+                        self.device_id,
+                        attr,
+                    )
+                    return
                 setattr(message, str(attr), value)
             else:
                 message = MessageNewProtocolSet(self._message_protocol_version)

--- a/tests/devices/e2/device_e2_test.py
+++ b/tests/devices/e2/device_e2_test.py
@@ -219,6 +219,37 @@ class TestMideaE2Device:
         assert message.target_temperature == 45
         assert message._body == bytearray([0x07, 45])
 
+    @pytest.mark.parametrize(
+        "attr",
+        [
+            DeviceAttributes.sterilization,
+            DeviceAttributes.screen_off,
+            DeviceAttributes.sleep,
+        ],
+    )
+    def test_set_attribute_old_protocol_unsupported_falls_back(
+        self,
+        attr: DeviceAttributes,
+    ) -> None:
+        """Old protocol falls back when MessageSet cannot carry the attribute."""
+        device = self._device('{"old_protocol": "true"}')
+        with patch.object(device, "build_send") as mock_build_send:
+            device.set_attribute(attr.value, True)
+            mock_build_send.assert_called_once()
+            message = mock_build_send.call_args[0][0]
+        # Without the fallback this is a MessageSet and the flag is dropped.
+        assert isinstance(message, MessageNewProtocolSet)
+        assert getattr(message, attr.value) is True
+
+    def test_set_attribute_old_protocol_keeps_supported_attributes(self) -> None:
+        """Attributes MessageSet does carry must still use the old message."""
+        device = self._device('{"old_protocol": "true"}')
+        with patch.object(device, "build_send") as mock_build_send:
+            device.set_attribute(DeviceAttributes.whole_tank_heating.value, True)
+            message = mock_build_send.call_args[0][0]
+        assert isinstance(message, MessageSet)
+        assert message.whole_tank_heating is True
+
     def test_set_attribute_new_protocol(self) -> None:
         """Test new protocol attributes use the new protocol set message."""
         device = self._device('{"old_protocol": "false"}')

--- a/tests/devices/e2/device_e2_test.py
+++ b/tests/devices/e2/device_e2_test.py
@@ -1,5 +1,6 @@
 """Test E2 Device."""
 
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -227,19 +228,23 @@ class TestMideaE2Device:
             DeviceAttributes.sleep,
         ],
     )
-    def test_set_attribute_old_protocol_unsupported_falls_back(
+    def test_set_attribute_old_protocol_unsupported_is_ignored(
         self,
         attr: DeviceAttributes,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Old protocol falls back when MessageSet cannot carry the attribute."""
+        """Old protocol ignores and logs attributes MessageSet cannot carry."""
         device = self._device('{"old_protocol": "true"}')
-        with patch.object(device, "build_send") as mock_build_send:
+        with (
+            patch.object(device, "build_send") as mock_build_send,
+            caplog.at_level(logging.WARNING, logger="midealan.devices.e2"),
+        ):
             device.set_attribute(attr.value, True)
-            mock_build_send.assert_called_once()
-            message = mock_build_send.call_args[0][0]
-        # Without the fallback this is a MessageSet and the flag is dropped.
-        assert isinstance(message, MessageNewProtocolSet)
-        assert getattr(message, attr.value) is True
+        # Without this guard a MessageSet went out with the flag silently
+        # dropped, which looks like a working command that does nothing.
+        mock_build_send.assert_not_called()
+        assert attr.value in caplog.text
+        assert '{"old_protocol": false}' in caplog.text
 
     def test_set_attribute_old_protocol_keeps_supported_attributes(self) -> None:
         """Attributes MessageSet does carry must still use the old message."""


### PR DESCRIPTION
Fixes #16

### Problem

`MessageSet` carries only `protection`, `whole_tank_heating`,
`target_temperature` and `variable_heating`. On the old-protocol branch,
`set_attribute()` did `setattr(message, attr, value)` for **every** other
attribute too. Python accepts that as a new unused attribute, the message is
serialised from its own fields, and the command goes out without the requested
change — silently. No exception, no log, no state change.

`_normalize_old_protocol()` resolves `"auto"` to the old protocol for any
`subtype <= 82`, so a device reporting **subtype 0** hits this on default
settings. That is why it presents as an unsupported model rather than a
protocol-selection bug: `{"old_protocol": false}` makes it work.

### Change

Per review feedback, this no longer mixes protocols automatically. Sending a
new-protocol message to a device classified as old protocol is not verified
against the official Midea lua protocol for every E2 subtype, and could put
unknown models into an unexpected state.

Instead, when the old protocol is selected and `MessageSet` cannot carry the
requested attribute, the integration logs a warning naming the attribute and
pointing at `customize` `{"old_protocol": false}`, and sends nothing.

- protocol boundary stays intact — no unexpected message reaches the device
- the silent no-op is gone; the log explains what happened and what to do
- the one-time explicit opt-in stays with the user, after checking device docs

Attributes `MessageSet` does carry are unaffected.

### Tests

- `test_set_attribute_old_protocol_unsupported_is_ignored` — parametrised over
  `sterilization`, `screen_off`, `sleep`; asserts no message is sent and the
  warning names the attribute and the `{"old_protocol": false}` hint.
  **Fails on `main`**, where a `MessageSet` goes out with the flag dropped.
- `test_set_attribute_old_protocol_keeps_supported_attributes` — guards the
  other direction, so `whole_tank_heating` still goes out as `MessageSet`.

```
uv run python -m pytest ./tests/    1549 passed
uv run ruff check .                 All checks passed
uv run mypy midealan                Success: no issues found in 85 source files
```

### Hardware context

Midea E2 electric water heater, model `510003ZF`, protocol V3, discovered
subtype 0. Sterilization is silently ignored on default settings and works
once `{"old_protocol": false}` is set — which is now what the warning tells
the user to do.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device attribute updates when using older communication protocols.
  - Unsupported attributes are now safely ignored and logged with guidance to enable the newer protocol.
  - Supported attributes continue to use the existing protocol without behavior changes.

- **Tests**
  - Added coverage verifying logging and preventing unsupported attribute updates from being sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->