### PR TITLE
fix(e2): make precision_halves symmetric so target temperature round-trips

### DIFF
--- a/midealan/devices/e2/__init__.py
+++ b/midealan/devices/e2/__init__.py
@@ -83,12 +83,6 @@ class DeviceAttributes(StrEnum):
     rate = "rate"
 
 
-# E2 subtype 255 devices use literal Celsius values in the target-temperature
-# command.  Other E2 variants use the legacy half-degree wire representation
-# unless ``precision_halves`` is explicitly enabled.
-_LITERAL_TEMPERATURE_SUBTYPES = frozenset({255})
-
-
 class MideaE2Device(MideaDevice):
     """Midea E2 device."""
 
@@ -193,6 +187,16 @@ class MideaE2Device(MideaDevice):
             if hasattr(message, str(status)):
                 value = getattr(message, str(status))
                 if (
+                    self._precision_halves
+                    and value is not None
+                    and status
+                    in (
+                        DeviceAttributes.current_temperature,
+                        DeviceAttributes.target_temperature,
+                    )
+                ):
+                    value = value / 2
+                if (
                     status == DeviceAttributes.heating_power
                     and value is not None
                     and self._heating_power_multiplier != 1.0
@@ -224,11 +228,7 @@ class MideaE2Device(MideaDevice):
             DeviceAttributes.current_temperature,
         ]:
             old_protocol = self._normalize_old_protocol(self._old_protocol)
-            if (
-                attr == DeviceAttributes.target_temperature
-                and not self._precision_halves
-                and self.subtype not in _LITERAL_TEMPERATURE_SUBTYPES
-            ):
+            if self._precision_halves and attr == DeviceAttributes.target_temperature:
                 value = value * 2
             if attr == DeviceAttributes.power:
                 message = MessagePower(self._message_protocol_version)

--- a/tests/devices/e2/device_e2_test.py
+++ b/tests/devices/e2/device_e2_test.py
@@ -187,24 +187,76 @@ class TestMideaE2Device:
         assert isinstance(message, MessagePower)
         assert message.power is True
 
-    def test_set_attribute_old_protocol_doubles_temperature(self) -> None:
-        """Test old protocol target temperature is doubled without halves."""
+    def test_set_attribute_sends_literal_temperature_by_default(self) -> None:
+        """Target temperature is sent literally, matching the literal read."""
         device = self._device()
         with patch.object(device, "build_send") as mock_build_send:
             device.set_attribute(DeviceAttributes.target_temperature.value, 40)
             mock_build_send.assert_called_once()
             message = mock_build_send.call_args[0][0]
         assert isinstance(message, MessageSet)
-        assert message.target_temperature == 80
+        assert message.target_temperature == 40
 
-    def test_set_attribute_precision_halves_keeps_temperature(self) -> None:
-        """Test precision halves keeps the raw target temperature."""
+    def test_set_attribute_precision_halves_doubles_temperature(self) -> None:
+        """precision_halves means the device speaks half-degrees on the wire."""
         device = self._device('{"precision_halves": true}')
         with patch.object(device, "build_send") as mock_build_send:
             device.set_attribute(DeviceAttributes.target_temperature.value, 40)
             message = mock_build_send.call_args[0][0]
         assert isinstance(message, MessageSet)
-        assert message.target_temperature == 40
+        assert message.target_temperature == 80
+
+    def test_process_message_precision_halves_halves_temperatures(self) -> None:
+        """precision_halves halves temperatures on read, mirroring the write."""
+
+        class FakeMessage:
+            current_temperature = 130
+            target_temperature = 150
+
+        device = self._device('{"precision_halves": true}')
+        with patch(
+            "midealan.devices.e2.MessageE2Response",
+            return_value=FakeMessage(),
+        ):
+            status = device.process_message(b"")
+
+        assert status[DeviceAttributes.current_temperature.value] == 65
+        assert status[DeviceAttributes.target_temperature.value] == 75
+
+    def test_process_message_keeps_literal_temperatures_by_default(self) -> None:
+        """Without precision_halves the wire value is already Celsius."""
+
+        class FakeMessage:
+            current_temperature = 65
+            target_temperature = 75
+
+        device = self._device()
+        with patch(
+            "midealan.devices.e2.MessageE2Response",
+            return_value=FakeMessage(),
+        ):
+            status = device.process_message(b"")
+
+        assert status[DeviceAttributes.current_temperature.value] == 65
+        assert status[DeviceAttributes.target_temperature.value] == 75
+
+    def test_temperature_round_trips(self) -> None:
+        """What is written must read back unchanged, in both modes."""
+        for customize in ("", '{"precision_halves": true}'):
+            device = self._device(customize)
+            with patch.object(device, "build_send") as mock_build_send:
+                device.set_attribute(DeviceAttributes.target_temperature.value, 65)
+                on_wire = mock_build_send.call_args[0][0].target_temperature
+
+            class FakeMessage:
+                target_temperature = on_wire
+
+            with patch(
+                "midealan.devices.e2.MessageE2Response",
+                return_value=FakeMessage(),
+            ):
+                status = device.process_message(b"")
+            assert status[DeviceAttributes.target_temperature.value] == 65
 
     def test_set_attribute_literal_temperature_for_subtype_255(
         self,


### PR DESCRIPTION
Fixes #18

### Problem

E2 doubles `target_temperature` on write whenever `precision_halves` is
**false**, and never halves anything on read. The two directions disagree, so a
setpoint cannot round-trip.

On a device whose wire format is literal Celsius, 65 °C is sent as 130 —
outside the 30–75 range the appliance accepts — so it is dropped silently. The
entity flips optimistically, the next poll reverts it, and it looks like flaky
hardware.

### Change

Mirror `MideaE3Device`, which already models this correctly: halve on read,
double on write, both gated on `precision_halves`, meaning *this device speaks
half-degrees on the wire*. E2 had the write condition inverted and the read half
missing.

This also makes the integration's documented description of the flag true for
E2 — "if the temperature value displayed on your water heater is twice the
actual value, set this to true" requires halving on read, which E2 never did.

Literal Celsius becomes the default for every subtype, so
`_LITERAL_TEMPERATURE_SUBTYPES` is dropped: subtype 255 keeps the literal
behaviour it was special-cased for.

### ⚠️ Behaviour change

E2 users who left `precision_halves` at the default will now have literal
values sent instead of doubled ones. That is the point of the fix — the default
path could not round-trip — but it is a real change and may warrant a major
version. Users who had set `precision_halves: true` as a workaround for the
inverted write will want to unset it. Happy to gate it behind a new option
instead if you would rather not change the default.

### Tests

- `test_set_attribute_sends_literal_temperature_by_default` — **fails on main** (sends 80 for 40)
- `test_process_message_precision_halves_halves_temperatures` — **fails on main** (read path did nothing)
- `test_temperature_round_trips` — **fails on main**; writes 65, feeds the wire value back through `process_message`, asserts 65 in both modes
- `test_process_message_keeps_literal_temperatures_by_default` — guards the default read path
- `test_set_attribute_precision_halves_doubles_temperature` — replaces the old test that asserted the inverted behaviour

Two existing tests encoded the old semantics and are updated accordingly; the
subtype 255 test is untouched and still passes, since literal is now the
default.

```
uv run python -m pytest ./tests/    1548 passed
uv run ruff check .                 All checks passed
uv run mypy midealan                Success: no issues found in 85 source files
```

### Verified on hardware

Midea E2 electric water heater, model `510003ZF`, protocol V3, subtype 0.
Setpoint writes are ignored on the defaults and apply immediately once the value
is sent literally. Reads were correct in both configurations throughout, which
is what identifies the device as literal-Celsius in both directions.

### Relationship to #17

Independent, both branched from `main`, and they touch neighbouring lines in
`set_attribute()` — whichever merges second may need a trivial rebase. #17
fixes switch commands being dropped; this fixes setpoints being rejected. Both
were needed to control this one device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected temperature reading and command handling for devices using half-degree precision.
  * Temperatures now remain literal Celsius values by default.
  * Enabled accurate conversion when half-degree precision is configured, including reliable read/write round trips.
  * Updated temperature behavior coverage to ensure displayed and transmitted values remain consistent across supported modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->