### PR TITLE
docs: document cloud download CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,26 @@ ac.set_swing(False, False)
 
 ### Command line tool
 
-The installed command is `midealan`. From a clone of this repository, use `uv run`:
+The package installs a `midealan` console command. From a clone of this repository, create
+the development environment, install the package in editable mode, and activate the virtual
+environment first:
 
 ```bash
-# Installed package
-midealan --help
+# Linux / macOS / WSL2
+git clone https://github.com/wuwentao/midea-lan.git
+cd midea-lan
+./scripts/setup.sh
+uv pip install -e .
+source .venv/bin/activate
 
-# Development checkout
+midealan --help
+```
+
+On Windows PowerShell, run `scripts\setup.ps1`, then `uv pip install -e .` and
+`.\.venv\Scripts\Activate.ps1` before using `midealan --help`. The console command is
+installed inside `.venv`, so use `uv run` when the virtual environment is not activated:
+
+```bash
 uv run python -m midealan.cli -h
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,14 +63,87 @@ ac.set_target_temperature(23.0, None)
 ac.set_swing(False, False)
 ```
 
-### command line tool
+### Command line tool
 
-```python3
-# for local install without uv/venv
-python3 -m midealan.cli -h
-# for uv development venv
+The installed command is `midealan`. From a clone of this repository, use `uv run`:
+
+```bash
+# Installed package
+midealan --help
+
+# Development checkout
 uv run python -m midealan.cli -h
 ```
+
+Available commands are `discover`, `decode`, `save`, `download`, and `setattr`. Run
+`midealan <command> --help` (or the `uv run` equivalent) for command-specific options.
+
+### Downloading cloud Lua and plugin files
+
+The `download` command signs in to a supported Midea cloud account, downloads the Lua
+protocol file for each selected appliance, then tries to download its plugin. Files are
+written to the current working directory. Use a separate empty directory if you want to
+keep the downloads together.
+
+Collected Lua files are published for reference in
+[wuwentao/midea-lua](https://github.com/wuwentao/midea-lua); contributions with additional
+device Lua files are welcome there.
+
+```text
+midealan download [--debug] --username USERNAME --password PASSWORD \
+  --cloud-name CLOUD [--host HOST | --device-sn SERIAL [--device-type HEX]]
+```
+
+When working from a checkout, replace `midealan` in the examples below with
+`uv run python -m midealan.cli`.
+
+Supported `--cloud-name` values are `美的美居`, `SmartHome`, `Midea Air`, `NetHome Plus`,
+and `Ariston Clima`.
+
+Download for a device discovered at a LAN address:
+
+```bash
+midealan download \
+  --cloud-name "美的美居" --username "user@example.com" --password "password" \
+  --host 192.0.2.121
+```
+
+Download for one serial number from the cloud account:
+
+```bash
+midealan download \
+  --cloud-name "SmartHome" --username "user@example.com" --password "password" \
+  --device-sn "0000005112429652937220340014X2X3"
+```
+
+Pass an explicit hexadecimal device type when the serial number does not identify the
+device type correctly:
+
+```bash
+midealan download \
+  --cloud-name "SmartHome" --username "user@example.com" --password "password" \
+  --device-sn "0000005112429652937220340014X2X3" --device-type AC
+```
+
+Omit both `--host` and `--device-sn` to process every appliance in the cloud account:
+
+```bash
+midealan download \
+  --cloud-name "SmartHome" --username "user@example.com" --password "password"
+```
+
+`--host` takes precedence when it is supplied with `--device-sn`; LAN discovery provides
+the serial number, type, and model. For a serial-number download, the device type is
+resolved in this order: `--device-type`, a matching appliance in the cloud account, then
+the legacy type byte in the serial number. A malformed or unsupported serial-number
+fallback uses type `0`, so pass `--device-type` when known.
+
+Each appliance is handled independently during account-wide downloads. A Lua or plugin
+failure is logged and later appliances continue to be processed. `美的美居` and
+`SmartHome` support Lua and plugin downloads. The legacy `Midea Air`, `NetHome Plus`, and
+`Ariston Clima` backend supports Lua downloads but not plugin downloads; the command logs
+a warning after a successful Lua download. Add `--debug` when diagnosing a failed request,
+and verify the files actually created in the working directory.
 
 ## Development
 

--- a/README_hans.md
+++ b/README_hans.md
@@ -65,13 +65,25 @@ ac.set_swing(False, False)
 
 ### 命令行工具
 
-已安装包时使用 `midealan` 命令；从本仓库开发环境运行时使用 `uv run`：
+本包安装后会提供 `midealan` 控制台命令。从本仓库克隆代码时，先创建开发环境、以 editable
+模式安装本包，并激活虚拟环境：
 
 ```bash
-# 已安装的软件包
-midealan --help
+# Linux / macOS / WSL2
+git clone https://github.com/wuwentao/midea-lan.git
+cd midea-lan
+./scripts/setup.sh
+uv pip install -e .
+source .venv/bin/activate
 
-# 本仓库开发环境
+midealan --help
+```
+
+在 Windows PowerShell 中，先运行 `scripts\setup.ps1`，再依次运行 `uv pip install -e .` 和
+`.\.venv\Scripts\Activate.ps1`，之后即可使用 `midealan --help`。控制台命令安装在 `.venv`
+中；未激活虚拟环境时，请使用 `uv run`：
+
+```bash
 uv run python -m midealan.cli -h
 ```
 

--- a/README_hans.md
+++ b/README_hans.md
@@ -65,12 +65,78 @@ ac.set_swing(False, False)
 
 ### 命令行工具
 
-```python3
-# for local install without uv/venv
-python3 -m midealan.cli -h
-# for uv development venv
+已安装包时使用 `midealan` 命令；从本仓库开发环境运行时使用 `uv run`：
+
+```bash
+# 已安装的软件包
+midealan --help
+
+# 本仓库开发环境
 uv run python -m midealan.cli -h
 ```
+
+可用子命令为 `discover`、`decode`、`save`、`download` 和 `setattr`。使用
+`midealan <子命令> --help`（或对应的 `uv run` 命令）查看各子命令参数。
+
+### 下载云端 Lua 与插件文件
+
+`download` 会登录支持的美的云账号，为每台选中的设备下载 Lua 协议文件，然后尝试下载插件。
+文件会写入当前工作目录；建议在专门的空目录中执行命令，以便集中保存下载结果。
+
+已收集的 Lua 文件会发布在 [wuwentao/midea-lua](https://github.com/wuwentao/midea-lua)
+作为参考，也欢迎在该仓库提交 PR 补充更多设备的 Lua 文件。
+
+```text
+midealan download [--debug] --username USERNAME --password PASSWORD \
+  --cloud-name CLOUD [--host HOST | --device-sn SERIAL [--device-type HEX]]
+```
+
+在本仓库开发环境中，请将以下示例中的 `midealan` 替换为
+`uv run python -m midealan.cli`。
+
+`--cloud-name` 支持的值为：`美的美居`、`SmartHome`、`Midea Air`、`NetHome Plus` 和
+`Ariston Clima`。
+
+按局域网地址发现并下载一台设备：
+
+```bash
+midealan download \
+  --cloud-name "美的美居" --username "user@example.com" --password "password" \
+  --host 192.0.2.121
+```
+
+按云账号内的设备序列号下载：
+
+```bash
+midealan download \
+  --cloud-name "SmartHome" --username "user@example.com" --password "password" \
+  --device-sn "0000005112429652937220340014X2X3"
+```
+
+当序列号无法正确推导设备类型时，可以显式传入十六进制设备类型：
+
+```bash
+midealan download \
+  --cloud-name "SmartHome" --username "user@example.com" --password "password" \
+  --device-sn "0000005112429652937220340014X2X3" --device-type AC
+```
+
+省略 `--host` 和 `--device-sn` 时，会处理云账号内的全部设备：
+
+```bash
+midealan download \
+  --cloud-name "SmartHome" --username "user@example.com" --password "password"
+```
+
+同时传入 `--host` 和 `--device-sn` 时，`--host` 优先；程序会通过局域网发现获取序列号、
+设备类型和型号。按序列号下载时，设备类型按以下顺序确定：`--device-type`、云账号中匹配
+设备的信息、序列号中的旧格式类型字节。序列号格式错误或不支持旧格式回退时，类型会使用
+`0`，因此已知类型时应传入 `--device-type`。
+
+批量下载时，每台设备独立处理；某台设备的 Lua 或插件下载失败只会记录日志，后续设备仍会
+继续处理。`美的美居` 与 `SmartHome` 支持 Lua 和插件下载。旧版 `Midea Air`、
+`NetHome Plus` 和 `Ariston Clima` 后端支持 Lua 下载，但不支持插件下载；Lua 下载成功后，
+命令会记录相应警告。排查请求失败时可添加 `--debug`，并检查当前工作目录中实际生成的文件。
 
 ## 开发环境
 


### PR DESCRIPTION
## Summary

Document the cloud download CLI usage in both English and Chinese README files.

- Shows installed and development invocation forms.
- Explains supported cloud names and target selection by host, serial number, or full cloud account.
- Notes output location, per-device failure handling, legacy Lua-only backends, and the midea-lua reference repository.

## Testing

- env UV_CACHE_DIR=/private/tmp/midea-local-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/midea-local-pycache uv run prek run prettier --files README.md README_hans.md
- env UV_CACHE_DIR=/private/tmp/midea-local-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/midea-local-pycache uv run python -m midealan.cli download --help