### PR TITLE
feat(bf): implement full BF microwave steam oven message parsing and …

### DIFF
--- a/midealan/devices/bf/__init__.py
+++ b/midealan/devices/bf/__init__.py
@@ -2,12 +2,16 @@
 
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar, Unpack
+from typing import Any, Unpack
 
 from midealan.const import DeviceType
 from midealan.device import MideaDevice, MideaDeviceInitKwargs
 
-from .message import MessageBFResponse, MessageQuery
+from .message import (
+    MessageBFResponse,
+    MessageQuery,
+    MessageSet,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,6 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 class DeviceAttributes(StrEnum):
     """Midea BF device attributes."""
 
+    # Basic status
     door = "door"
     status = "status"
     time_remaining = "time_remaining"
@@ -22,19 +27,109 @@ class DeviceAttributes(StrEnum):
     tank_ejected = "tank_ejected"
     water_change_reminder = "water_change_reminder"
     water_shortage = "water_shortage"
+    # Work mode and cooking params
+    work_mode = "work_mode"
+    fire_power = "fire_power"
+    pre_heat = "pre_heat"
+    turntable = "turntable"
+    hot_wind = "hot_wind"
+    # Temperature settings
+    temperature = "temperature"
+    temperature_above = "temperature_above"
+    temperature_underside = "temperature_underside"
+    probe_temperature = "probe_temperature"
+    # Current temperatures
+    cur_temperature_above = "cur_temperature_above"
+    cur_temperature_underside = "cur_temperature_underside"
+    cur_probe_temperature = "cur_probe_temperature"
+    # Cooking params
+    steam_quantity = "steam_quantity"
+    weight = "weight"
+    people_number = "people_number"
+    # Time settings
+    hour_set = "hour_set"
+    minute_set = "minute_set"
+    second_set = "second_set"
+    # Status flags
+    child_lock = "child_lock"
+    furnace_light = "furnace_light"
+    flip_side = "flip_side"
+    reaction = "reaction"
+    high_temperature_lock = "high_temperature_lock"
+    high_temperature_work = "high_temperature_work"
+    high_temperature = "high_temperature"
+    probe_mode = "probe_mode"
+    probe = "probe"
+    error_code = "error_code"
+    ramadan = "ramadan"
+    # Multi-stage cooking
+    totalstep = "totalstep"
+    stepnum = "stepnum"
+    cloudmenuid = "cloudmenuid"
+    # Maintenance
+    clean_scale = "clean_scale"
+    clean_sink_ponding = "clean_sink_ponding"
+    dissipate_heat = "dissipate_heat"
+    cbs_version = "cbs_version"
+    ota = "ota"
+    # Execute status
+    execute = "execute"
+    # Controls (not reported by device, for HA entity mapping)
+    power = "power"
+    screen_luminance = "screen_luminance"
+    volume = "volume"
+
+
+# Attributes that can be directly set on MessageSet (same name on device and message)
+_SETTABLE_ATTRS: frozenset[DeviceAttributes] = frozenset(
+    {
+        DeviceAttributes.power,
+        DeviceAttributes.child_lock,
+        DeviceAttributes.furnace_light,
+        DeviceAttributes.hot_wind,
+        DeviceAttributes.door,
+        DeviceAttributes.screen_luminance,
+        DeviceAttributes.volume,
+        DeviceAttributes.ramadan,
+        DeviceAttributes.work_mode,
+        DeviceAttributes.fire_power,
+        DeviceAttributes.temperature,
+        DeviceAttributes.temperature_above,
+        DeviceAttributes.temperature_underside,
+        DeviceAttributes.probe_temperature,
+        DeviceAttributes.steam_quantity,
+        DeviceAttributes.weight,
+        DeviceAttributes.people_number,
+        DeviceAttributes.turntable,
+        DeviceAttributes.pre_heat,
+        DeviceAttributes.hour_set,
+        DeviceAttributes.minute_set,
+        DeviceAttributes.second_set,
+    },
+)
+
+# Work-mode-related attributes that need current work_mode context to serialize
+# correctly via workModeControl instead of an empty setControl body.
+_WORK_MODE_SETTABLE_ATTRS: frozenset[DeviceAttributes] = frozenset(
+    {
+        DeviceAttributes.work_mode,
+        DeviceAttributes.fire_power,
+        DeviceAttributes.temperature,
+        DeviceAttributes.temperature_above,
+        DeviceAttributes.temperature_underside,
+        DeviceAttributes.probe_temperature,
+        DeviceAttributes.steam_quantity,
+        DeviceAttributes.weight,
+        DeviceAttributes.people_number,
+        DeviceAttributes.turntable,
+        DeviceAttributes.pre_heat,
+        DeviceAttributes.hot_wind,
+    },
+)
 
 
 class MideaBFDevice(MideaDevice):
     """Midea BF device."""
-
-    _status: ClassVar[dict[int, str]] = {
-        0x01: "PowerSave",
-        0x02: "Standby",
-        0x03: "Working",
-        0x04: "Finished",
-        0x05: "Delay",
-        0x06: "Paused",
-    }
 
     def __init__(
         self,
@@ -46,15 +141,7 @@ class MideaBFDevice(MideaDevice):
         super().__init__(
             device_type=DeviceType.BF,
             **kwargs,
-            attributes={
-                DeviceAttributes.door: None,
-                DeviceAttributes.status: None,
-                DeviceAttributes.time_remaining: None,
-                DeviceAttributes.current_temperature: None,
-                DeviceAttributes.tank_ejected: None,
-                DeviceAttributes.water_change_reminder: None,
-                DeviceAttributes.water_shortage: None,
-            },
+            attributes=dict.fromkeys(DeviceAttributes, None),
         )
 
     def build_query(self) -> list[MessageQuery]:
@@ -65,24 +152,68 @@ class MideaBFDevice(MideaDevice):
         """Midea BF device process message."""
         message = MessageBFResponse(msg)
         _LOGGER.debug("[%s] Received: %s", self.device_id, message)
-        new_status = {}
+        # message layer already resolves work_status into a string name
+        # (see MessageBFBody._parse_status_and_power), so no translator needed.
+        new_status: dict[str, Any] = {}
         for status in self._attributes:
             if hasattr(message, str(status)):
                 value = getattr(message, str(status))
-                if status == DeviceAttributes.status:
-                    if value in MideaBFDevice._status:
-                        self._attributes[DeviceAttributes.status] = (
-                            MideaBFDevice._status.get(value)
-                        )
-                    else:
-                        self._attributes[DeviceAttributes.status] = "Unknown"
-                else:
-                    self._attributes[status] = value
-                new_status[str(status)] = self._attributes[status]
+                self._attributes[status] = value
+                new_status[str(status)] = value
         return new_status
+
+    def make_message_set(self) -> MessageSet:
+        """Create a MessageSet pre-populated with current work-mode attributes.
+
+        Ensures that adjusting a single work-mode parameter (e.g. fire_power)
+        carries the active work_mode so the message routes to workModeControl
+        rather than producing an empty setControl command.
+        """
+        message = MessageSet(self._message_protocol_version)
+        message.work_mode = self._attributes[DeviceAttributes.work_mode]
+        message.fire_power = self._attributes[DeviceAttributes.fire_power]
+        message.temperature = self._attributes[DeviceAttributes.temperature]
+        message.temperature_above = self._attributes[DeviceAttributes.temperature_above]
+        message.temperature_underside = self._attributes[
+            DeviceAttributes.temperature_underside
+        ]
+        message.probe_temperature = self._attributes[DeviceAttributes.probe_temperature]
+        message.steam_quantity = self._attributes[DeviceAttributes.steam_quantity]
+        message.weight = self._attributes[DeviceAttributes.weight]
+        message.people_number = self._attributes[DeviceAttributes.people_number]
+        message.turntable = self._attributes[DeviceAttributes.turntable]
+        message.pre_heat = self._attributes[DeviceAttributes.pre_heat]
+        message.hot_wind = self._attributes[DeviceAttributes.hot_wind]
+        return message
 
     def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea BF device set attribute."""
+        # status on device maps to work_status on message
+        if attr == DeviceAttributes.status:
+            if not isinstance(value, str):
+                _LOGGER.warning(
+                    "[%s] Invalid status value: %r (expected str)",
+                    self.device_id,
+                    value,
+                )
+                return
+            message = MessageSet(self._message_protocol_version)
+            message.work_status = value
+            self.build_send(message)
+            return
+
+        if attr not in _SETTABLE_ATTRS:
+            _LOGGER.warning("[%s] Unsupported attribute: %s", self.device_id, attr)
+            return
+
+        # Work-mode-related attributes need the current work_mode context so the
+        # MessageSet routes to workModeControl instead of an empty setControl.
+        if attr in _WORK_MODE_SETTABLE_ATTRS:
+            message = self.make_message_set()
+        else:
+            message = MessageSet(self._message_protocol_version)
+        setattr(message, attr, value)
+        self.build_send(message)
 
 
 class MideaAppliance(MideaBFDevice):

--- a/midealan/devices/bf/__init__.py
+++ b/midealan/devices/bf/__init__.py
@@ -9,6 +9,7 @@ from midealan.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import (
     WORK_MODE_MAP,
+    FirePower,
     MessageBFResponse,
     MessageQuery,
     MessageSet,
@@ -247,6 +248,16 @@ class MideaBFDevice(MideaDevice):
         if attr == DeviceAttributes.work_mode and value not in WORK_MODE_MAP:
             _LOGGER.warning(
                 "[%s] Unsupported work_mode value: %s",
+                self.device_id,
+                value,
+            )
+            return
+
+        # Same for fire_power: an unknown name maps to the 0xFF no-change sentinel
+        # in MessageSet, which would silently re-issue the program unchanged.
+        if attr == DeviceAttributes.fire_power and value not in FirePower.__members__:
+            _LOGGER.warning(
+                "[%s] Unsupported fire_power value: %s",
                 self.device_id,
                 value,
             )

--- a/midealan/devices/bf/__init__.py
+++ b/midealan/devices/bf/__init__.py
@@ -8,9 +8,11 @@ from midealan.const import DeviceType
 from midealan.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import (
+    WORK_MODE_MAP,
     MessageBFResponse,
     MessageQuery,
     MessageSet,
+    WorkStatus,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -60,7 +62,7 @@ class DeviceAttributes(StrEnum):
     high_temperature = "high_temperature"
     probe_mode = "probe_mode"
     probe = "probe"
-    error_code = "error_code"
+    error = "error"
     ramadan = "ramadan"
     # Multi-stage cooking
     totalstep = "totalstep"
@@ -127,6 +129,26 @@ _WORK_MODE_SETTABLE_ATTRS: frozenset[DeviceAttributes] = frozenset(
     },
 )
 
+# Numeric attributes serialized with bit-shift / mask operations on MessageSet.
+# Callers (e.g. Home Assistant number entities) may pass floats, so coerce to int
+# before assignment to avoid a TypeError during serialization.
+_INT_ATTRS: frozenset[DeviceAttributes] = frozenset(
+    {
+        DeviceAttributes.temperature,
+        DeviceAttributes.temperature_above,
+        DeviceAttributes.temperature_underside,
+        DeviceAttributes.probe_temperature,
+        DeviceAttributes.steam_quantity,
+        DeviceAttributes.weight,
+        DeviceAttributes.people_number,
+        DeviceAttributes.screen_luminance,
+        DeviceAttributes.volume,
+        DeviceAttributes.hour_set,
+        DeviceAttributes.minute_set,
+        DeviceAttributes.second_set,
+    },
+)
+
 
 class MideaBFDevice(MideaDevice):
     """Midea BF device."""
@@ -171,6 +193,11 @@ class MideaBFDevice(MideaDevice):
         """
         message = MessageSet(self._message_protocol_version)
         message.work_mode = self._attributes[DeviceAttributes.work_mode]
+        # Carry the configured cook time so a work-mode resend keeps it instead
+        # of defaulting to zero (see _build_work_mode_control).
+        message.work_hour = self._attributes[DeviceAttributes.hour_set]
+        message.work_minute = self._attributes[DeviceAttributes.minute_set]
+        message.work_second = self._attributes[DeviceAttributes.second_set]
         message.fire_power = self._attributes[DeviceAttributes.fire_power]
         message.temperature = self._attributes[DeviceAttributes.temperature]
         message.temperature_above = self._attributes[DeviceAttributes.temperature_above]
@@ -197,6 +224,15 @@ class MideaBFDevice(MideaDevice):
                     value,
                 )
                 return
+            # Reject names not in WorkStatus so an unknown status is not silently
+            # serialized as the 0xFF no-change sentinel.
+            if value not in WorkStatus.__members__:
+                _LOGGER.warning(
+                    "[%s] Unsupported status value: %s",
+                    self.device_id,
+                    value,
+                )
+                return
             message = MessageSet(self._message_protocol_version)
             message.work_status = value
             self.build_send(message)
@@ -206,12 +242,30 @@ class MideaBFDevice(MideaDevice):
             _LOGGER.warning("[%s] Unsupported attribute: %s", self.device_id, attr)
             return
 
+        # Reject work_mode names not in the mapping so they are not silently sent
+        # as a no-op (0xFF) command with no state change.
+        if attr == DeviceAttributes.work_mode and value not in WORK_MODE_MAP:
+            _LOGGER.warning(
+                "[%s] Unsupported work_mode value: %s",
+                self.device_id,
+                value,
+            )
+            return
+
         # Work-mode-related attributes need the current work_mode context so the
         # MessageSet routes to workModeControl instead of an empty setControl.
         if attr in _WORK_MODE_SETTABLE_ATTRS:
             message = self.make_message_set()
         else:
             message = MessageSet(self._message_protocol_version)
+        # Coerce numeric fields to int: MessageSet serializes them with >> and &,
+        # which raise TypeError on float input from callers like HA number entities.
+        if attr in _INT_ATTRS and isinstance(value, (int, float)):
+            value = int(value)
+        # A caller-set people_number must clear weight, otherwise the shared
+        # parse (weight always set) makes _build_work_mode_control prefer weight.
+        if attr == DeviceAttributes.people_number:
+            message.weight = None
         setattr(message, attr, value)
         self.build_send(message)
 

--- a/midealan/devices/bf/message.py
+++ b/midealan/devices/bf/message.py
@@ -386,11 +386,8 @@ class MessageSet(MessageBFBase):
     def body(self) -> bytearray:
         """Message body. Override to set body_type from control type."""
         content = self._body  # determines and sets self.body_type
-        body = bytearray([])
-        if self.body_type is not None:
-            body.append(self.body_type)
-        if content is not None:
-            body.extend(content)
+        body = bytearray([self.body_type])
+        body.extend(content)
         return body
 
     @property
@@ -400,7 +397,26 @@ class MessageSet(MessageBFBase):
         Priority: work_mode > notWorkMode fields > setControl fields.
         body_type is dynamically set to match Lua's bodyBytes[0] control type.
         """
-        if self.work_mode is not None:
+        # work_mode and its parameter fields all route to workModeControl so a
+        # single parameter change (e.g. fire_power) still emits a valid body.
+        # hot_wind stays with notWorkMode below to match the Lua protocol.
+        work_mode_fields = [
+            self.work_mode,
+            self.work_hour,
+            self.work_minute,
+            self.work_second,
+            self.fire_power,
+            self.temperature,
+            self.temperature_above,
+            self.temperature_underside,
+            self.probe_temperature,
+            self.steam_quantity,
+            self.weight,
+            self.people_number,
+            self.pre_heat,
+            self.turntable,
+        ]
+        if any(field is not None for field in work_mode_fields):
             self.body_type = ListTypes.X01  # workModeControl
             return self._build_work_mode_control()
         not_work_mode_fields = [
@@ -464,8 +480,11 @@ class MessageSet(MessageBFBase):
             BYTE_DOOR_OPEN,
             BYTE_DOOR_CLOSE,
         )
-        screen_byte = self.screen_luminance or BYTE_FF
-        volume_byte = self.volume or BYTE_FF
+        # Use is None checks so a valid 0 value is preserved (0 != no-change).
+        screen_byte = (
+            BYTE_FF if self.screen_luminance is None else self.screen_luminance
+        )
+        volume_byte = BYTE_FF if self.volume is None else self.volume
         hot_wind_byte = self._bool_to_byte(
             self.hot_wind,
             BYTE_HOT_WIND_ON,
@@ -549,8 +568,8 @@ class MessageSet(MessageBFBase):
             probe_high = (self.probe_temperature >> 8) & BYTE_FF
             probe_low = self.probe_temperature & BYTE_FF
 
-        # Steam quantity
-        steam_byte = self.steam_quantity or BYTE_FF
+        # Steam quantity (is None check keeps a valid 0 from meaning no-change)
+        steam_byte = BYTE_FF if self.steam_quantity is None else self.steam_quantity
 
         # Weight / people number
         if self.weight is not None:
@@ -766,7 +785,13 @@ class MessageBFBody(MessageBody):
         )
 
     def _parse_steam_weight(self, body: bytearray) -> None:
-        """Parse steam_quantity and weight/people_number from body."""
+        """Parse steam_quantity and weight/people_number from body.
+
+        The protocol packs weight and people count into the same byte
+        (OFFSET_WEIGHT_PEOPLE); only one applies to the active work mode. Both
+        derived values are exposed, so consumers must read the field that
+        matches the current mode and ignore the other.
+        """
         sq = self.read_byte(body, OFFSET_STEAM_QUANTITY, BYTE_FF)
         self.steam_quantity = sq if sq != MAX_BYTE_VALUE else None
         b = self.read_byte(body, OFFSET_WEIGHT_PEOPLE, BYTE_FF)
@@ -823,7 +848,9 @@ class MessageBFBody(MessageBody):
         self.tank_ejected = bool(b & BIT_TANK_EJECTED)
         self.water_shortage = bool(b & BIT_WATER_SHORTAGE)
         self.water_change_reminder = bool(b & BIT_WATER_CHANGE)
-        self.error_code = bool(b & BIT_ERROR_CODE)
+        # Presence flag only (the protocol byte exposes no numeric code here),
+        # so name it `error` rather than implying a readable error code.
+        self.error = bool(b & BIT_ERROR_CODE)
         self.pre_heat = bool(b & BIT_PREHEAT)
 
     def _parse_byte33_flags(self, body: bytearray) -> None:

--- a/midealan/devices/bf/message.py
+++ b/midealan/devices/bf/message.py
@@ -1,6 +1,8 @@
 """Midea local BF message."""
 
-from midealan.const import MAX_BYTE_VALUE, DeviceType, ProtocolVersion
+from enum import IntEnum
+
+from midealan.const import MAX_BYTE_VALUE, DeviceType
 from midealan.message import (
     ListTypes,
     MessageBody,
@@ -8,6 +10,274 @@ from midealan.message import (
     MessageResponse,
     MessageType,
 )
+
+# Body type constants
+BODY_TYPE_TOTAL_STATE = 0x01
+
+# Byte offsets in MessageBFBody (body[0] is body_type, data starts at body[1])
+OFFSET_EXECUTE = 1
+OFFSET_CLOUDMENUID_HIGH = 2
+OFFSET_CLOUDMENUID_MID = 3
+OFFSET_CLOUDMENUID_LOW = 4
+OFFSET_TOTALSTEP_STEPNUM = 5
+OFFSET_FLAGS_B6 = 6
+OFFSET_WORK_MODE_HIGH = 7
+OFFSET_WORK_MODE_LOW = 8
+OFFSET_HOUR_SET = 9
+OFFSET_MINUTE_SET = 10
+OFFSET_SECOND_SET = 11
+OFFSET_FIRE_POWER = 12
+OFFSET_TEMP_ABOVE_HIGH = 13
+OFFSET_TEMP_ABOVE_LOW = 14
+OFFSET_TEMP_UNDERSIDE_HIGH = 15
+OFFSET_TEMP_UNDERSIDE_LOW = 16
+OFFSET_PROBE_TEMP_HIGH = 17
+OFFSET_PROBE_TEMP_LOW = 18
+OFFSET_STEAM_QUANTITY = 19
+OFFSET_WEIGHT_PEOPLE = 20
+OFFSET_WORK_HOUR = 22
+OFFSET_WORK_MINUTE = 23
+OFFSET_WORK_SECOND = 24
+OFFSET_CUR_TEMP_ABOVE_HIGH = 25
+OFFSET_CUR_TEMP_ABOVE_LOW = 26
+OFFSET_CUR_TEMP_UNDERSIDE_HIGH = 27
+OFFSET_CUR_TEMP_UNDERSIDE_LOW = 28
+OFFSET_CUR_PROBE_TEMP_HIGH = 29
+OFFSET_CUR_PROBE_TEMP_LOW = 30
+OFFSET_WORK_STATUS = 31
+OFFSET_FLAGS_B32 = 32
+OFFSET_FLAGS_B33 = 33
+OFFSET_RAMADAN = 34
+OFFSET_HOT_WIND = 35
+OFFSET_CBS_VERSION_MAJOR = 47
+OFFSET_CBS_VERSION_MINOR = 48
+OFFSET_CBS_VERSION_PATCH = 49
+OFFSET_FLAGS_B56 = 56
+OFFSET_FLAGS_B58 = 58
+
+# Bit masks (response parsing)
+BIT_PROBE = 0x02
+BIT_TURNTABLE = 0x08
+BIT_HOT_WIND = 0x20
+BIT_RAMADAN = 0x20
+BIT_CHILD_LOCK = 0x01
+BIT_DOOR = 0x02
+BIT_TANK_EJECTED = 0x04
+BIT_WATER_SHORTAGE = 0x08
+BIT_WATER_CHANGE = 0x10
+BIT_PREHEAT = 0x20
+BIT_ERROR_CODE = 0x80
+BIT_FLIP_SIDE = 0x01
+BIT_REACTION = 0x02
+BIT_FURNACE_LIGHT = 0x04
+BIT_HIGH_TEMP_LOCK = 0x08
+BIT_HIGH_TEMP_WORK = 0x10
+BIT_HIGH_TEMP = 0x20
+BIT_PROBE_MODE = 0x40
+BIT_CLEAN_SCALE = 0x40
+BIT_OTA = 0x80
+BIT_CLEAN_SINK_PONDING = 0x01
+BIT_DISSIPATE_HEAT = 0x02
+
+# Bit masks (workModeControl set body, byte b5)
+BIT_SET_PRE_HEAT = 0x01
+BIT_SET_PROBE = 0x02
+BIT_SET_TURNTABLE = 0x08
+BIT_SET_HOT_WIND = 0x10
+
+# setControl parameter IDs
+PARAM_ID_STEAM = 0x00
+PARAM_ID_TIME = 0x01
+PARAM_ID_FIRE_POWER = 0x02
+PARAM_ID_TEMP = 0x03
+PARAM_ID_PROBE_TEMP = 0x04
+PARAM_ID_TEMP_ABOVE_UNDERSIDE = 0x05
+
+# setControl temp_above/underside sub-index
+SUBINDEX_ABOVE = 0x00
+SUBINDEX_UNDERSIDE = 0x01
+
+# Special byte values
+BYTE_FF = 0xFF
+BYTE_POWER_ON = 0x11
+BYTE_POWER_OFF = 0x01
+BYTE_LOCK_ON = 0x01
+BYTE_LOCK_OFF = 0x00
+BYTE_LIGHT_ON = 0x01
+BYTE_LIGHT_OFF = 0x00
+BYTE_DOOR_OPEN = 0x01
+BYTE_DOOR_CLOSE = 0x00
+BYTE_HOT_WIND_ON = 0x01
+BYTE_HOT_WIND_OFF = 0x00
+BYTE_RAMADAN_ON = 0x01
+BYTE_RAMADAN_OFF = 0x00
+
+# Weight conversion factor (device sends weight/10)
+WEIGHT_DIVISOR = 10
+
+# Time conversion factors
+SECONDS_PER_HOUR = 3600
+SECONDS_PER_MINUTE = 60
+
+
+class WorkStatus(IntEnum):
+    """BF work status."""
+
+    save_power = 0x01
+    standby = 0x02
+    work = 0x03
+    work_finish = 0x04
+    order = 0x05
+    pause = 0x06
+    pause_c = 0x07
+    three = 0x08
+    wait_to_start = 0x10
+    self_inspection = 0x0A
+    query_version = 0x0B
+    demo = 0x0C
+    after_checking = 0x0E
+
+
+class FirePower(IntEnum):
+    """BF fire power."""
+
+    fire_power_0 = 0x00
+    fire_power_1 = 0x01
+    fire_power_2 = 0x02
+    fire_power_3 = 0x03
+    fire_power_4 = 0x04
+    fire_power_5 = 0x05
+    fire_power_6 = 0x06
+    fire_power_7 = 0x07
+    fire_power_8 = 0x08
+    fire_power_9 = 0x09
+    fire_power_10 = 0x0A
+
+
+# Work mode name <-> (high_byte, low_byte) mapping (from Lua workMode16/workMode)
+WORK_MODE_MAP: dict[str, tuple[int, int]] = {
+    "microwave": (0x01, 0x00),
+    "microwave_1": (0x01, 0x01),
+    "microwave_2": (0x01, 0x02),
+    "microwave_3": (0x01, 0x03),
+    "microwave_4": (0x01, 0x04),
+    "microwave_5": (0x01, 0x05),
+    "microwave_steam_above_tube": (0x02, 0x00),
+    "microwave_double_tube": (0x03, 0x00),
+    "microwave_hot_wind_tube_fan": (0x04, 0x00),
+    "microwave_underside_tube_hot_wind_tube_fan": (0x05, 0x00),
+    "microwave_double_tube_hot_wind_tube_fan": (0x06, 0x00),
+    "microwave_steam": (0x07, 0x00),
+    "microwave_steam_1": (0x07, 0x01),
+    "unfreeze": (0x09, 0x00),
+    "unfreeze_1": (0x09, 0x01),
+    "unfreeze_2": (0x09, 0x02),
+    "unfreeze_3": (0x09, 0x03),
+    "unfreeze_t": (0x0A, 0x00),
+    "microwave_above_tube": (0x0B, 0x00),
+    "microwave_above_tube_1": (0x0B, 0x01),
+    "microwave_above_tube_2": (0x0B, 0x02),
+    "microwave_above_tube_fan": (0x0C, 0x00),
+    "fast_unfreeze": (0x0D, 0x00),
+    "fresh_unfreeze": (0x0E, 0x00),
+    "microwave_zymosis": (0x0F, 0x00),
+    "pure_steam": (0x29, 0x00),
+    "pure_steam_1": (0x29, 0x01),
+    "pure_steam_2": (0x29, 0x02),
+    "pure_steam_3": (0x29, 0x03),
+    "pure_steam_4": (0x29, 0x04),
+    "pure_steam_5": (0x29, 0x05),
+    "pure_steam_6": (0x29, 0x06),
+    "pure_steam_7": (0x29, 0x07),
+    "pure_steam_8": (0x29, 0x08),
+    "pure_steam_9": (0x29, 0x09),
+    "steam_above_tube": (0x2B, 0x00),
+    "steam_underside_tube": (0x2C, 0x00),
+    "steam_double_tube": (0x2D, 0x00),
+    "steam_hot_wind_tube_fan": (0x2E, 0x00),
+    "steam_hot_wind_tube_fan_1": (0x2E, 0x01),
+    "steam_hot_wind_tube_fan_2": (0x2E, 0x02),
+    "steam_hot_wind_tube": (0x2F, 0x00),
+    "steam_double_tube_fan": (0x30, 0x00),
+    "steam_above_inside_outside_tube_fan": (0x31, 0x00),
+    "steam_above_inside_tube_fan": (0x32, 0x00),
+    "above_tube": (0x51, 0x00),
+    "underside_tube": (0x52, 0x00),
+    "double_tube": (0x53, 0x00),
+    "hot_wind_tube_fan": (0x54, 0x00),
+    "pure_preheat": (0x55, 0x00),
+    "above_tube_hot_wind_tube_fan": (0x56, 0x00),
+    "underside_tube_hot_wind_tube_fan": (0x57, 0x00),
+    "zymosis": (0x58, 0x00),
+    "double_tube_hot_wind_tube_fan": (0x59, 0x00),
+    "above_tube_revolve": (0x5A, 0x00),
+    "underside_tube_revolve": (0x5B, 0x00),
+    "double_tube_revolve": (0x5C, 0x00),
+    "hot_wind_tube_fan_revolve": (0x5D, 0x00),
+    "warm": (0x5E, 0x00),
+    "double_tube_fan": (0x5F, 0x00),
+    "double_tube_fan_1": (0x5F, 0x01),
+    "double_tube_fan_2": (0x5F, 0x02),
+    "double_tube_fan_3": (0x5F, 0x03),
+    "above_inside_tube_revolve": (0x60, 0x00),
+    "above_inside_tube_fan": (0x61, 0x00),
+    "above_inside_outside_tube_revolve": (0x62, 0x00),
+    "above_inside_outside_tube_fan": (0x63, 0x00),
+    "above_inside_underside_tube": (0x64, 0x00),
+    "above_inside_underside_tube_1": (0x64, 0x01),
+    "above_inside_underside_tube_fan": (0x65, 0x00),
+    "above_inside_underside_tube_fan_1": (0x65, 0x01),
+    "above_inside_tube": (0x66, 0x00),
+    "above_inside_outside_tube": (0x67, 0x00),
+    "underside_tube_fan": (0x68, 0x00),
+    "above_tube_fan": (0x69, 0x00),
+    "above_tube_fan_1": (0x69, 0x01),
+    "above_tube_fan_2": (0x69, 0x02),
+    "scale_clean": (0x79, 0x00),
+    "clean": (0x7A, 0x00),
+    "remove_odor": (0x7B, 0x00),
+    "remove_odor_2": (0x7B, 0x02),
+    "high_temperature_clean": (0x7C, 0x00),
+    "dining_utensils_clean": (0x7D, 0x00),
+    "auto_menu": (0xA1, 0x00),
+    "eco": (0xA2, 0x00),
+    "above_tube_1": (0x51, 0x01),
+    "above_tube_2": (0x51, 0x02),
+    "above_tube_3": (0x51, 0x03),
+    "underside_tube_1": (0x52, 0x01),
+    "underside_tube_2": (0x52, 0x02),
+    "double_tube_1": (0x53, 0x01),
+    "double_tube_2": (0x53, 0x02),
+    "double_tube_3": (0x53, 0x03),
+    "double_tube_4": (0x53, 0x04),
+    "double_tube_5": (0x53, 0x05),
+    "double_tube_6": (0x53, 0x06),
+    "hot_wind_tube_fan_1": (0x54, 0x01),
+    "hot_wind_tube_fan_2": (0x54, 0x02),
+    "hot_wind_tube_fan_3": (0x54, 0x03),
+    "hot_wind_tube_fan_4": (0x54, 0x04),
+    "hot_wind_tube_fan_5": (0x54, 0x05),
+    "double_tube_hot_wind_tube_fan_1": (0x59, 0x01),
+    "double_tube_hot_wind_tube_fan_2": (0x59, 0x02),
+    "double_tube_hot_wind_tube_fan_3": (0x59, 0x03),
+    "double_tube_hot_wind_tube_fan_4": (0x59, 0x04),
+    "double_tube_hot_wind_tube_fan_5": (0x59, 0x05),
+}
+
+# Reverse map: (high, low) -> name
+WORK_MODE_REVERSE: dict[tuple[int, int], str] = {v: k for k, v in WORK_MODE_MAP.items()}
+
+
+def work_mode_to_bytes(mode: str | None) -> tuple[int, int]:
+    """Convert work mode name to (high, low) bytes."""
+    if mode is None:
+        return (BYTE_FF, BYTE_FF)
+    return WORK_MODE_MAP.get(mode, (BYTE_FF, BYTE_FF))
+
+
+def work_mode_to_name(high: int, low: int) -> str:
+    """Convert (high, low) bytes to work mode name."""
+    return WORK_MODE_REVERSE.get((high, low), "unknown")
 
 
 class MessageBFBase(MessageRequest):
@@ -45,52 +315,567 @@ class MessageQuery(MessageBFBase):
 
     @property
     def _body(self) -> bytearray:
-        return bytearray([])
+        return bytearray([0x01])
 
 
 class MessageSet(MessageBFBase):
     """BF message set."""
 
-    def __init__(self, protocol_version: ProtocolVersion) -> None:
+    def __init__(self, protocol_version: int) -> None:
         """Initialize BF message set."""
         super().__init__(
             protocol_version=protocol_version,
-            message_type=MessageType.query,
+            message_type=MessageType.set,
             body_type=ListTypes.X02,
         )
+        # Non-work mode controls (notWorkModeControl in Lua)
         self.power: bool | None = None
+        self.work_status: str | None = None  # save_power/standby/work/pause
         self.child_lock: bool | None = None
+        self.furnace_light: bool | None = None
+        self.door: bool | None = None  # True=open, False=close
+        self.screen_luminance: int | None = None
+        self.volume: int | None = None
+        self.hot_wind: bool | None = None
+        self.ramadan: bool | None = None
+        # Work mode controls (workModeControl/singleCooking in Lua)
+        self.work_mode: str | None = None
+        self.work_hour: int | None = None
+        self.work_minute: int | None = None
+        self.work_second: int | None = None
+        self.fire_power: str | None = None
+        self.temperature: int | None = None
+        self.temperature_above: int | None = None
+        self.temperature_underside: int | None = None
+        self.probe_temperature: int | None = None
+        self.steam_quantity: int | None = None
+        self.weight: int | None = None
+        self.people_number: int | None = None
+        self.pre_heat: bool | None = None
+        self.turntable: bool | None = None
+        # Set controls (setControl in Lua) - runtime parameter adjustments
+        self.steam_set: int | None = None
+        self.hour_set: int | None = None
+        self.minute_set: int | None = None
+        self.second_set: int | None = None
+        self.fire_power_set: str | None = None
+        self.temp_set: int | None = None
+        self.probe_temp_set: int | None = None
+        self.temp_above_set: int | None = None
+        self.temp_underside_set: int | None = None
+
+    @staticmethod
+    def _fire_power_value(name: str | None) -> int:
+        if name is None:
+            return BYTE_FF
+        try:
+            return FirePower[name].value
+        except KeyError:
+            return BYTE_FF
+
+    @staticmethod
+    def _work_status_value(status: str | None) -> int:
+        if status is None:
+            return BYTE_FF
+        try:
+            return WorkStatus[status].value
+        except KeyError:
+            return BYTE_FF
+
+    @property
+    def body(self) -> bytearray:
+        """Message body. Override to set body_type from control type."""
+        content = self._body  # determines and sets self.body_type
+        body = bytearray([])
+        if self.body_type is not None:
+            body.append(self.body_type)
+        if content is not None:
+            body.extend(content)
+        return body
 
     @property
     def _body(self) -> bytearray:
-        power = 0xFF if self.power is None else 0x11 if self.power else 0x01
-        child_lock = (
-            0xFF if self.child_lock is None else 0x01 if self.child_lock else 0x00
+        """Determine which control group to use based on set fields.
+
+        Priority: work_mode > notWorkMode fields > setControl fields.
+        body_type is dynamically set to match Lua's bodyBytes[0] control type.
+        """
+        if self.work_mode is not None:
+            self.body_type = ListTypes.X01  # workModeControl
+            return self._build_work_mode_control()
+        not_work_mode_fields = [
+            self.work_status,
+            self.power,
+            self.furnace_light,
+            self.child_lock,
+            self.door,
+            self.hot_wind,
+            self.screen_luminance,
+            self.volume,
+            self.ramadan,
+        ]
+        if any(field is not None for field in not_work_mode_fields):
+            self.body_type = ListTypes.X02  # notWorkModeControl
+            return self._build_not_work_mode_control()
+        # setControl: parameter adjustments during work
+        set_control_fields = [
+            self.steam_set,
+            self.hour_set,
+            self.minute_set,
+            self.second_set,
+            self.fire_power_set,
+            self.temp_set,
+            self.probe_temp_set,
+            self.temp_above_set,
+            self.temp_underside_set,
+        ]
+        if any(field is not None for field in set_control_fields):
+            self.body_type = ListTypes.X03  # setControl
+            return self._build_set_control()
+        msg = "MessageSet has no control fields set"
+        raise ValueError(msg)
+
+    def _build_not_work_mode_control(self) -> bytearray:
+        """Build notWorkModeControl body content (body_type=0x02 added by framework)."""
+        power_byte = self._bool_to_byte(
+            self.power,
+            BYTE_POWER_ON,
+            BYTE_POWER_OFF,
         )
-        return bytearray([power, child_lock] + [0xFF] * 7)
+        # work_status takes priority over power: when both are set, only work_status
+        # byte is written (Lua writes statusByte = workStatus or powerByte).
+        status_byte = (
+            self._work_status_value(self.work_status)
+            if self.work_status is not None
+            else power_byte
+        )
+        lock_byte = self._bool_to_byte(
+            self.child_lock,
+            BYTE_LOCK_ON,
+            BYTE_LOCK_OFF,
+        )
+        light_byte = self._bool_to_byte(
+            self.furnace_light,
+            BYTE_LIGHT_ON,
+            BYTE_LIGHT_OFF,
+        )
+        door_byte = self._bool_to_byte(
+            self.door,
+            BYTE_DOOR_OPEN,
+            BYTE_DOOR_CLOSE,
+        )
+        screen_byte = self.screen_luminance or BYTE_FF
+        volume_byte = self.volume or BYTE_FF
+        hot_wind_byte = self._bool_to_byte(
+            self.hot_wind,
+            BYTE_HOT_WIND_ON,
+            BYTE_HOT_WIND_OFF,
+        )
+        ramadan_byte = self._bool_to_byte(
+            self.ramadan,
+            BYTE_RAMADAN_ON,
+            BYTE_RAMADAN_OFF,
+        )
+
+        # Lua bodyBytes[1..17] (bodyBytes[0]=0x02 is body_type, added by framework)
+        return bytearray(
+            [
+                status_byte,
+                lock_byte,
+                light_byte,
+                BYTE_FF,
+                door_byte,
+                BYTE_FF,
+                BYTE_FF,
+                screen_byte,
+                volume_byte,
+                BYTE_FF,
+                BYTE_FF,
+                hot_wind_byte,
+                BYTE_FF,
+                BYTE_FF,
+                BYTE_FF,
+                ramadan_byte,
+                BYTE_FF,
+            ],
+        )
+
+    @staticmethod
+    def _bool_to_byte(value: bool | None, true_val: int, false_val: int) -> int:
+        """Convert optional bool to byte value."""
+        if value is None:
+            return BYTE_FF
+        return {True: true_val, False: false_val}[value]
+
+    def _build_work_mode_control(self) -> bytearray:
+        """Build workModeControl/singleCooking body content (body_type=0x01 added by framework)."""  # noqa: E501
+        # b5 flags: bit0=pre_heat, bit1=probe, bit3=turntable, bit4=hot_wind
+        b5 = (
+            (BIT_SET_PRE_HEAT if self.pre_heat is True else 0)
+            | (BIT_SET_PROBE if self.probe_temperature is not None else 0)
+            | (BIT_SET_TURNTABLE if self.turntable is True else 0)
+            | (BIT_SET_HOT_WIND if self.hot_wind is True else 0)
+        )
+
+        mode_high, mode_low = work_mode_to_bytes(self.work_mode)
+
+        work_hour = self.work_hour or 0x00
+        work_minute = self.work_minute or 0x00
+        work_second = self.work_second or 0x00
+        fire_power_byte = self._fire_power_value(self.fire_power)
+
+        # Temperature bytes
+        temp_high = temp_low = 0x00
+        temp_above_high = temp_above_low = 0x00
+        temp_underside_high = temp_underside_low = 0x00
+
+        if self.temperature is not None:
+            temp_high = (self.temperature >> 8) & BYTE_FF
+            temp_low = self.temperature & BYTE_FF
+            temp_above_high = temp_high
+            temp_above_low = temp_low
+            temp_underside_high = temp_high
+            temp_underside_low = temp_low
+        if self.temperature_above is not None:
+            temp_above_high = (self.temperature_above >> 8) & BYTE_FF
+            temp_above_low = self.temperature_above & BYTE_FF
+        if self.temperature_underside is not None:
+            temp_underside_high = (self.temperature_underside >> 8) & BYTE_FF
+            temp_underside_low = self.temperature_underside & BYTE_FF
+
+        # Probe temperature
+        probe_high = probe_low = 0x00
+        if self.probe_temperature is not None:
+            probe_high = (self.probe_temperature >> 8) & BYTE_FF
+            probe_low = self.probe_temperature & BYTE_FF
+
+        # Steam quantity
+        steam_byte = self.steam_quantity or BYTE_FF
+
+        # Weight / people number
+        if self.weight is not None:
+            weight_byte = (self.weight // WEIGHT_DIVISOR) & BYTE_FF
+        elif self.people_number is not None:
+            weight_byte = self.people_number & BYTE_FF
+        else:
+            weight_byte = BYTE_FF
+
+        # Lua bodyBytes[1..21] (bodyBytes[0]=0x01 is body_type, added by framework)
+        return bytearray(
+            [
+                0x00,  # bodyBytes[1] reserved
+                0x00,  # bodyBytes[2] reserved
+                0x00,  # bodyBytes[3] reserved
+                0x00,  # bodyBytes[4] reserved
+                b5,  # bodyBytes[5] flags
+                mode_high,  # bodyBytes[6] work mode high
+                mode_low,  # bodyBytes[7] work mode low
+                work_hour,  # bodyBytes[8]
+                work_minute,  # bodyBytes[9]
+                work_second,  # bodyBytes[10]
+                fire_power_byte,  # bodyBytes[11]
+                temp_above_high,  # bodyBytes[12]
+                temp_above_low,  # bodyBytes[13]
+                temp_underside_high,  # bodyBytes[14]
+                temp_underside_low,  # bodyBytes[15]
+                probe_high,  # bodyBytes[16]
+                probe_low,  # bodyBytes[17]
+                steam_byte,  # bodyBytes[18]
+                weight_byte,  # bodyBytes[19]
+                BYTE_FF,  # bodyBytes[20]
+                0x00,  # bodyBytes[21]
+            ],
+        )
+
+    def _build_set_control(self) -> bytearray:
+        """Build setControl body content (body_type=0x03 added by framework)."""
+        body = bytearray([0x01, 0x00])  # 0x01, paramSum placeholder
+        param_sum = 0
+
+        if self.steam_set is not None:
+            body.append(PARAM_ID_STEAM)
+            param_sum += 1
+            body.append(self.steam_set & BYTE_FF)
+
+        time_fields = [self.hour_set, self.minute_set, self.second_set]
+        if any(f is not None for f in time_fields):
+            body.append(PARAM_ID_TIME)
+            body.extend(
+                [
+                    self.hour_set or 0x00,
+                    self.minute_set or 0x00,
+                    self.second_set or 0x00,
+                ],
+            )
+            param_sum += 1
+
+        if self.fire_power_set is not None:
+            body.append(PARAM_ID_FIRE_POWER)
+            param_sum += 1
+            body.append(self._fire_power_value(self.fire_power_set))
+
+        if self.temp_set is not None:
+            temp_high = (self.temp_set >> 8) & BYTE_FF
+            temp_low = self.temp_set & BYTE_FF
+            body.append(PARAM_ID_TEMP)
+            body.append(0x00)
+            body.append(temp_high)
+            body.append(temp_low)
+            param_sum += 1
+
+        if self.probe_temp_set is not None:
+            temp_high = (self.probe_temp_set >> 8) & BYTE_FF
+            temp_low = self.probe_temp_set & BYTE_FF
+            body.append(PARAM_ID_PROBE_TEMP)
+            body.append(0x00)
+            body.append(temp_high)
+            body.append(temp_low)
+            param_sum += 1
+
+        if self.temp_above_set is not None:
+            temp_high = (self.temp_above_set >> 8) & BYTE_FF
+            temp_low = self.temp_above_set & BYTE_FF
+            body.append(PARAM_ID_TEMP_ABOVE_UNDERSIDE)
+            body.append(0x00)
+            body.append(0x00)
+            body.append(SUBINDEX_ABOVE)
+            body.append(temp_high)
+            body.append(temp_low)
+            param_sum += 1
+
+        if self.temp_underside_set is not None:
+            temp_high = (self.temp_underside_set >> 8) & BYTE_FF
+            temp_low = self.temp_underside_set & BYTE_FF
+            body.append(PARAM_ID_TEMP_ABOVE_UNDERSIDE)
+            body.append(0x00)
+            body.append(0x00)
+            body.append(SUBINDEX_UNDERSIDE)
+            body.append(temp_high)
+            body.append(temp_low)
+            param_sum += 1
+
+        body[1] = param_sum
+        return body
 
 
 class MessageBFBody(MessageBody):
-    """BF message body."""
+    """BF message body (totalState)."""
 
     def __init__(self, body: bytearray) -> None:
         """Initialize BF message body."""
         super().__init__(body)
-        self.status = body[31]
-        self.time_remaining = (
-            (0 if body[22] == MAX_BYTE_VALUE else body[22]) * 3600
-            + (0 if body[23] == MAX_BYTE_VALUE else body[23]) * 60
-            + (0 if body[24] == MAX_BYTE_VALUE else body[24])
+
+        self._parse_execute_status(body)
+        self._parse_cloudmenuid(body)
+        self._parse_steps(body)
+        self._parse_probe_turntable_flags(body)
+        self._parse_work_mode(body)
+        self._parse_time_settings(body)
+        self._parse_fire_power(body)
+        self._parse_temperatures(body)
+        self._parse_steam_weight(body)
+        self._parse_work_time(body)
+        self._parse_current_temperatures(body)
+        self._parse_status_and_power(body)
+        self._parse_byte32_flags(body)
+        self._parse_byte33_flags(body)
+        self._parse_byte34_flags(body)
+        self._parse_byte35_flags(body)
+        self._parse_cbs_version(body)
+        self._parse_byte56_flags(body)
+        self._parse_byte58_flags(body)
+
+    def _parse_execute_status(self, body: bytearray) -> None:
+        """Parse execute status from body."""
+        execute = self.read_byte(body, OFFSET_EXECUTE, 0)
+        self.execute = {
+            0x00: "ok",
+            0x01: "status_nonsupport",
+            0x02: "function_nonsupport",
+            0x03: "param_range_error",
+        }.get(execute, "unknown")
+
+    def _parse_cloudmenuid(self, body: bytearray) -> None:
+        """Parse cloudmenuid from body."""
+        self.cloudmenuid = (
+            self.read_byte(body, OFFSET_CLOUDMENUID_HIGH, 0) << 16
+            | self.read_byte(body, OFFSET_CLOUDMENUID_MID, 0) << 8
+            | self.read_byte(body, OFFSET_CLOUDMENUID_LOW, 0)
         )
-        cur_temperature = body[25] * 256 + body[26]
-        if cur_temperature == 0:
-            cur_temperature = body[27] * 256 + body[28]
-        self.current_temperature = cur_temperature
-        self.child_lock = (body[32] & 0x01) > 0
-        self.door = (body[32] & 0x02) > 0
-        self.tank_ejected = (body[32] & 0x04) > 0
-        self.water_state = (body[32] & 0x08) > 0
-        self.water_change_reminder = (body[32] & 0x10) > 0
+
+    def _parse_steps(self, body: bytearray) -> None:
+        """Parse totalstep and stepnum from body."""
+        b = self.read_byte(body, OFFSET_TOTALSTEP_STEPNUM, 0)
+        self.totalstep = b >> 4
+        self.stepnum = b & 0x0F
+
+    def _parse_probe_turntable_flags(self, body: bytearray) -> None:
+        """Parse probe and turntable flags from body."""
+        b = self.read_byte(body, OFFSET_FLAGS_B6, 0)
+        self.probe = bool(b & BIT_PROBE)
+        self.turntable = bool(b & BIT_TURNTABLE)
+
+    def _parse_work_mode(self, body: bytearray) -> None:
+        """Parse work_mode from body."""
+        self.work_mode = work_mode_to_name(
+            self.read_byte(body, OFFSET_WORK_MODE_HIGH, BYTE_FF),
+            self.read_byte(body, OFFSET_WORK_MODE_LOW, BYTE_FF),
+        )
+
+    def _parse_time_settings(self, body: bytearray) -> None:
+        """Parse hour_set/minute_set/second_set from body."""
+        self.hour_set = self._read_time_byte(body, OFFSET_HOUR_SET)
+        self.minute_set = self._read_time_byte(body, OFFSET_MINUTE_SET)
+        self.second_set = self._read_time_byte(body, OFFSET_SECOND_SET)
+
+    def _read_time_byte(self, body: bytearray, offset: int) -> int:
+        """Read a time byte, returning 0 if 0xFF."""
+        if len(body) > offset and body[offset] != MAX_BYTE_VALUE:
+            return body[offset]
+        return 0
+
+    def _parse_fire_power(self, body: bytearray) -> None:
+        """Parse fire_power from body."""
+        fp = self.read_byte(body, OFFSET_FIRE_POWER, BYTE_FF)
+        try:
+            self.fire_power = FirePower(fp).name
+        except ValueError:
+            self.fire_power = "unknown"
+
+    def _parse_temperatures(self, body: bytearray) -> None:
+        """Parse temperature settings from body."""
+        self.temperature_above = self._read_word(
+            body,
+            OFFSET_TEMP_ABOVE_HIGH,
+            OFFSET_TEMP_ABOVE_LOW,
+        )
+        self.temperature_underside = self._read_word(
+            body,
+            OFFSET_TEMP_UNDERSIDE_HIGH,
+            OFFSET_TEMP_UNDERSIDE_LOW,
+        )
+        self.temperature = (
+            self.temperature_above
+            if self.temperature_above != 0
+            else self.temperature_underside
+        )
+        self.probe_temperature = self._read_word(
+            body,
+            OFFSET_PROBE_TEMP_HIGH,
+            OFFSET_PROBE_TEMP_LOW,
+        )
+
+    def _parse_steam_weight(self, body: bytearray) -> None:
+        """Parse steam_quantity and weight/people_number from body."""
+        sq = self.read_byte(body, OFFSET_STEAM_QUANTITY, BYTE_FF)
+        self.steam_quantity = sq if sq != MAX_BYTE_VALUE else None
+        b = self.read_byte(body, OFFSET_WEIGHT_PEOPLE, BYTE_FF)
+        self.weight = b * WEIGHT_DIVISOR if b != MAX_BYTE_VALUE else None
+        self.people_number = b if b != MAX_BYTE_VALUE else None
+
+    def _parse_work_time(self, body: bytearray) -> None:
+        """Parse work_hour/minute/second and compute time_remaining."""
+        self.work_hour = self._read_time_byte(body, OFFSET_WORK_HOUR)
+        self.work_minute = self._read_time_byte(body, OFFSET_WORK_MINUTE)
+        self.work_second = self._read_time_byte(body, OFFSET_WORK_SECOND)
+        self.time_remaining = (
+            self.work_hour * SECONDS_PER_HOUR
+            + self.work_minute * SECONDS_PER_MINUTE
+            + self.work_second
+        )
+
+    def _parse_current_temperatures(self, body: bytearray) -> None:
+        """Parse current temperatures from body."""
+        self.cur_temperature_above = self._read_word(
+            body,
+            OFFSET_CUR_TEMP_ABOVE_HIGH,
+            OFFSET_CUR_TEMP_ABOVE_LOW,
+        )
+        self.cur_temperature_underside = self._read_word(
+            body,
+            OFFSET_CUR_TEMP_UNDERSIDE_HIGH,
+            OFFSET_CUR_TEMP_UNDERSIDE_LOW,
+        )
+        if (cur_temp := self.cur_temperature_above) == 0:
+            cur_temp = self.cur_temperature_underside
+        self.current_temperature = cur_temp
+        self.cur_probe_temperature = self._read_word(
+            body,
+            OFFSET_CUR_PROBE_TEMP_HIGH,
+            OFFSET_CUR_PROBE_TEMP_LOW,
+        )
+
+    def _parse_status_and_power(self, body: bytearray) -> None:
+        """Parse work_status and infer power state."""
+        status_byte = self.read_byte(body, OFFSET_WORK_STATUS, 0)
+        try:
+            self.status = WorkStatus(status_byte).name
+        except ValueError:
+            self.status = "unknown"
+        # save_power means device is off; unknown status cannot be trusted as on
+        self.power = self.status not in ("save_power", "unknown")
+
+    def _parse_byte32_flags(self, body: bytearray) -> None:
+        """Parse flags from body byte 32."""
+        b = self.read_byte(body, OFFSET_FLAGS_B32, 0)
+        self.child_lock = bool(b & BIT_CHILD_LOCK)
+        self.door = bool(b & BIT_DOOR)
+        self.tank_ejected = bool(b & BIT_TANK_EJECTED)
+        self.water_shortage = bool(b & BIT_WATER_SHORTAGE)
+        self.water_change_reminder = bool(b & BIT_WATER_CHANGE)
+        self.error_code = bool(b & BIT_ERROR_CODE)
+        self.pre_heat = bool(b & BIT_PREHEAT)
+
+    def _parse_byte33_flags(self, body: bytearray) -> None:
+        """Parse flags from body byte 33."""
+        b = self.read_byte(body, OFFSET_FLAGS_B33, 0)
+        self.flip_side = bool(b & BIT_FLIP_SIDE)
+        self.reaction = bool(b & BIT_REACTION)
+        self.furnace_light = bool(b & BIT_FURNACE_LIGHT)
+        self.high_temperature_lock = (b & BIT_HIGH_TEMP_LOCK) == 0
+        self.high_temperature_work = bool(b & BIT_HIGH_TEMP_WORK)
+        self.high_temperature = bool(b & BIT_HIGH_TEMP)
+        self.probe_mode = bool(b & BIT_PROBE_MODE)
+
+    def _parse_byte34_flags(self, body: bytearray) -> None:
+        """Parse ramadan flag from body byte 34."""
+        b = self.read_byte(body, OFFSET_RAMADAN, 0)
+        self.ramadan = bool(b & BIT_RAMADAN)
+
+    def _parse_byte35_flags(self, body: bytearray) -> None:
+        """Parse hot_wind flag from body byte 35."""
+        b = self.read_byte(body, OFFSET_HOT_WIND, 0)
+        self.hot_wind = bool(b & BIT_HOT_WIND)
+
+    def _parse_cbs_version(self, body: bytearray) -> None:
+        """Parse cbs_version from body."""
+        if len(body) > OFFSET_CBS_VERSION_PATCH:
+            major = body[OFFSET_CBS_VERSION_MAJOR]
+            minor = body[OFFSET_CBS_VERSION_MINOR]
+            patch = body[OFFSET_CBS_VERSION_PATCH]
+            self.cbs_version = f"V{major}.{minor}.{patch}"
+        else:
+            self.cbs_version = "V0.0.0"
+
+    def _parse_byte56_flags(self, body: bytearray) -> None:
+        """Parse clean_scale and ota flags from body byte 56."""
+        b = self.read_byte(body, OFFSET_FLAGS_B56, 0)
+        self.clean_scale = bool(b & BIT_CLEAN_SCALE)
+        self.ota = bool(b & BIT_OTA)
+
+    def _parse_byte58_flags(self, body: bytearray) -> None:
+        """Parse clean_sink_ponding and dissipate_heat flags from body byte 58."""
+        b = self.read_byte(body, OFFSET_FLAGS_B58, 0)
+        self.clean_sink_ponding = bool(b & BIT_CLEAN_SINK_PONDING)
+        self.dissipate_heat = bool(b & BIT_DISSIPATE_HEAT)
+
+    def _read_word(self, body: bytearray, high_offset: int, low_offset: int) -> int:
+        """Read a 16-bit word from two body bytes."""
+        return self.read_byte(body, high_offset, 0) << 8 | self.read_byte(
+            body,
+            low_offset,
+            0,
+        )
 
 
 class MessageBFResponse(MessageResponse):
@@ -102,7 +887,7 @@ class MessageBFResponse(MessageResponse):
         if (
             self.message_type
             in [MessageType.set, MessageType.notify1, MessageType.query]
-            and self.body_type == 0x01
+            and self.body_type == BODY_TYPE_TOTAL_STATE
         ):
             self.set_body(MessageBFBody(super().body))
         self.set_attr()

--- a/tests/devices/bf/device_bf_test.py
+++ b/tests/devices/bf/device_bf_test.py
@@ -1,11 +1,42 @@
 """Test BF Device."""
 
+from unittest.mock import patch
+
 import pytest
 
-from midealan.const import DeviceType, ProtocolVersion
+from midealan.const import ProtocolVersion
 from midealan.devices.bf import DeviceAttributes, MideaBFDevice
-from midealan.devices.bf.message import MessageBFBase, MessageQuery, MessageSet
+from midealan.devices.bf.message import (
+    MessageQuery,
+    MessageSet,
+    WorkStatus,
+)
+from midealan.exceptions import SocketException
 from midealan.message import ListTypes, MessageType
+
+
+def _build_device() -> MideaBFDevice:
+    """Build a Midea BF device."""
+    return MideaBFDevice(
+        name="Test BF Device",
+        device_id=1,
+        ip_address="192.168.1.1",
+        port=12345,
+        token="AA",
+        key="BB",
+        device_protocol=ProtocolVersion.V1,
+        model="test_model",
+        subtype=1,
+        customize="",
+    )
+
+
+def _build_message(message_type: MessageType, body: bytearray) -> bytes:
+    """Build a full BF response message."""
+    header = bytearray(
+        [0xAA] + ([0x0] * 7) + [ProtocolVersion.V1] + [message_type],
+    )
+    return bytes(header + body + bytearray([0x00]))
 
 
 class TestMideaBFDevice:
@@ -16,139 +47,397 @@ class TestMideaBFDevice:
     @pytest.fixture(autouse=True)
     def _setup_device(self) -> None:
         """Midea BF Device setup."""
-        self.device = MideaBFDevice(
-            name="Test Device",
-            device_id=1,
-            ip_address="192.168.1.1",
-            port=12345,
-            token="AA",
-            key="BB",
-            device_protocol=ProtocolVersion.V1,
-            model="test_model",
-            subtype=1,
-            customize="",
-        )
+        self.device = _build_device()
 
-    def test_initial_attributes(self) -> None:
-        """Test initial attributes."""
-        assert self.device.attributes[DeviceAttributes.door] is None
-        assert self.device.attributes[DeviceAttributes.status] is None
-        assert self.device.attributes[DeviceAttributes.time_remaining] is None
-        assert self.device.attributes[DeviceAttributes.current_temperature] is None
-        assert self.device.attributes[DeviceAttributes.tank_ejected] is None
-        assert self.device.attributes[DeviceAttributes.water_change_reminder] is None
-        assert self.device.attributes[DeviceAttributes.water_shortage] is None
+    def test_initial_attributes_all_none(self) -> None:
+        """Test all initial attributes are None."""
+        for attr in DeviceAttributes:
+            assert self.device.attributes[attr] is None
 
     def test_build_query(self) -> None:
-        """Test build query."""
+        """Test build query returns one MessageQuery."""
         queries = self.device.build_query()
         assert len(queries) == 1
         assert isinstance(queries[0], MessageQuery)
 
-    def test_set_attribute(self) -> None:
-        """Test set attribute is a no-op."""
-        self.device.set_attribute(DeviceAttributes.door.value, True)
-
-    def test_query_response(self) -> None:
-        """Test query response with valid status."""
-        header = bytearray(
-            [0xAA, 0x00, DeviceType.BF] + [0x00] * 5 + [ProtocolVersion.V1],
-        ) + bytearray([MessageType.query])
-        body = bytearray(33)
-        body[0] = 0x01  # body type
-        body[22] = 0x01  # hours
-        body[23] = 0x01  # minutes
-        body[24] = 0x01  # seconds
-        body[25] = 0x01  # temperature high byte
-        body[26] = 0x2C  # temperature low byte -> 300
-        body[31] = 0x03  # status -> Working
-        body[32] = 0x16  # door + tank_ejected + change_reminder
-        result = self.device.process_message(bytes(header + body + bytearray(1)))
-        assert self.device.attributes[DeviceAttributes.door] is True
-        assert self.device.attributes[DeviceAttributes.status] == "Working"
-        assert self.device.attributes[DeviceAttributes.time_remaining] == 3661
-        assert self.device.attributes[DeviceAttributes.current_temperature] == 300
-        assert self.device.attributes[DeviceAttributes.tank_ejected] is True
-        assert self.device.attributes[DeviceAttributes.water_change_reminder] is True
-        assert self.device.attributes[DeviceAttributes.water_shortage] is None
-        assert result[DeviceAttributes.status.value] == "Working"
-
-    def test_notify_response_fallback_temperature(self) -> None:
-        """Test notify1 response with fallback temperature and unknown status."""
-        header = bytearray(
-            [0xAA, 0x00, DeviceType.BF] + [0x00] * 5 + [ProtocolVersion.V1],
-        ) + bytearray([MessageType.notify1])
-        body = bytearray(33)
-        body[0] = 0x01  # body type
-        body[22] = 0xFF  # invalid hours
-        body[23] = 0xFF  # invalid minutes
-        body[24] = 0xFF  # invalid seconds
-        body[27] = 0x00  # fallback temperature high byte
-        body[28] = 0x64  # fallback temperature low byte -> 100
-        body[31] = 0x07  # unknown status
-        self.device.process_message(bytes(header + body + bytearray(1)))
-        assert self.device.attributes[DeviceAttributes.door] is False
-        assert self.device.attributes[DeviceAttributes.status] == "Unknown"
-        assert self.device.attributes[DeviceAttributes.time_remaining] == 0
-        assert self.device.attributes[DeviceAttributes.current_temperature] == 100
-        assert self.device.attributes[DeviceAttributes.tank_ejected] is False
-        assert self.device.attributes[DeviceAttributes.water_change_reminder] is False
-
-    def test_unexpected_response(self) -> None:
-        """Test unexpected body type updates nothing."""
-        header = bytearray(
-            [0xAA, 0x00, DeviceType.BF] + [0x00] * 5 + [ProtocolVersion.V1],
-        ) + bytearray([MessageType.query])
-        body = bytearray(33)
-        body[0] = 0x02  # unexpected body type
-        result = self.device.process_message(bytes(header + body + bytearray(1)))
-        assert result == {}
-
-
-class TestMessageBFBase:
-    """Test BF Message Base."""
-
-    def test_body_not_implemented(self) -> None:
-        """Test body not implemented."""
-        msg = MessageBFBase(
-            protocol_version=ProtocolVersion.V1,
-            message_type=MessageType.query,
-            body_type=ListTypes.X01,
+    def test_process_message_basic(self) -> None:
+        """Test process message with a basic totalState body."""
+        body = bytearray(60)
+        body[0] = 0x01  # body_type totalState
+        body[31] = WorkStatus.standby.value
+        new_status = self.device.process_message(
+            _build_message(MessageType.query, body),
         )
-        with pytest.raises(NotImplementedError):
-            _ = msg.body
+        assert self.device.attributes[DeviceAttributes.status] == "standby"
+        assert self.device.attributes[DeviceAttributes.power] is True
+        assert DeviceAttributes.status.value in new_status
+        assert new_status[DeviceAttributes.status.value] == "standby"
+
+    def test_process_message_save_power(self) -> None:
+        """Test process message with save_power status -> power=False."""
+        body = bytearray(60)
+        body[0] = 0x01
+        body[31] = WorkStatus.save_power.value
+        self.device.process_message(
+            _build_message(MessageType.query, body),
+        )
+        assert self.device.attributes[DeviceAttributes.power] is False
+        assert self.device.attributes[DeviceAttributes.status] == "save_power"
+
+    def test_process_message_all_flags(self) -> None:
+        """Test process message with all byte32/33 flags set."""
+        body = bytearray(60)
+        body[0] = 0x01
+        body[31] = WorkStatus.work.value
+        body[32] = 0xBF  # all byte32 flags
+        body[33] = 0x7F  # all byte33 flags
+        body[35] = 0x20  # hot_wind
+        body[56] = 0xC0  # clean_scale + ota
+        body[58] = 0x03  # clean_sink_ponding + dissipate_heat
+        self.device.process_message(
+            _build_message(MessageType.set, body),
+        )
+        assert self.device.attributes[DeviceAttributes.child_lock] is True
+        assert self.device.attributes[DeviceAttributes.door] is True
+        assert self.device.attributes[DeviceAttributes.tank_ejected] is True
+        assert self.device.attributes[DeviceAttributes.water_shortage] is True
+        assert self.device.attributes[DeviceAttributes.water_change_reminder] is True
+        assert self.device.attributes[DeviceAttributes.error] is True
+        assert self.device.attributes[DeviceAttributes.pre_heat] is True
+        assert self.device.attributes[DeviceAttributes.flip_side] is True
+        assert self.device.attributes[DeviceAttributes.reaction] is True
+        assert self.device.attributes[DeviceAttributes.furnace_light] is True
+        assert self.device.attributes[DeviceAttributes.hot_wind] is True
+        assert self.device.attributes[DeviceAttributes.clean_scale] is True
+        assert self.device.attributes[DeviceAttributes.ota] is True
+        assert self.device.attributes[DeviceAttributes.clean_sink_ponding] is True
+        assert self.device.attributes[DeviceAttributes.dissipate_heat] is True
+
+    def test_process_message_temperatures(self) -> None:
+        """Test process message with temperature values."""
+        body = bytearray(60)
+        body[0] = 0x01
+        body[31] = WorkStatus.work.value
+        body[13] = 0x00  # temp_above_high
+        body[14] = 200  # temp_above_low
+        body[15] = 0x00  # temp_underside_high
+        body[16] = 180  # temp_underside_low
+        body[25] = 0x00  # cur_temp_above_high
+        body[26] = 180  # cur_temp_above_low
+        self.device.process_message(
+            _build_message(MessageType.query, body),
+        )
+        assert self.device.attributes[DeviceAttributes.temperature] == 200
+        assert self.device.attributes[DeviceAttributes.temperature_above] == 200
+        assert self.device.attributes[DeviceAttributes.temperature_underside] == 180
+        assert self.device.attributes[DeviceAttributes.current_temperature] == 180
+
+    def test_process_message_time_remaining(self) -> None:
+        """Test process message with work time and time_remaining."""
+        body = bytearray(60)
+        body[0] = 0x01
+        body[31] = WorkStatus.work.value
+        body[22] = 1  # work_hour
+        body[23] = 30  # work_minute
+        body[24] = 0  # work_second
+        self.device.process_message(
+            _build_message(MessageType.query, body),
+        )
+        assert self.device.attributes[DeviceAttributes.time_remaining] == 5400
+
+    def test_process_message_work_mode(self) -> None:
+        """Test process message with work_mode."""
+        body = bytearray(60)
+        body[0] = 0x01
+        body[31] = WorkStatus.work.value
+        body[7] = 0x01  # microwave high
+        body[8] = 0x00  # microwave low
+        self.device.process_message(
+            _build_message(MessageType.query, body),
+        )
+        assert self.device.attributes[DeviceAttributes.work_mode] == "microwave"
+
+    def test_process_message_fire_power(self) -> None:
+        """Test process message with fire_power."""
+        body = bytearray(60)
+        body[0] = 0x01
+        body[31] = WorkStatus.work.value
+        body[12] = 0x05  # fire_power_5
+        self.device.process_message(
+            _build_message(MessageType.query, body),
+        )
+        assert self.device.attributes[DeviceAttributes.fire_power] == "fire_power_5"
+
+    def test_process_message_steam_weight(self) -> None:
+        """Test process message with steam and weight."""
+        body = bytearray(60)
+        body[0] = 0x01
+        body[31] = WorkStatus.work.value
+        body[19] = 5  # steam_quantity
+        body[20] = 50  # weight/people: 50*10=500
+        self.device.process_message(
+            _build_message(MessageType.query, body),
+        )
+        assert self.device.attributes[DeviceAttributes.steam_quantity] == 5
+        assert self.device.attributes[DeviceAttributes.weight] == 500
+        assert self.device.attributes[DeviceAttributes.people_number] == 50
+
+    def test_process_message_cbs_version(self) -> None:
+        """Test process message with cbs_version."""
+        body = bytearray(60)
+        body[0] = 0x01
+        body[31] = WorkStatus.work.value
+        body[47] = 1
+        body[48] = 2
+        body[49] = 3
+        self.device.process_message(
+            _build_message(MessageType.query, body),
+        )
+        assert self.device.attributes[DeviceAttributes.cbs_version] == "V1.2.3"
+
+    def test_process_message_maintenance_flags(self) -> None:
+        """Test process message with clean_scale, ota, etc."""
+        body = bytearray(60)
+        body[0] = 0x01
+        body[31] = WorkStatus.work.value
+        body[56] = 0xC0  # clean_scale + ota
+        body[58] = 0x03  # clean_sink_ponding + dissipate_heat
+        self.device.process_message(
+            _build_message(MessageType.query, body),
+        )
+        assert self.device.attributes[DeviceAttributes.clean_scale] is True
+        assert self.device.attributes[DeviceAttributes.ota] is True
+        assert self.device.attributes[DeviceAttributes.clean_sink_ponding] is True
+        assert self.device.attributes[DeviceAttributes.dissipate_heat] is True
+
+    def test_set_attribute_power(self) -> None:
+        """Test set_attribute with power raises SocketException (no socket)."""
+        with pytest.raises(SocketException):
+            self.device.set_attribute(DeviceAttributes.power, True)
+        # set_attribute sends command but doesn't update local state
+        assert self.device.attributes[DeviceAttributes.power] is None
+
+    def test_set_attribute_child_lock(self) -> None:
+        """Test set_attribute with child_lock."""
+        with pytest.raises(SocketException):
+            self.device.set_attribute(DeviceAttributes.child_lock, True)
+        assert self.device.attributes[DeviceAttributes.child_lock] is None
+
+    def test_set_attribute_furnace_light(self) -> None:
+        """Test set_attribute with furnace_light."""
+        with pytest.raises(SocketException):
+            self.device.set_attribute(DeviceAttributes.furnace_light, True)
+        assert self.device.attributes[DeviceAttributes.furnace_light] is None
+
+    def test_set_attribute_hot_wind(self) -> None:
+        """Test set_attribute with hot_wind."""
+        with pytest.raises(SocketException):
+            self.device.set_attribute(DeviceAttributes.hot_wind, True)
+        assert self.device.attributes[DeviceAttributes.hot_wind] is None
+
+    def test_set_attribute_door(self) -> None:
+        """Test set_attribute with door."""
+        with pytest.raises(SocketException):
+            self.device.set_attribute(DeviceAttributes.door, True)
+        assert self.device.attributes[DeviceAttributes.door] is None
+
+    def test_set_attribute_work_mode(self) -> None:
+        """Test set_attribute with work_mode."""
+        with pytest.raises(SocketException):
+            self.device.set_attribute(DeviceAttributes.work_mode, "microwave")
+        assert self.device.attributes[DeviceAttributes.work_mode] is None
+
+    def test_set_attribute_fire_power(self) -> None:
+        """Test set_attribute with fire_power routes to workModeControl.
+
+        Even without an active work_mode, fire_power is a work-mode parameter
+        field so it serializes via workModeControl and reaches build_send.
+        """
+        with pytest.raises(SocketException):
+            self.device.set_attribute(DeviceAttributes.fire_power, "fire_power_5")
+        assert self.device.attributes[DeviceAttributes.fire_power] is None
+
+    def test_set_attribute_fire_power_with_work_mode(self) -> None:
+        """Test set_attribute with fire_power when work_mode is active."""
+        # First set up work_mode via a processed message
+        body = bytearray(60)
+        body[0] = 0x01
+        body[31] = WorkStatus.work.value
+        body[7] = 0x01  # microwave high
+        body[8] = 0x00  # microwave low
+        self.device.process_message(_build_message(MessageType.query, body))
+        # Now fire_power should route via make_message_set with work_mode context
+        with pytest.raises(SocketException):
+            self.device.set_attribute(DeviceAttributes.fire_power, "fire_power_5")
+
+    def test_set_attribute_temperature(self) -> None:
+        """Test set_attribute with temperature routes to workModeControl.
+
+        Even without an active work_mode, temperature is a work-mode parameter
+        field so it serializes via workModeControl and reaches build_send.
+        """
+        with pytest.raises(SocketException):
+            self.device.set_attribute(DeviceAttributes.temperature, 200)
+        assert self.device.attributes[DeviceAttributes.temperature] is None
+
+    def test_set_attribute_temperature_with_work_mode(self) -> None:
+        """Test set_attribute with temperature when work_mode is active."""
+        body = bytearray(60)
+        body[0] = 0x01
+        body[31] = WorkStatus.work.value
+        body[7] = 0x01  # microwave high
+        body[8] = 0x00  # microwave low
+        self.device.process_message(_build_message(MessageType.query, body))
+        with pytest.raises(SocketException):
+            self.device.set_attribute(DeviceAttributes.temperature, 200)
+
+    def test_set_attribute_status_with_string(self) -> None:
+        """Test set_attribute with status (maps to work_status on message)."""
+        with pytest.raises(SocketException):
+            self.device.set_attribute(DeviceAttributes.status, "standby")
+        assert self.device.attributes[DeviceAttributes.status] is None
+
+    def test_set_attribute_status_invalid_type(self) -> None:
+        """Test set_attribute with status as non-string logs warning and returns."""
+        # This should not crash, just log a warning and return early
+        self.device.set_attribute(DeviceAttributes.status, 42)
+        assert self.device.attributes[DeviceAttributes.status] is None
+
+    def test_set_attribute_unsupported_attribute(self) -> None:
+        """Test set_attribute with unsupported attribute logs warning."""
+        # Attributes not in _SETTABLE_ATTRS and not status should be ignored
+        self.device.set_attribute(DeviceAttributes.time_remaining, 3600)
+        assert self.device.attributes[DeviceAttributes.time_remaining] is None
+
+    def test_set_attribute_hour_set(self) -> None:
+        """Test set_attribute with hour_set."""
+        with pytest.raises(SocketException):
+            self.device.set_attribute(DeviceAttributes.hour_set, 1)
+        assert self.device.attributes[DeviceAttributes.hour_set] is None
+
+    def test_set_attribute_minute_set(self) -> None:
+        """Test set_attribute with minute_set."""
+        with pytest.raises(SocketException):
+            self.device.set_attribute(DeviceAttributes.minute_set, 30)
+        assert self.device.attributes[DeviceAttributes.minute_set] is None
+
+    def test_set_attribute_second_set(self) -> None:
+        """Test set_attribute with second_set."""
+        with pytest.raises(SocketException):
+            self.device.set_attribute(DeviceAttributes.second_set, 0)
+        assert self.device.attributes[DeviceAttributes.second_set] is None
+
+    def test_process_message_updates_returned_dict(self) -> None:
+        """Test process_message returns a dict of updated attributes."""
+        body = bytearray(60)
+        body[0] = 0x01
+        body[31] = WorkStatus.standby.value
+        new_status = self.device.process_message(
+            _build_message(MessageType.query, body),
+        )
+        assert isinstance(new_status, dict)
+        # All attributes that MessageBFBody provides should be in new_status
+        assert DeviceAttributes.status.value in new_status
+        assert DeviceAttributes.power.value in new_status
+
+    def test_process_message_notify_type(self) -> None:
+        """Test process_message with notify1 message type."""
+        body = bytearray(60)
+        body[0] = 0x01
+        body[31] = WorkStatus.work.value
+        self.device.process_message(
+            _build_message(MessageType.notify1, body),
+        )
+        assert self.device.attributes[DeviceAttributes.status] == "work"
+
+    def test_process_message_non_total_state(self) -> None:
+        """Test process_message with non-totalState body_type."""
+        body = bytearray(10)
+        body[0] = 0x02  # not totalState (0x01)
+        new_status = self.device.process_message(
+            _build_message(MessageType.query, body),
+        )
+        # No BF-specific attributes should be parsed
+        assert self.device.attributes[DeviceAttributes.status] is None
+        assert DeviceAttributes.status.value not in new_status
+
+    def test_set_attribute_status_unsupported_value(self) -> None:
+        """Unknown status name is rejected instead of sent as a no-op."""
+        with patch.object(self.device, "build_send") as mock_build_send:
+            self.device.set_attribute(DeviceAttributes.status, "not_a_status")
+            mock_build_send.assert_not_called()
+
+    def test_set_attribute_status_valid_value_builds_message(self) -> None:
+        """A valid status name is serialized as work_status."""
+        with patch.object(self.device, "build_send") as mock_build_send:
+            self.device.set_attribute(DeviceAttributes.status, "standby")
+            mock_build_send.assert_called_once()
+            message = mock_build_send.call_args[0][0]
+            assert message.work_status == "standby"
+
+    def test_set_attribute_work_mode_unsupported_value(self) -> None:
+        """Unknown work_mode name is rejected instead of sent as a no-op."""
+        with patch.object(self.device, "build_send") as mock_build_send:
+            self.device.set_attribute(DeviceAttributes.work_mode, "not_a_mode")
+            mock_build_send.assert_not_called()
+
+    def test_set_attribute_float_coerced_to_int(self) -> None:
+        """Numeric attributes coerce float input to int before serialization.
+
+        A float would otherwise raise TypeError during the >> / & serialization
+        in MessageSet. temperature routes via workModeControl.
+        """
+        with patch.object(self.device, "build_send") as mock_build_send:
+            self.device.set_attribute(DeviceAttributes.temperature, 200.0)
+            mock_build_send.assert_called_once()
+            message = mock_build_send.call_args[0][0]
+            assert message.temperature == 200
+            assert isinstance(message.temperature, int)
+            # Serialization must not raise on the coerced value.
+            assert message.body[0] == ListTypes.X01
+
+    def test_set_attribute_people_number_clears_weight(self) -> None:
+        """Setting people_number clears weight so it is not preferred."""
+        body = bytearray(60)
+        body[0] = 0x01
+        body[31] = WorkStatus.work.value
+        body[7] = 0x01  # microwave high
+        body[8] = 0x00  # microwave low
+        body[20] = 50  # weight/people byte -> weight=500, people_number=50
+        self.device.process_message(_build_message(MessageType.query, body))
+        assert self.device.attributes[DeviceAttributes.weight] == 500
+        with patch.object(self.device, "build_send") as mock_build_send:
+            self.device.set_attribute(DeviceAttributes.people_number, 4)
+            mock_build_send.assert_called_once()
+            message = mock_build_send.call_args[0][0]
+            assert message.weight is None
+            assert message.people_number == 4
+
+    def test_set_attribute_work_mode_resend_preserves_cook_time(self) -> None:
+        """make_message_set carries hour/minute/second into work time fields."""
+        body = bytearray(60)
+        body[0] = 0x01
+        body[31] = WorkStatus.work.value
+        body[7] = 0x01  # microwave high
+        body[8] = 0x00  # microwave low
+        body[9] = 1  # hour_set
+        body[10] = 30  # minute_set
+        body[11] = 15  # second_set
+        self.device.process_message(_build_message(MessageType.query, body))
+        with patch.object(self.device, "build_send") as mock_build_send:
+            self.device.set_attribute(DeviceAttributes.fire_power, "fire_power_5")
+            mock_build_send.assert_called_once()
+            message = mock_build_send.call_args[0][0]
+            assert message.work_hour == 1
+            assert message.work_minute == 30
+            assert message.work_second == 15
 
 
-class TestMessageQuery:
-    """Test BF Message Query."""
+class TestMakeMessageSet:
+    """Test make_message_set directly."""
 
-    def test_query_body(self) -> None:
-        """Test query body."""
-        msg = MessageQuery(protocol_version=ProtocolVersion.V1)
-        assert msg.body == bytearray([0x01])
-
-
-class TestMessageSet:
-    """Test BF Message Set."""
-
-    @pytest.mark.parametrize(
-        ("power", "child_lock", "power_byte", "child_lock_byte"),
-        [
-            (None, None, 0xFF, 0xFF),
-            (True, True, 0x11, 0x01),
-            (False, False, 0x01, 0x00),
-        ],
-    )
-    def test_set_body(
-        self,
-        power: bool | None,
-        child_lock: bool | None,
-        power_byte: int,
-        child_lock_byte: int,
-    ) -> None:
-        """Test set body."""
-        msg = MessageSet(protocol_version=ProtocolVersion.V1)
-        msg.power = power
-        msg.child_lock = child_lock
-        expected_body = bytearray([0x02, power_byte, child_lock_byte] + [0xFF] * 7)
-        assert msg.body == expected_body
+    def test_make_message_set_returns_message_set(self) -> None:
+        """make_message_set returns a MessageSet with work-mode context."""
+        device = _build_device()
+        message = device.make_message_set()
+        assert isinstance(message, MessageSet)

--- a/tests/devices/bf/device_bf_test.py
+++ b/tests/devices/bf/device_bf_test.py
@@ -381,6 +381,12 @@ class TestMideaBFDevice:
             self.device.set_attribute(DeviceAttributes.work_mode, "not_a_mode")
             mock_build_send.assert_not_called()
 
+    def test_set_attribute_fire_power_unsupported_value(self) -> None:
+        """Unknown fire_power name is rejected instead of sent as a no-op."""
+        with patch.object(self.device, "build_send") as mock_build_send:
+            self.device.set_attribute(DeviceAttributes.fire_power, "bogus")
+            mock_build_send.assert_not_called()
+
     def test_set_attribute_float_coerced_to_int(self) -> None:
         """Numeric attributes coerce float input to int before serialization.
 

--- a/tests/devices/bf/message_bf_test.py
+++ b/tests/devices/bf/message_bf_test.py
@@ -1,0 +1,1137 @@
+"""Test BF message."""
+
+import pytest
+
+from midealan.const import ProtocolVersion
+from midealan.devices.bf.message import (
+    FirePower,
+    MessageBFBody,
+    MessageBFResponse,
+    MessageQuery,
+    MessageSet,
+    WorkStatus,
+    work_mode_to_bytes,
+    work_mode_to_name,
+)
+from midealan.message import ListTypes, MessageType
+
+
+class TestMessageQuery:
+    """Test MessageQuery."""
+
+    def test_query_body(self) -> None:
+        """Test query body."""
+        query = MessageQuery(protocol_version=ProtocolVersion.V1)
+        # body_type 0x01 prepended by framework, content is [0x01]
+        assert query.body == bytearray([ListTypes.X01, 0x01])
+
+
+class TestWorkModeHelpers:
+    """Test work mode mapping helpers."""
+
+    def test_work_mode_to_bytes_known(self) -> None:
+        """Test known work mode conversion."""
+        assert work_mode_to_bytes("microwave") == (0x01, 0x00)
+        assert work_mode_to_bytes("pure_steam") == (0x29, 0x00)
+        assert work_mode_to_bytes("above_tube") == (0x51, 0x00)
+        assert work_mode_to_bytes("eco") == (0xA2, 0x00)
+
+    def test_work_mode_to_bytes_unknown(self) -> None:
+        """Test unknown work mode returns 0xFF."""
+        assert work_mode_to_bytes("nonexistent_mode") == (0xFF, 0xFF)
+
+    def test_work_mode_to_bytes_none(self) -> None:
+        """Test None mode returns 0xFF."""
+        assert work_mode_to_bytes(None) == (0xFF, 0xFF)
+
+    def test_work_mode_to_name_known(self) -> None:
+        """Test known work mode reverse conversion."""
+        assert work_mode_to_name(0x01, 0x00) == "microwave"
+        assert work_mode_to_name(0x29, 0x00) == "pure_steam"
+        assert work_mode_to_name(0x51, 0x00) == "above_tube"
+
+    def test_work_mode_to_name_unknown(self) -> None:
+        """Test unknown bytes return 'unknown'."""
+        assert work_mode_to_name(0xFF, 0xFF) == "unknown"
+
+    def test_work_mode_to_bytes_low_variant(self) -> None:
+        """Test work mode with low byte variant."""
+        assert work_mode_to_bytes("microwave_1") == (0x01, 0x01)
+        assert work_mode_to_bytes("pure_steam_5") == (0x29, 0x05)
+
+    def test_work_mode_roundtrip(self) -> None:
+        """Test roundtrip: name -> bytes -> name."""
+        for name in ("microwave", "eco", "scale_clean"):
+            result = work_mode_to_name(*work_mode_to_bytes(name))
+            assert result == name
+
+
+class TestFirePower:
+    """Test FirePower enum."""
+
+    def test_values(self) -> None:
+        """Test FirePower values."""
+        assert FirePower.fire_power_0.value == 0x00
+        assert FirePower.fire_power_10.value == 0x0A
+
+    def test_all_values(self) -> None:
+        """Test all FirePower enum values cover 0..10."""
+        for i in range(11):
+            assert FirePower(i).value == i
+
+    def test_invalid_value(self) -> None:
+        """Test invalid FirePower value raises ValueError."""
+        with pytest.raises(ValueError, match=r".*"):
+            FirePower(0x0B)
+
+
+class TestWorkStatus:
+    """Test WorkStatus enum."""
+
+    def test_values(self) -> None:
+        """Test WorkStatus values."""
+        assert WorkStatus.save_power.value == 0x01
+        assert WorkStatus.standby.value == 0x02
+        assert WorkStatus.work.value == 0x03
+        assert WorkStatus.pause.value == 0x06
+
+    def test_all_defined_values(self) -> None:
+        """Test all defined WorkStatus members."""
+        assert WorkStatus.work_finish.value == 0x04
+        assert WorkStatus.order.value == 0x05
+        assert WorkStatus.pause_c.value == 0x07
+        assert WorkStatus.self_inspection.value == 0x0A
+        assert WorkStatus.wait_to_start.value == 0x10
+
+    def test_invalid_value(self) -> None:
+        """Test invalid WorkStatus value raises ValueError."""
+        with pytest.raises(ValueError, match=r".*"):
+            WorkStatus(0x00)
+
+
+class TestMessageSet:
+    """Test MessageSet."""
+
+    def test_message_type_is_set(self) -> None:
+        """Test MessageSet uses MessageType.set."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        assert msg.message_type == MessageType.set
+
+    def test_set_power_not_work_mode(self) -> None:
+        """Test setting power routes to notWorkModeControl (body_type 0x02)."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.power = True
+        body = msg.body
+        assert body[0] == ListTypes.X02
+        # status_byte (power=True -> 0x11) is body[1]
+        assert body[1] == 0x11
+
+    def test_set_power_off(self) -> None:
+        """Test setting power=False routes to notWorkModeControl."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.power = False
+        body = msg.body
+        assert body[0] == ListTypes.X02
+        assert body[1] == 0x01  # BYTE_POWER_OFF
+
+    def test_set_child_lock(self) -> None:
+        """Test setting child_lock routes to notWorkModeControl."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.child_lock = True
+        body = msg.body
+        assert body[0] == ListTypes.X02
+        # child_lock is body[2] (after status_byte)
+        assert body[2] == 0x01
+
+    def test_set_child_lock_off(self) -> None:
+        """Test setting child_lock=False."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.child_lock = False
+        body = msg.body
+        assert body[0] == ListTypes.X02
+        assert body[2] == 0x00  # BYTE_LOCK_OFF
+
+    def test_set_furnace_light(self) -> None:
+        """Test setting furnace_light."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.furnace_light = True
+        body = msg.body
+        assert body[0] == ListTypes.X02
+        assert body[3] == 0x01
+
+    def test_set_furnace_light_off(self) -> None:
+        """Test setting furnace_light=False."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.furnace_light = False
+        body = msg.body
+        assert body[3] == 0x00  # BYTE_LIGHT_OFF
+
+    def test_set_door(self) -> None:
+        """Test setting door routes to notWorkModeControl."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.door = True
+        body = msg.body
+        assert body[0] == ListTypes.X02
+        assert body[5] == 0x01  # BYTE_DOOR_OPEN
+
+    def test_set_door_close(self) -> None:
+        """Test setting door=False."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.door = False
+        body = msg.body
+        assert body[5] == 0x00  # BYTE_DOOR_CLOSE
+
+    def test_set_hot_wind(self) -> None:
+        """Test setting hot_wind routes to notWorkModeControl."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.hot_wind = True
+        body = msg.body
+        assert body[0] == ListTypes.X02
+        assert body[12] == 0x01  # BYTE_HOT_WIND_ON
+
+    def test_set_hot_wind_off(self) -> None:
+        """Test setting hot_wind=False."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.hot_wind = False
+        body = msg.body
+        assert body[12] == 0x00  # BYTE_HOT_WIND_OFF
+
+    def test_set_screen_luminance(self) -> None:
+        """Test setting screen_luminance routes to notWorkModeControl."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.screen_luminance = 5
+        body = msg.body
+        assert body[0] == ListTypes.X02
+        assert body[8] == 5  # screen_luminance byte
+
+    def test_set_volume(self) -> None:
+        """Test setting volume routes to notWorkModeControl."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.volume = 8
+        body = msg.body
+        assert body[0] == ListTypes.X02
+        assert body[9] == 8  # volume byte
+
+    def test_set_work_status(self) -> None:
+        """Test setting work_status routes to notWorkModeControl."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.work_status = "standby"
+        body = msg.body
+        assert body[0] == ListTypes.X02
+        assert body[1] == WorkStatus.standby.value  # 0x02
+
+    def test_not_work_mode_all_fields(self) -> None:
+        """Test notWorkModeControl with all fields set."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.power = True
+        msg.child_lock = True
+        msg.furnace_light = True
+        msg.door = True
+        msg.hot_wind = True
+        msg.screen_luminance = 3
+        msg.volume = 7
+        body = msg.body
+        assert body[0] == ListTypes.X02
+        assert body[1] == 0x11  # BYTE_POWER_ON
+        assert body[2] == 0x01  # BYTE_LOCK_ON
+        assert body[3] == 0x01  # BYTE_LIGHT_ON
+        assert body[5] == 0x01  # BYTE_DOOR_OPEN
+        assert body[8] == 3  # screen_luminance
+        assert body[9] == 7  # volume
+        assert body[12] == 0x01  # BYTE_HOT_WIND_ON
+
+    def test_set_work_mode_routes_to_work_mode_control(self) -> None:
+        """Test setting work_mode routes to workModeControl (body_type 0x01)."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.work_mode = "microwave"
+        msg.work_hour = 0
+        msg.work_minute = 30
+        msg.work_second = 0
+        body = msg.body
+        assert body[0] == ListTypes.X01
+
+    def test_work_mode_control_full(self) -> None:
+        """Test workModeControl with full parameters."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.work_mode = "microwave"
+        msg.work_hour = 1
+        msg.work_minute = 30
+        msg.work_second = 0
+        msg.fire_power = "fire_power_5"
+        msg.temperature = 200  # 200 = 0x00C8
+        msg.probe_temperature = 80
+        msg.steam_quantity = 3
+        msg.pre_heat = True
+        msg.turntable = True
+        msg.hot_wind = True
+        body = msg.body
+        assert body[0] == ListTypes.X01  # body_type
+        # b5 flags: pre_heat(0x01)+probe(0x02)+turntable(0x08)+hot_wind(0x10)
+        assert body[5] & 0x01 != 0  # pre_heat bit
+        assert body[5] & 0x08 != 0  # turntable bit
+        assert body[5] & 0x10 != 0  # hot_wind bit
+        assert body[6] == 0x01  # mode high (microwave)
+        assert body[7] == 0x00  # mode low
+        assert body[8] == 1  # hour
+        assert body[9] == 30  # minute
+        assert body[10] == 0  # second
+        assert body[11] == 5  # fire_power_5 value
+
+    def test_work_mode_control_temperature_above(self) -> None:
+        """Test workModeControl with separate temperature_above."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.work_mode = "above_tube"
+        msg.temperature_above = 200
+        msg.temperature_underside = 180
+        body = msg.body
+        assert body[0] == ListTypes.X01
+        # temperature_above = 200 -> high=0, low=200
+        assert body[12] == 0  # temp_above_high
+        assert body[13] == 200  # temp_above_low
+        # temperature_underside = 180 -> high=0, low=180
+        assert body[14] == 0  # temp_underside_high
+        assert body[15] == 180  # temp_underside_low
+
+    def test_work_mode_control_weight(self) -> None:
+        """Test workModeControl with weight."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.work_mode = "microwave"
+        msg.weight = 500  # weight / 10 = 50
+        body = msg.body
+        assert body[19] == 50  # weight / WEIGHT_DIVISOR
+
+    def test_work_mode_control_people_number(self) -> None:
+        """Test workModeControl with people_number (no weight set)."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.work_mode = "microwave"
+        msg.people_number = 4
+        body = msg.body
+        assert body[19] == 4  # people_number
+
+    def test_work_mode_control_no_flags(self) -> None:
+        """Test workModeControl b5=0 when no flags set."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.work_mode = "microwave"
+        body = msg.body
+        assert body[5] == 0  # b5 flags all zero
+
+    def test_set_hour_set_routes_to_set_control(self) -> None:
+        """Test setting hour_set routes to setControl (body_type 0x03)."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.hour_set = 1
+        body = msg.body
+        assert body[0] == ListTypes.X03
+
+    def test_set_no_control_fields_raises_value_error(self) -> None:
+        """MessageSet with no serializable control fields raises ValueError.
+
+        With every field left as None, no control group is selected, so
+        accessing body raises ValueError.
+        """
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        with pytest.raises(ValueError, match="no control fields"):
+            _ = msg.body
+
+    def test_set_work_mode_param_field_routes_to_work_mode_control(self) -> None:
+        """A lone work-mode parameter field routes to workModeControl.
+
+        Setting only turntable (no work_mode) must still serialize via the
+        work-mode control body instead of raising, so single-parameter updates
+        before the first response succeed.
+        """
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.turntable = True
+        body = msg.body
+        assert body[0] == ListTypes.X01  # workModeControl
+
+    def test_set_control_param_sum_at_index_one(self) -> None:
+        """ParamSum must be at body[1] (content), not overwrite first param id."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.hour_set = 1
+        msg.minute_set = 30
+        body = msg.body
+        assert body[0] == ListTypes.X03  # body_type
+        # content: [0x01, paramSum, 0x01(time id), hour, minute, second, ...]
+        assert body[1] == 0x01  # header
+        assert body[2] == 0x01  # paramSum = 1 (time group)
+        assert body[3] == 0x01  # time param id preserved (not overwritten)
+
+    def test_set_control_steam_set(self) -> None:
+        """Test setControl with steam_set."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.steam_set = 5
+        body = msg.body
+        assert body[0] == ListTypes.X03
+        # content: [0x01, paramSum=1, 0x00(steam id), 5]
+        assert body[1] == 0x01  # header
+        assert body[2] == 0x01  # paramSum = 1
+        assert body[3] == 0x00  # steam param id
+        assert body[4] == 5  # steam value
+
+    def test_set_control_time_group(self) -> None:
+        """Test setControl with time group (hour_set + minute_set + second_set)."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.hour_set = 1
+        msg.minute_set = 30
+        msg.second_set = 0
+        body = msg.body
+        assert body[0] == ListTypes.X03
+        assert body[2] == 0x01  # paramSum = 1 (time)
+        assert body[3] == 0x01  # time param id
+        assert body[4] == 1  # hour
+        assert body[5] == 30  # minute
+        assert body[6] == 0  # second
+
+    def test_set_control_fire_power_set(self) -> None:
+        """Test setControl with fire_power_set."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.fire_power_set = "fire_power_8"
+        body = msg.body
+        assert body[0] == ListTypes.X03
+        assert body[2] == 0x01  # paramSum = 1
+        assert body[3] == 0x02  # fire_power param id
+        assert body[4] == 0x08  # fire_power_8 value
+
+    def test_set_control_temp_set(self) -> None:
+        """Test setControl with temp_set."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.temp_set = 200  # 200 = 0x00C8
+        body = msg.body
+        assert body[0] == ListTypes.X03
+        assert body[2] == 0x01  # paramSum = 1
+        assert body[3] == 0x03  # temp param id
+        assert body[4] == 0x00  # reserved
+        assert body[5] == 0x00  # temp high
+        assert body[6] == 200  # temp low
+
+    def test_set_control_probe_temp_set(self) -> None:
+        """Test setControl with probe_temp_set."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.probe_temp_set = 80  # 80 = 0x0050
+        body = msg.body
+        assert body[0] == ListTypes.X03
+        assert body[2] == 0x01  # paramSum = 1
+        assert body[3] == 0x04  # probe_temp param id
+        assert body[4] == 0x00  # reserved
+        assert body[5] == 0x00  # probe_temp high
+        assert body[6] == 80  # probe_temp low
+
+    def test_set_control_temp_above_set(self) -> None:
+        """Test setControl with temp_above_set."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.temp_above_set = 250  # 250 = 0x00FA
+        body = msg.body
+        assert body[0] == ListTypes.X03
+        assert body[2] == 0x01  # paramSum = 1
+        assert body[3] == 0x05  # temp param id
+        assert body[4] == 0x00  # sub-field 0
+        assert body[5] == 0x00  # reserved
+        assert body[6] == 0x00  # sub-id for above (0)
+        assert body[7] == 0x00  # temp_high (250 >> 8 = 0)
+        assert body[8] == 250  # temp_low
+
+    def test_set_control_temp_underside_set(self) -> None:
+        """Test setControl with temp_underside_set."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.temp_underside_set = 180
+        body = msg.body
+        assert body[0] == ListTypes.X03
+        assert body[2] == 0x01  # paramSum = 1
+        # 0x05, 0x00, 0x00, 0x01, high, low
+        assert body[3] == 0x05  # same param id
+        assert body[4] == 0x00
+        assert body[5] == 0x00
+        assert body[6] == 0x01  # sub-id for underside
+
+    def test_set_control_multiple_params(self) -> None:
+        """Test setControl with multiple param groups."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.steam_set = 3
+        msg.hour_set = 1
+        msg.minute_set = 30
+        msg.fire_power_set = "fire_power_5"
+        body = msg.body
+        assert body[0] == ListTypes.X03
+        assert body[2] == 0x03  # paramSum = 3 (steam + time + fire_power)
+
+    def test_bool_to_byte_true(self) -> None:
+        """Test _bool_to_byte returns true_val for True."""
+        result = MessageSet._bool_to_byte(True, 0x11, 0x01)
+        assert result == 0x11
+
+    def test_bool_to_byte_false(self) -> None:
+        """Test _bool_to_byte returns false_val for False."""
+        result = MessageSet._bool_to_byte(False, 0x11, 0x01)
+        assert result == 0x01
+
+    def test_bool_to_byte_none(self) -> None:
+        """Test _bool_to_byte returns 0xFF for None."""
+        result = MessageSet._bool_to_byte(None, 0x11, 0x01)
+        assert result == 0xFF
+
+    def test_fire_power_value_known(self) -> None:
+        """Test _fire_power_value for known name."""
+        assert MessageSet._fire_power_value("fire_power_5") == 5
+
+    def test_fire_power_value_none(self) -> None:
+        """Test _fire_power_value returns 0xFF for None."""
+        assert MessageSet._fire_power_value(None) == 0xFF
+
+    def test_fire_power_value_unknown(self) -> None:
+        """Test _fire_power_value returns 0xFF for unknown name."""
+        assert MessageSet._fire_power_value("unknown_power") == 0xFF
+
+    def test_work_status_value_known(self) -> None:
+        """Test _work_status_value for known status."""
+        assert MessageSet._work_status_value("standby") == 0x02
+
+    def test_work_status_value_none(self) -> None:
+        """Test _work_status_value returns 0xFF for None."""
+        assert MessageSet._work_status_value(None) == 0xFF
+
+    def test_work_status_value_unknown(self) -> None:
+        """Test _work_status_value returns 0xFF for unknown status."""
+        assert MessageSet._work_status_value("invalid_status") == 0xFF
+
+    def test_routing_priority_work_mode_over_not_work_mode(self) -> None:
+        """Test work_mode takes priority over notWorkMode fields."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.work_mode = "microwave"
+        msg.power = True  # would normally route to notWorkMode
+        body = msg.body
+        assert body[0] == ListTypes.X01  # workModeControl wins
+
+    def test_routing_priority_not_work_mode_over_set_control(self) -> None:
+        """Test notWorkMode takes priority over setControl fields."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.power = True  # notWorkMode field
+        msg.hour_set = 1  # setControl field
+        body = msg.body
+        assert body[0] == ListTypes.X02  # notWorkMode wins
+
+
+class TestMessageBFBody:
+    """Test MessageBFBody parsing."""
+
+    def _make_body(self, length: int = 60) -> bytearray:
+        """Create a minimal body with given length, body_type at index 0."""
+        body = bytearray(length)
+        body[0] = 0x01  # body_type
+        return body
+
+    def test_execute_ok(self) -> None:
+        """Test execute status = ok (default)."""
+        body = self._make_body()
+        msg = MessageBFBody(body=body)
+        assert msg.execute == "ok"
+
+    def test_execute_status_nonsupport(self) -> None:
+        """Test execute status = status_nonsupport."""
+        body = self._make_body()
+        body[1] = 0x01
+        msg = MessageBFBody(body=body)
+        assert msg.execute == "status_nonsupport"
+
+    def test_execute_function_nonsupport(self) -> None:
+        """Test execute status = function_nonsupport."""
+        body = self._make_body()
+        body[1] = 0x02
+        msg = MessageBFBody(body=body)
+        assert msg.execute == "function_nonsupport"
+
+    def test_execute_param_range_error(self) -> None:
+        """Test execute status = param_range_error."""
+        body = self._make_body()
+        body[1] = 0x03
+        msg = MessageBFBody(body=body)
+        assert msg.execute == "param_range_error"
+
+    def test_execute_unknown_value(self) -> None:
+        """Test execute status with unknown value returns 'unknown'."""
+        body = self._make_body()
+        body[1] = 0xFF  # not in known execute status mapping
+        msg = MessageBFBody(body=body)
+        assert msg.execute == "unknown"
+
+    def test_cloudmenuid(self) -> None:
+        """Test cloudmenuid parsing."""
+        body = self._make_body()
+        body[2] = 0x01
+        body[3] = 0x02
+        body[4] = 0x03
+        msg = MessageBFBody(body=body)
+        assert msg.cloudmenuid == 0x010203
+
+    def test_cloudmenuid_zero(self) -> None:
+        """Test cloudmenuid = 0 when all bytes are 0."""
+        body = self._make_body()
+        msg = MessageBFBody(body=body)
+        assert msg.cloudmenuid == 0
+
+    def test_totalstep_and_stepnum(self) -> None:
+        """Test totalstep and stepnum parsing from byte 5."""
+        body = self._make_body()
+        body[5] = 0x32  # totalstep=3, stepnum=2
+        msg = MessageBFBody(body=body)
+        assert msg.totalstep == 3
+        assert msg.stepnum == 2
+
+    def test_totalstep_max_stepnum_zero(self) -> None:
+        """Test totalstep=15 (max) and stepnum=0."""
+        body = self._make_body()
+        body[5] = 0xF0  # totalstep=15, stepnum=0
+        msg = MessageBFBody(body=body)
+        assert msg.totalstep == 15
+        assert msg.stepnum == 0
+
+    def test_probe_and_turntable_flags(self) -> None:
+        """Test probe and turntable flags from byte 6."""
+        body = self._make_body()
+        body[6] = 0x0A  # probe(bit1)=1, turntable(bit3)=1
+        msg = MessageBFBody(body=body)
+        assert msg.probe is True
+        assert msg.turntable is True
+
+    def test_probe_false_turntable_false(self) -> None:
+        """Test probe and turntable both False."""
+        body = self._make_body()
+        body[6] = 0x00
+        msg = MessageBFBody(body=body)
+        assert msg.probe is False
+        assert msg.turntable is False
+
+    def test_work_mode_parsing(self) -> None:
+        """Test work_mode parsing."""
+        body = self._make_body()
+        body[7] = 0x01
+        body[8] = 0x00
+        msg = MessageBFBody(body=body)
+        assert msg.work_mode == "microwave"
+
+    def test_work_mode_parsing_unknown(self) -> None:
+        """Test work_mode parsing with unknown bytes."""
+        body = self._make_body()
+        body[7] = 0xFF
+        body[8] = 0xFF
+        msg = MessageBFBody(body=body)
+        assert msg.work_mode == "unknown"
+
+    def test_time_settings_default(self) -> None:
+        """Test time settings (hour_set/minute_set/second_set) default to 0."""
+        body = self._make_body()
+        body[9] = 0xFF  # hour_set = 0xFF -> treated as 0
+        body[10] = 0xFF
+        body[11] = 0xFF
+        msg = MessageBFBody(body=body)
+        assert msg.hour_set == 0
+        assert msg.minute_set == 0
+        assert msg.second_set == 0
+
+    def test_time_settings_with_values(self) -> None:
+        """Test time settings with actual values."""
+        body = self._make_body()
+        body[9] = 2  # hour_set
+        body[10] = 30  # minute_set
+        body[11] = 15  # second_set
+        msg = MessageBFBody(body=body)
+        assert msg.hour_set == 2
+        assert msg.minute_set == 30
+        assert msg.second_set == 15
+
+    def test_fire_power_known(self) -> None:
+        """Test fire_power parsing with known value."""
+        body = self._make_body()
+        body[12] = 0x05  # fire_power_5
+        msg = MessageBFBody(body=body)
+        assert msg.fire_power == "fire_power_5"
+
+    def test_fire_power_unknown(self) -> None:
+        """Test fire_power parsing with unknown value."""
+        body = self._make_body()
+        body[12] = 0x0B  # invalid fire_power
+        msg = MessageBFBody(body=body)
+        assert msg.fire_power == "unknown"
+
+    def test_fire_power_ff(self) -> None:
+        """Test fire_power with 0xFF (unset)."""
+        body = self._make_body()
+        body[12] = 0xFF
+        msg = MessageBFBody(body=body)
+        assert msg.fire_power == "unknown"
+
+    def test_temperature_above_only(self) -> None:
+        """Test temperature parsing when only temperature_above is nonzero."""
+        body = self._make_body()
+        body[13] = 0x00  # temp_above_high
+        body[14] = 200  # temp_above_low = 200
+        body[15] = 0x00  # temp_underside_high
+        body[16] = 0x00  # temp_underside_low
+        msg = MessageBFBody(body=body)
+        assert msg.temperature_above == 200
+        assert msg.temperature_underside == 0
+        assert msg.temperature == 200  # above != 0 -> use above
+
+    def test_temperature_underside_only(self) -> None:
+        """Test temperature when only temperature_underside is nonzero."""
+        body = self._make_body()
+        body[13] = 0x00
+        body[14] = 0x00  # above = 0
+        body[15] = 0x00
+        body[16] = 180  # underside = 180
+        msg = MessageBFBody(body=body)
+        assert msg.temperature_above == 0
+        assert msg.temperature_underside == 180
+        assert msg.temperature == 180  # above=0 -> use underside
+
+    def test_temperature_both_zero(self) -> None:
+        """Test temperature when both above and underside are 0."""
+        body = self._make_body()
+        msg = MessageBFBody(body=body)
+        assert msg.temperature == 0  # fallback to underside (also 0)
+
+    def test_temperature_16bit(self) -> None:
+        """Test temperature parsing with 16-bit value."""
+        body = self._make_body()
+        body[13] = 0x01  # high byte
+        body[14] = 0x00  # low byte -> 256
+        msg = MessageBFBody(body=body)
+        assert msg.temperature_above == 256
+        assert msg.temperature == 256
+
+    def test_probe_temperature(self) -> None:
+        """Test probe_temperature parsing."""
+        body = self._make_body()
+        body[17] = 0x00  # high
+        body[18] = 80  # low
+        msg = MessageBFBody(body=body)
+        assert msg.probe_temperature == 80
+
+    def test_probe_temperature_zero(self) -> None:
+        """Test probe_temperature = 0."""
+        body = self._make_body()
+        msg = MessageBFBody(body=body)
+        assert msg.probe_temperature == 0
+
+    def test_steam_quantity(self) -> None:
+        """Test steam_quantity parsing."""
+        body = self._make_body()
+        body[19] = 5
+        msg = MessageBFBody(body=body)
+        assert msg.steam_quantity == 5
+
+    def test_steam_quantity_unset(self) -> None:
+        """Test steam_quantity = 0xFF -> None."""
+        body = self._make_body()
+        body[19] = 0xFF
+        msg = MessageBFBody(body=body)
+        assert msg.steam_quantity is None
+
+    def test_weight(self) -> None:
+        """Test weight parsing (value * 10)."""
+        body = self._make_body()
+        body[20] = 50  # weight = 50 * 10 = 500
+        msg = MessageBFBody(body=body)
+        assert msg.weight == 500
+        assert msg.people_number == 50
+
+    def test_weight_unset(self) -> None:
+        """Test weight = 0xFF -> None."""
+        body = self._make_body()
+        body[20] = 0xFF
+        msg = MessageBFBody(body=body)
+        assert msg.weight is None
+        assert msg.people_number is None
+
+    def test_people_number(self) -> None:
+        """Test people_number parsing (same byte as weight)."""
+        body = self._make_body()
+        body[20] = 4  # people_number = 4, weight = 40
+        msg = MessageBFBody(body=body)
+        assert msg.people_number == 4
+        assert msg.weight == 40
+
+    def test_time_remaining(self) -> None:
+        """Test time_remaining computed from work_hour/minute/second."""
+        body = self._make_body()
+        body[22] = 1
+        body[23] = 30
+        body[24] = 0
+        msg = MessageBFBody(body=body)
+        assert msg.time_remaining == 5400  # 1h30m
+
+    def test_time_remaining_zero(self) -> None:
+        """Test time_remaining = 0 when all work time bytes are 0."""
+        body = self._make_body()
+        msg = MessageBFBody(body=body)
+        assert msg.time_remaining == 0
+
+    def test_time_remaining_full_hour(self) -> None:
+        """Test time_remaining with only hours."""
+        body = self._make_body()
+        body[22] = 2  # 2 hours
+        body[23] = 0
+        body[24] = 0
+        msg = MessageBFBody(body=body)
+        assert msg.time_remaining == 7200  # 2h
+
+    def test_current_temperatures_above(self) -> None:
+        """Test current_temperature when cur_temperature_above is nonzero."""
+        body = self._make_body()
+        body[25] = 0x00  # cur_temp_above_high
+        body[26] = 180  # cur_temp_above_low
+        body[27] = 0x00  # cur_temp_underside_high
+        body[28] = 150  # cur_temp_underside_low
+        msg = MessageBFBody(body=body)
+        assert msg.cur_temperature_above == 180
+        assert msg.cur_temperature_underside == 150
+        assert msg.current_temperature == 180  # above nonzero -> use above
+
+    def test_current_temperatures_underside(self) -> None:
+        """Test current_temperature when cur_temperature_above is 0."""
+        body = self._make_body()
+        body[25] = 0x00
+        body[26] = 0x00  # cur_temp_above = 0
+        body[27] = 0x00
+        body[28] = 150  # cur_temp_underside = 150
+        msg = MessageBFBody(body=body)
+        assert msg.current_temperature == 150  # above=0 -> use underside
+
+    def test_cur_probe_temperature(self) -> None:
+        """Test cur_probe_temperature parsing."""
+        body = self._make_body()
+        body[29] = 0x00  # high
+        body[30] = 75  # low
+        msg = MessageBFBody(body=body)
+        assert msg.cur_probe_temperature == 75
+
+    def test_power_inferred_from_status(self) -> None:
+        """Test power is inferred from status: save_power=False, others=True."""
+        body = self._make_body()
+        body[31] = WorkStatus.save_power.value
+        msg = MessageBFBody(body=body)
+        assert msg.power is False
+        assert msg.status == "save_power"
+
+        body[31] = WorkStatus.standby.value
+        msg = MessageBFBody(body=body)
+        assert msg.power is True
+        assert msg.status == "standby"
+
+    def test_status_unknown_value(self) -> None:
+        """Test status parsing with invalid value returns 'unknown'."""
+        body = self._make_body()
+        body[31] = 0x00  # not in WorkStatus enum
+        msg = MessageBFBody(body=body)
+        assert msg.status == "unknown"
+        assert msg.power is False  # unknown status cannot be trusted as on
+
+    def test_status_all_valid_values(self) -> None:
+        """Test all valid WorkStatus values parse correctly."""
+        for name, value in {
+            "save_power": 0x01,
+            "standby": 0x02,
+            "work": 0x03,
+            "work_finish": 0x04,
+            "order": 0x05,
+            "pause": 0x06,
+            "pause_c": 0x07,
+            "self_inspection": 0x0A,
+            "wait_to_start": 0x10,
+        }.items():
+            body = self._make_body()
+            body[31] = value
+            msg = MessageBFBody(body=body)
+            assert msg.status == name
+
+    def test_status_flags_byte32(self) -> None:
+        """Test flags in byte 32 (child_lock, door, tank_ejected, etc)."""
+        body = self._make_body()
+        body[32] = 0x07  # child_lock + door + tank_ejected
+        msg = MessageBFBody(body=body)
+        assert msg.child_lock is True
+        assert msg.door is True
+        assert msg.tank_ejected is True
+        assert msg.water_shortage is False
+        assert msg.water_change_reminder is False
+        assert msg.error is False
+
+    def test_byte32_water_shortage(self) -> None:
+        """Test water_shortage flag in byte 32."""
+        body = self._make_body()
+        body[32] = 0x08  # water_shortage bit
+        msg = MessageBFBody(body=body)
+        assert msg.water_shortage is True
+        assert msg.child_lock is False
+        assert msg.door is False
+
+    def test_byte32_water_change_reminder(self) -> None:
+        """Test water_change_reminder flag in byte 32."""
+        body = self._make_body()
+        body[32] = 0x10  # water_change bit
+        msg = MessageBFBody(body=body)
+        assert msg.water_change_reminder is True
+
+    def test_byte32_error(self) -> None:
+        """Test error flag in byte 32."""
+        body = self._make_body()
+        body[32] = 0x80  # error bit
+        msg = MessageBFBody(body=body)
+        assert msg.error is True
+
+    def test_byte32_pre_heat(self) -> None:
+        """Test pre_heat flag in byte 32."""
+        body = self._make_body()
+        body[32] = 0x20  # pre_heat bit
+        msg = MessageBFBody(body=body)
+        assert msg.pre_heat is True
+
+    def test_byte32_all_flags(self) -> None:
+        """Test all flags in byte 32 set simultaneously."""
+        body = self._make_body()
+        # all bits: child_lock(0x01)+door(0x02)+tank_ejected(0x04)
+        # +water_shortage(0x08)+water_change(0x10)+pre_heat(0x20)+error(0x80)=0xBF
+        body[32] = 0xBF
+        msg = MessageBFBody(body=body)
+        assert msg.child_lock is True
+        assert msg.door is True
+        assert msg.tank_ejected is True
+        assert msg.water_shortage is True
+        assert msg.water_change_reminder is True
+        assert msg.error is True
+        assert msg.pre_heat is True
+
+    def test_status_flags_byte33(self) -> None:
+        """Test flags in byte 33 (flip_side, reaction, furnace_light, etc)."""
+        body = self._make_body()
+        body[33] = 0x07  # flip_side + reaction + furnace_light
+        msg = MessageBFBody(body=body)
+        assert msg.flip_side is True
+        assert msg.reaction is True
+        assert msg.furnace_light is True
+
+    def test_byte33_high_temperature_lock(self) -> None:
+        """Test high_temperature_lock (bit3=0 means lock ON)."""
+        body = self._make_body()
+        body[33] = 0x00  # all bits off -> high_temp_lock bit=0 -> lock is ON
+        msg = MessageBFBody(body=body)
+        assert msg.high_temperature_lock is True  # bit=0 -> True
+
+    def test_byte33_high_temperature_lock_off(self) -> None:
+        """Test high_temperature_lock off (bit3=1 means lock OFF)."""
+        body = self._make_body()
+        body[33] = 0x08  # only high_temp_lock bit set -> lock is OFF
+        msg = MessageBFBody(body=body)
+        assert msg.high_temperature_lock is False  # bit=1 -> False
+
+    def test_byte33_high_temperature_work(self) -> None:
+        """Test high_temperature_work flag."""
+        body = self._make_body()
+        body[33] = 0x10  # high_temperature_work bit
+        msg = MessageBFBody(body=body)
+        assert msg.high_temperature_work is True
+
+    def test_byte33_high_temperature(self) -> None:
+        """Test high_temperature flag."""
+        body = self._make_body()
+        body[33] = 0x20  # high_temperature bit
+        msg = MessageBFBody(body=body)
+        assert msg.high_temperature is True
+
+    def test_byte33_probe_mode(self) -> None:
+        """Test probe_mode flag."""
+        body = self._make_body()
+        body[33] = 0x40  # probe_mode bit
+        msg = MessageBFBody(body=body)
+        assert msg.probe_mode is True
+
+    def test_byte33_all_flags(self) -> None:
+        """Test all flags in byte 33."""
+        body = self._make_body()
+        body[33] = 0x7F  # bits 0-6 set
+        msg = MessageBFBody(body=body)
+        assert msg.flip_side is True
+        assert msg.reaction is True
+        assert msg.furnace_light is True
+        assert msg.high_temperature_lock is False  # bit3=1 -> lock off
+        assert msg.high_temperature_work is True
+        assert msg.high_temperature is True
+        assert msg.probe_mode is True
+
+    def test_byte34_ramadan(self) -> None:
+        """Test ramadan flag from byte 34."""
+        body = self._make_body()
+        body[34] = 0x20  # BIT_RAMADAN
+        msg = MessageBFBody(body=body)
+        assert msg.ramadan is True
+
+    def test_byte34_ramadan_false(self) -> None:
+        """Test ramadan False."""
+        body = self._make_body()
+        body[34] = 0x00
+        msg = MessageBFBody(body=body)
+        assert msg.ramadan is False
+
+    def test_byte35_hot_wind(self) -> None:
+        """Test hot_wind flag from byte 35."""
+        body = self._make_body()
+        body[35] = 0x20  # hot_wind bit
+        msg = MessageBFBody(body=body)
+        assert msg.hot_wind is True
+
+    def test_byte35_hot_wind_false(self) -> None:
+        """Test hot_wind False."""
+        body = self._make_body()
+        body[35] = 0x00
+        msg = MessageBFBody(body=body)
+        assert msg.hot_wind is False
+
+    def test_cbs_version(self) -> None:
+        """Test cbs_version string parsing."""
+        body = self._make_body(length=60)
+        body[47] = 1
+        body[48] = 2
+        body[49] = 3
+        msg = MessageBFBody(body=body)
+        assert msg.cbs_version == "V1.2.3"
+
+    def test_cbs_version_zero(self) -> None:
+        """Test cbs_version with all zeros."""
+        body = self._make_body(length=60)
+        msg = MessageBFBody(body=body)
+        assert msg.cbs_version == "V0.0.0"
+
+    def test_cbs_version_short_body(self) -> None:
+        """Test cbs_version with body too short returns V0.0.0."""
+        body = bytearray(10)  # shorter than OFFSET_CBS_VERSION_PATCH=49
+        body[0] = 0x01
+        msg = MessageBFBody(body=body)
+        assert msg.cbs_version == "V0.0.0"
+
+    def test_clean_scale_and_ota(self) -> None:
+        """Test clean_scale and ota flags from byte 56."""
+        body = self._make_body(length=60)
+        body[56] = 0xC0  # clean_scale(bit6) + ota(bit7)
+        msg = MessageBFBody(body=body)
+        assert msg.clean_scale is True
+        assert msg.ota is True
+
+    def test_clean_scale_only(self) -> None:
+        """Test clean_scale only."""
+        body = self._make_body(length=60)
+        body[56] = 0x40  # clean_scale bit only
+        msg = MessageBFBody(body=body)
+        assert msg.clean_scale is True
+        assert msg.ota is False
+
+    def test_ota_only(self) -> None:
+        """Test ota only."""
+        body = self._make_body(length=60)
+        body[56] = 0x80  # ota bit only
+        msg = MessageBFBody(body=body)
+        assert msg.clean_scale is False
+        assert msg.ota is True
+
+    def test_byte58_clean_sink_ponding(self) -> None:
+        """Test clean_sink_ponding flag from byte 58."""
+        body = self._make_body(length=60)
+        body[58] = 0x01  # clean_sink_ponding bit
+        msg = MessageBFBody(body=body)
+        assert msg.clean_sink_ponding is True
+        assert msg.dissipate_heat is False
+
+    def test_byte58_dissipate_heat(self) -> None:
+        """Test dissipate_heat flag from byte 58."""
+        body = self._make_body(length=60)
+        body[58] = 0x02  # dissipate_heat bit
+        msg = MessageBFBody(body=body)
+        assert msg.clean_sink_ponding is False
+        assert msg.dissipate_heat is True
+
+    def test_byte58_both_flags(self) -> None:
+        """Test both flags in byte 58."""
+        body = self._make_body(length=60)
+        body[58] = 0x03  # both bits
+        msg = MessageBFBody(body=body)
+        assert msg.clean_sink_ponding is True
+        assert msg.dissipate_heat is True
+
+
+def _build_message(message_type: MessageType, body: bytearray) -> bytes:
+    """Build a full BF response message."""
+    header = bytearray(
+        [0xAA] + ([0x0] * 7) + [ProtocolVersion.V1] + [message_type],
+    )
+    return bytes(header + body + bytearray([0x00]))
+
+
+class TestMessageBFResponse:
+    """Test MessageBFResponse."""
+
+    def test_total_state_response(self) -> None:
+        """Test parsing of a totalState (body_type 0x01) response."""
+        body = bytearray(60)
+        body[0] = 0x01  # body_type
+        body[31] = WorkStatus.standby.value  # status=standby, power=True
+        message = MessageBFResponse(_build_message(MessageType.query, body))
+        assert hasattr(message, "body_type")
+        assert message.body_type == 0x01
+        assert hasattr(message, "status")
+        assert message.status == "standby"
+        assert hasattr(message, "power")
+        assert message.power is True
+
+    def test_response_with_all_attributes(self) -> None:
+        """Test response parsing populates all expected attributes."""
+        body = bytearray(60)
+        body[0] = 0x01  # body_type totalState
+        body[31] = WorkStatus.work.value  # status=work
+        body[32] = 0xBF  # all byte32 flags
+        body[33] = 0x7F  # all byte33 flags
+        body[34] = 0x20  # ramadan
+        body[35] = 0x20  # hot_wind
+        body[56] = 0xC0  # clean_scale + ota
+        body[58] = 0x03  # clean_sink_ponding + dissipate_heat
+        message = MessageBFResponse(
+            _build_message(MessageType.query, body),
+        )
+        assert message.status == "work"  # type: ignore[attr-defined]
+        assert message.power is True  # type: ignore[attr-defined]
+        assert message.child_lock is True  # type: ignore[attr-defined]
+        assert message.door is True  # type: ignore[attr-defined]
+        assert message.tank_ejected is True  # type: ignore[attr-defined]
+        assert message.ramadan is True  # type: ignore[attr-defined]
+        assert message.hot_wind is True  # type: ignore[attr-defined]
+        assert message.clean_scale is True  # type: ignore[attr-defined]
+        assert message.ota is True  # type: ignore[attr-defined]
+        assert message.clean_sink_ponding is True  # type: ignore[attr-defined]
+        assert message.dissipate_heat is True  # type: ignore[attr-defined]
+
+    def test_response_save_power(self) -> None:
+        """Test response with save_power status -> power=False."""
+        body = bytearray(60)
+        body[0] = 0x01
+        body[31] = WorkStatus.save_power.value
+        message = MessageBFResponse(
+            _build_message(MessageType.set, body),
+        )
+        assert message.power is False  # type: ignore[attr-defined]
+
+    def test_response_notify_type(self) -> None:
+        """Test response with notify1 message type."""
+        body = bytearray(60)
+        body[0] = 0x01
+        body[31] = WorkStatus.standby.value
+        message = MessageBFResponse(
+            _build_message(MessageType.notify1, body),
+        )
+        assert message.status == "standby"  # type: ignore[attr-defined]
+
+    def test_response_non_total_state_body_type(self) -> None:
+        """Test response with non-0x01 body_type does not parse BF attributes."""
+        body = bytearray(10)
+        body[0] = 0x02  # not totalState
+        message = MessageBFResponse(
+            _build_message(MessageType.query, body),
+        )
+        # Should not have BF-specific attributes
+        assert not hasattr(message, "status")


### PR DESCRIPTION
## Overview / 概述

feat(bf): add BF device message / 新增 BF 设备消息

## Background / 背景

The BF device type (microwave-steamed-roasted integrated cooker) had limited protocol support.
This PR enhances the BF message parser with comprehensive attribute parsing and control commands,
covering status flags, temperatures, work modes, fire power, steam quantity, and various control features.
/ BF 设备类型（微蒸烤一体机）此前协议支持有限。
本 PR 增强了 BF 消息解析器，支持全面的属性解析和控制命令，
包括状态标志位、温度、工作模式、火力、蒸汽量以及各种控制功能。

## Changes / 变更内容

- **BF message.py**: Major expansion with 40+ named constants (byte offsets, bit masks, special values),
  comprehensive `MessageBFBody` parsing for execute status, cloud menu ID, work steps,
  work mode, time settings, fire power, temperatures (above/underside/probe), steam quantity,
  weight/people count, current temperatures, work status, and multiple flag bytes (B32, B33, B56, B58);
  added `MessageQuery`, `MessageSet`, and `MessageBFResponse` classes
  / **BF message.py**：大幅扩展，新增 40+ 命名常量（字节偏移量、位掩码、特殊值），
  `MessageBFBody` 全面解析执行状态、云端菜单 ID、工作步骤、工作模式、时间设置、火力、
  温度（上/下/探针）、蒸汽量、重量/人数、当前温度、工作状态以及多个标志位字节（B32、B33、B56、B58）；
  新增 `MessageQuery`、`MessageSet`、`MessageBFResponse` 类
- **BF __init__.py**: Expanded `DeviceAttributes` enum to 50+ attributes including door, status,
  work_mode, fire_power, pre_heat, turntable, hot_wind, various temperatures, steam_quantity,
  weight, people_number, child_lock, furnace_light, flip_side, reaction, error_code, etc.;
  updated `set_attribute()` to handle status mapping and direct attribute setting on MessageSet
  / **BF __init__.py**：扩展 `DeviceAttributes` 枚举至 50+ 属性，包括门状态、工作状态、工作模式、
  火力、预热、转盘、热风、各种温度、蒸汽量、重量、人数、童锁、炉灯、翻面、反应、错误码等；
  更新 `set_attribute()` 处理状态映射和直接在 MessageSet 上设置属性

## Files Changed / 涉及文件

| File / 文件 | Change Type / 变更类型 |
|---|---|
| `midealocal/devices/bf/__init__.py` | Major expansion — 50+ attributes, updated set_attribute / 大幅扩展 — 50+ 属性，更新 set_attribute |
| `midealocal/devices/bf/message.py` | Major expansion — new constants, MessageBFBody parsing, control classes / 大幅扩展 — 新常量、MessageBFBody 解析、控制类 |

## Breaking Changes / 破坏性变更

No breaking changes. / 无破坏性变更。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for expanded BF device settings, including work modes, cooking parameters, temperatures, timers, power, and maintenance controls.
  * Added richer status reporting for execution state, menu details, sensor values, and operating information.
* **Bug Fixes**
  * Improved validation and handling of unsupported or incomplete device responses.
  * Preserved configured cooking times and zero-valued settings when sending updates.
  * Corrected work-mode command routing and shared weight/people value handling.
  * Renamed the public error status field to `error`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->