### PR TITLE
feat(a1): allow customize to override the prompt_tone default

### DIFF
--- a/midealan/devices/a1/__init__.py
+++ b/midealan/devices/a1/__init__.py
@@ -230,6 +230,10 @@ class MideaA1Device(MideaDevice):
                         for k in keys:
                             self._modes[k] = modes[k]
                         to_update["modes"] = self._modes
+                    if "prompt_tone" in params:
+                        prompt_tone = bool(params.get("prompt_tone"))
+                        self._attributes[DeviceAttributes.prompt_tone] = prompt_tone
+                        to_update[DeviceAttributes.prompt_tone.value] = prompt_tone
                     if to_update:
                         self.update_all(to_update)
             except Exception:

--- a/midealan/devices/a1/__init__.py
+++ b/midealan/devices/a1/__init__.py
@@ -230,8 +230,8 @@ class MideaA1Device(MideaDevice):
                         for k in keys:
                             self._modes[k] = modes[k]
                         to_update["modes"] = self._modes
-                    if "prompt_tone" in params:
-                        prompt_tone = bool(params.get("prompt_tone"))
+                    if isinstance(params.get("prompt_tone"), bool):
+                        prompt_tone = params["prompt_tone"]
                         self._attributes[DeviceAttributes.prompt_tone] = prompt_tone
                         to_update[DeviceAttributes.prompt_tone.value] = prompt_tone
                     if to_update:

--- a/tests/devices/a1/device_a1_test.py
+++ b/tests/devices/a1/device_a1_test.py
@@ -178,9 +178,24 @@ class TestMideaA1Device:
         with patch.object(self.device, "update_all") as mock_update_all:
             self.device.set_customize('{"prompt_tone": false}')
             assert self.device.attributes[DeviceAttributes.prompt_tone] is False
+            assert self.device.make_message_set().prompt_tone is False
             mock_update_all.assert_called_once_with({"prompt_tone": False})
 
         with patch.object(self.device, "update_all") as mock_update_all:
             self.device.set_customize('{"prompt_tone": true}')
             assert self.device.attributes[DeviceAttributes.prompt_tone] is True
+            assert self.device.make_message_set().prompt_tone is True
             mock_update_all.assert_called_once_with({"prompt_tone": True})
+
+    def test_set_customize_prompt_tone_ignores_non_boolean(self) -> None:
+        """Test set customize ignores a non-boolean prompt_tone instead of coercing it.
+
+        JSON has no ambiguity about what a boolean is, so a malformed value (a
+        string, a number, null) should be rejected rather than passed through
+        Python's truthiness - bool("false") is True, which would silently invert
+        a user's intent.
+        """
+        with patch.object(self.device, "update_all") as mock_update_all:
+            self.device.set_customize('{"prompt_tone": "false"}')
+            assert self.device.attributes[DeviceAttributes.prompt_tone] is True
+            mock_update_all.assert_not_called()

--- a/tests/devices/a1/device_a1_test.py
+++ b/tests/devices/a1/device_a1_test.py
@@ -165,3 +165,22 @@ class TestMideaA1Device:
                     "modes": {1: "New Manual", 2: "New Mode"},
                 },
             )
+
+    def test_set_customize_prompt_tone(self) -> None:
+        """Test set customize can override the prompt_tone default.
+
+        prompt_tone is a write-only flag attached to every outgoing set command and
+        is never reported back by the device, so the integration has no way to learn
+        the real hardware state - it only holds this default in memory. Some users
+        want the confirmation beep off by default instead of on, so it must be
+        overridable per-device rather than changing the shared default for everyone.
+        """
+        with patch.object(self.device, "update_all") as mock_update_all:
+            self.device.set_customize('{"prompt_tone": false}')
+            assert self.device.attributes[DeviceAttributes.prompt_tone] is False
+            mock_update_all.assert_called_once_with({"prompt_tone": False})
+
+        with patch.object(self.device, "update_all") as mock_update_all:
+            self.device.set_customize('{"prompt_tone": true}')
+            assert self.device.attributes[DeviceAttributes.prompt_tone] is True
+            mock_update_all.assert_called_once_with({"prompt_tone": True})


### PR DESCRIPTION
## Summary

`prompt_tone` defaults to `True` and is never persisted — it's a write-only
flag attached to every outgoing `set` command (`midealan/devices/a1/__init__.py`
`make_message_set`) and is never parsed back from the device's status
response. That means the integration only ever holds this default in
memory, and every reconnect (HA restart, config-entry reload) resets the
confirmation beep back on, regardless of what a user last set it to.

This exposes `prompt_tone` through the existing per-device `customize`
JSON already used for `speeds`/`modes`. It's opt-in: nothing changes for
anyone who doesn't set it.

Related to wuwentao/midea_ac_lan#383 (same underlying limitation reported
for AC devices — the local protocol doesn't echo `prompt_tone` back on
query, so a real fix needs cross-restart persistence on the HA side, which
is a bigger change; this PR is the practical per-device workaround in the
meantime).

## Usage

In the device's Options flow customize field:

```json
{"prompt_tone": false}
```

## Test plan

- [x] Added `test_set_customize_prompt_tone`, covering both `true` and
      `false`, mirroring the existing `test_set_customize` style
- [x] Ran patch on local home assistant and verified toggle works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-device customization for prompt tone.
  * Boolean prompt tone settings now apply to generated messages and are synchronized across the device.

* **Bug Fixes**
  * Invalid non-boolean prompt tone values are ignored without changing device settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->