### PR TITLE
fix: close socket catch error

### DIFF
--- a/midealan/device.py
+++ b/midealan/device.py
@@ -8,6 +8,8 @@ from collections.abc import Callable
 from enum import IntEnum, StrEnum
 from typing import Any, ClassVar, NotRequired, TypedDict, Unpack
 
+from typing_extensions import deprecated
+
 from .const import DeviceType, ProtocolVersion
 from .exceptions import SocketException
 from .message import (
@@ -105,6 +107,7 @@ class MideaDevice(threading.Thread):
         self._ip_address = kwargs["ip_address"]
         self._port = kwargs["port"]
         self._security = LocalSecurity()
+        self._socket_lock = threading.Lock()
         self._token = bytes.fromhex(kwargs["token"])
         self._key = bytes.fromhex(kwargs["key"])
         self._buffer = b""
@@ -235,16 +238,19 @@ class MideaDevice(threading.Thread):
     def connect(self, check_protocol: bool = False) -> bool:
         """Connect to device."""
         connected = False
+        sock: socket.socket | None = None
         try:
-            self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self._socket.settimeout(SOCKET_TIMEOUT)
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            with self._socket_lock:
+                self._socket = sock
+            sock.settimeout(SOCKET_TIMEOUT)
             _LOGGER.debug(
                 "[%s] Connecting to %s:%s",
                 self._device_id,
                 self._ip_address,
                 self._port,
             )
-            self._socket.connect((self._ip_address, self._port))
+            sock.connect((self._ip_address, self._port))
             _LOGGER.debug("[%s] Connected", self._device_id)
             if self._device_protocol_version == ProtocolVersion.V3:
                 self.authenticate()
@@ -272,8 +278,8 @@ class MideaDevice(threading.Thread):
         finally:
             # Any failure path leaves connected False; release the socket once
             # here instead of repeating close_socket() in every handler.
-            if not connected:
-                self.close_socket()
+            if not connected and sock is not None:
+                self.close_socket(sock)
         # enable/disable device in init connection
         if check_protocol:
             self.set_available(connected)
@@ -640,6 +646,11 @@ class MideaDevice(threading.Thread):
         status = {"available": available}
         self.update_all(status)
 
+    @deprecated("enable_device is replaced by set_available")
+    def enable_device(self, available: bool = True) -> None:
+        """Enable device."""
+        self.set_available(available)
+
     def open(self) -> None:
         """Open thread."""
         if not self._is_run:
@@ -662,12 +673,14 @@ class MideaDevice(threading.Thread):
         """
         return self._is_run
 
-    def close_socket(self) -> None:
+    def close_socket(self, sock: socket.socket | None = None) -> None:
         """Close socket."""
-        self._unsupported_protocol = []
-        self._buffer = b""
-        sock = self._socket
-        # use local variable to avoid race condition with self
+        with self._socket_lock:
+            if sock is None:
+                sock = self._socket
+            if sock is None or self._socket is sock:
+                self._unsupported_protocol = []
+                self._buffer = b""
         if sock is not None:
             try:
                 sock.shutdown(socket.SHUT_RDWR)
@@ -686,9 +699,10 @@ class MideaDevice(threading.Thread):
             except (OSError, AttributeError, ValueError) as e:
                 _LOGGER.debug("[%s] Error while closing socket: %s", self._device_id, e)
             finally:
-                # Avoid race condition: only clear self._socket.
-                if self._socket == sock:
-                    self._socket = None
+                with self._socket_lock:
+                    # Avoid clearing a socket installed by a concurrent reconnect.
+                    if self._socket is sock:
+                        self._socket = None
 
     def set_ip_address(self, ip_address: str) -> None:
         """Set IP address."""
@@ -725,7 +739,6 @@ class MideaDevice(threading.Thread):
             # the while guard was evaluated, so skip opening a socket / network
             # I/O once teardown is in progress.
             if self._should_run() and self.connect(check_protocol=True) is False:
-                self.close_socket()
                 connection_retries += 1
                 # Sleep time with exponential backoff, maximum 600 seconds
                 sleep_time = min(5 * (2 ** (connection_retries - 1)), 600)

--- a/midealan/device.py
+++ b/midealan/device.py
@@ -107,7 +107,7 @@ class MideaDevice(threading.Thread):
         self._ip_address = kwargs["ip_address"]
         self._port = kwargs["port"]
         self._security = LocalSecurity()
-        self._socket_lock = threading.Lock()
+        self._socket_lock = threading.RLock()
         self._token = bytes.fromhex(kwargs["token"])
         self._key = bytes.fromhex(kwargs["key"])
         self._buffer = b""
@@ -239,47 +239,54 @@ class MideaDevice(threading.Thread):
         """Connect to device."""
         connected = False
         sock: socket.socket | None = None
-        try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            with self._socket_lock:
+        with self._socket_lock:
+            was_running = self._is_run
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 self._socket = sock
-            sock.settimeout(SOCKET_TIMEOUT)
-            _LOGGER.debug(
-                "[%s] Connecting to %s:%s",
-                self._device_id,
-                self._ip_address,
-                self._port,
-            )
-            sock.connect((self._ip_address, self._port))
-            _LOGGER.debug("[%s] Connected", self._device_id)
-            if self._device_protocol_version == ProtocolVersion.V3:
-                self.authenticate()
-            # 1. midea_ac_lan add device verify token with connect and auth
-            # 2. init connection, check_protocol
-            if check_protocol:
-                self.refresh_status(check_protocol=check_protocol)
-            connected = True
-        except TimeoutError:
-            _LOGGER.debug("[%s] Connection timed out", self._device_id)
-        except OSError:  # refresh_status exception
-            _LOGGER.debug("[%s] Connection error", self._device_id)
-        except AuthException:  # authenticate exception
-            _LOGGER.warning("[%s] Authentication failed", self._device_id)
-        except SocketException:  # refresh_status exception
-            _LOGGER.debug("[%s] Connect socket exception", self._device_id)
-        except NoSupportedProtocol:  # refresh_status exception
-            _LOGGER.warning("[%s] No supported query protocol", self._device_id)
-        except Exception as e:
-            _LOGGER.exception(
-                "[%s] Unknown error during connect device",
-                self._device_id,
-                exc_info=e,
-            )
-        finally:
-            # Any failure path leaves connected False; release the socket once
-            # here instead of repeating close_socket() in every handler.
-            if not connected and sock is not None:
-                self.close_socket(sock)
+                sock.settimeout(SOCKET_TIMEOUT)
+                _LOGGER.debug(
+                    "[%s] Connecting to %s:%s",
+                    self._device_id,
+                    self._ip_address,
+                    self._port,
+                )
+                sock.connect((self._ip_address, self._port))
+                _LOGGER.debug("[%s] Connected", self._device_id)
+                if self._device_protocol_version == ProtocolVersion.V3:
+                    self.authenticate()
+                # 1. midea_ac_lan add device verify token with connect and auth
+                # 2. init connection, check_protocol
+                if check_protocol:
+                    self.refresh_status(check_protocol=check_protocol)
+                if was_running and not self._is_run:
+                    _LOGGER.debug(
+                        "[%s] Connection closed before lifecycle completed",
+                        self._device_id,
+                    )
+                else:
+                    connected = True
+            except TimeoutError:
+                _LOGGER.debug("[%s] Connection timed out", self._device_id)
+            except OSError:  # refresh_status exception
+                _LOGGER.debug("[%s] Connection error", self._device_id)
+            except AuthException:  # authenticate exception
+                _LOGGER.warning("[%s] Authentication failed", self._device_id)
+            except SocketException:  # refresh_status exception
+                _LOGGER.debug("[%s] Connect socket exception", self._device_id)
+            except NoSupportedProtocol:  # refresh_status exception
+                _LOGGER.warning("[%s] No supported query protocol", self._device_id)
+            except Exception as e:
+                _LOGGER.exception(
+                    "[%s] Unknown error during connect device",
+                    self._device_id,
+                    exc_info=e,
+                )
+            finally:
+                # Any failure path leaves connected False; release the socket once
+                # here instead of repeating close_socket() in every handler.
+                if not connected and sock is not None:
+                    self.close_socket(sock)
         # enable/disable device in init connection
         if check_protocol:
             self.set_available(connected)

--- a/midealan/device.py
+++ b/midealan/device.py
@@ -8,8 +8,6 @@ from collections.abc import Callable
 from enum import IntEnum, StrEnum
 from typing import Any, ClassVar, NotRequired, TypedDict, Unpack
 
-from typing_extensions import deprecated
-
 from .const import DeviceType, ProtocolVersion
 from .exceptions import SocketException
 from .message import (
@@ -260,11 +258,11 @@ class MideaDevice(threading.Thread):
         except OSError:  # refresh_status exception
             _LOGGER.debug("[%s] Connection error", self._device_id)
         except AuthException:  # authenticate exception
-            _LOGGER.debug("[%s] Authentication failed", self._device_id)
+            _LOGGER.warning("[%s] Authentication failed", self._device_id)
         except SocketException:  # refresh_status exception
             _LOGGER.debug("[%s] Connect socket exception", self._device_id)
         except NoSupportedProtocol:  # refresh_status exception
-            _LOGGER.debug("[%s] No supported query protocol", self._device_id)
+            _LOGGER.warning("[%s] No supported query protocol", self._device_id)
         except Exception as e:
             _LOGGER.exception(
                 "[%s] Unknown error during connect device",
@@ -301,7 +299,7 @@ class MideaDevice(threading.Thread):
             response.hex(),
         )
         if len(response) < MIN_AUTH_RESPONSE:
-            _LOGGER.debug(
+            _LOGGER.warning(
                 "[%s] Received auth response len %d error, bytes: %s",
                 self._device_id,
                 len(response),
@@ -390,9 +388,9 @@ class MideaDevice(threading.Thread):
             cmds = [MessageQueryAppliance(self.device_type), *cmds]
         error_count = 0
         _LOGGER.debug(
-            "[%s] refresh_status with cmds: %s, check_protocol %s, \
-            device %s, type %s, model %s, subtype %s, device_protocol: %s, \
-            message_protocol %s, unsupported_protocol: %s",
+            "[%s] refresh_status with cmds: %s, check_protocol %s, "
+            "device %s, type %s, model %s, subtype %s, device_protocol: %s, "
+            "message_protocol %s, unsupported_protocol: %s",
             self._device_id,
             cmds,
             check_protocol,
@@ -462,7 +460,7 @@ class MideaDevice(threading.Thread):
                 error_count += 1
             # all the query failed
             if error_count == len(cmds):
-                _LOGGER.debug(
+                _LOGGER.warning(
                     "[%s] all the query cmds failed %s, please report bug",
                     self._device_id,
                     cmds,
@@ -604,7 +602,7 @@ class MideaDevice(threading.Thread):
             self.build_send(cmd)
         except OSError as e:
             _LOGGER.debug(
-                "[{%s] Interface send_command failure, %s, cmd_type: %s, cmd_body: %s",
+                "[%s] send_command failure, %s, cmd_type: %s, cmd_body: %s",
                 self._device_id,
                 repr(e),
                 cmd_type,
@@ -642,11 +640,6 @@ class MideaDevice(threading.Thread):
         status = {"available": available}
         self.update_all(status)
 
-    @deprecated("enable_device is replaced by set_available")
-    def enable_device(self, available: bool = True) -> None:
-        """Enable device."""
-        self.set_available(available)
-
     def open(self) -> None:
         """Open thread."""
         if not self._is_run:
@@ -673,9 +666,11 @@ class MideaDevice(threading.Thread):
         """Close socket."""
         self._unsupported_protocol = []
         self._buffer = b""
-        if self._socket:
+        sock = self._socket
+        # use local variable to avoid race condition with self
+        if sock is not None:
             try:
-                self._socket.shutdown(socket.SHUT_RDWR)
+                sock.shutdown(socket.SHUT_RDWR)
             except OSError as e:
                 # shutdown() raises ENOTCONN if the peer already went away;
                 # that's fine, we still close() below.
@@ -685,12 +680,15 @@ class MideaDevice(threading.Thread):
                     e,
                 )
             try:
-                self._socket.close()
+                sock.close()
                 _LOGGER.debug("[%s] Socket closed", self._device_id)
-            except OSError as e:
+            # catch OSError, AttributeError, ValueError to avoid race condition
+            except (OSError, AttributeError, ValueError) as e:
                 _LOGGER.debug("[%s] Error while closing socket: %s", self._device_id, e)
             finally:
-                self._socket = None
+                # Avoid race condition: only clear self._socket.
+                if self._socket == sock:
+                    self._socket = None
 
     def set_ip_address(self, ip_address: str) -> None:
         """Set IP address."""

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -1,6 +1,6 @@
 """Midea Lan device test."""
 
-from typing import ClassVar
+from typing import Any, ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -210,6 +210,46 @@ class TestMideaDevice:
             assert self.device._socket is None
             assert self.device._buffer == b""
 
+    def test_connect_failure_only_closes_its_own_socket(self) -> None:
+        """Test failed connect cleanup does not close a replaced socket."""
+        old_socket = MagicMock()
+        new_socket: Any = MagicMock()
+
+        def fail_after_socket_replaced(*_args: object) -> None:
+            self.device._socket = new_socket
+            raise OSError("connect failed")
+
+        old_socket.connect.side_effect = fail_after_socket_replaced
+        self.device._buffer = b"active"
+        self.device._unsupported_protocol = ["new"]
+        with (
+            patch("socket.socket", return_value=old_socket),
+            patch.object(self.device, "authenticate"),
+            patch.object(self.device, "refresh_status"),
+        ):
+            assert self.device.connect(check_protocol=True) is False
+
+        old_socket.close.assert_called_once()
+        new_socket.close.assert_not_called()
+        assert self.device._socket is new_socket
+        assert self.device._buffer == b"active"
+        assert self.device._unsupported_protocol == ["new"]
+
+    def test_connect_v2_without_protocol_check(self) -> None:
+        """Test successful V2 connect skips auth and protocol checks."""
+        socket_mock = MagicMock()
+        self.device._device_protocol_version = ProtocolVersion.V2
+        with (
+            patch("socket.socket", return_value=socket_mock),
+            patch.object(self.device, "authenticate") as authenticate_mock,
+            patch.object(self.device, "refresh_status") as refresh_mock,
+        ):
+            assert self.device.connect() is True
+
+        authenticate_mock.assert_not_called()
+        refresh_mock.assert_not_called()
+        assert self.device.available is False
+
     def test_authenticate(self) -> None:
         """Test authenticate."""
         socket_mock = MagicMock()
@@ -405,6 +445,18 @@ class TestMideaDevice:
             with pytest.raises(NoSupportedProtocol):
                 self.device.refresh_status(True)  # Unsupported protocol
 
+    def test_refresh_status_without_appliance_or_protocol_check(self) -> None:
+        """Test refresh_status can send queries without response validation."""
+        cmd = MagicMock()
+        self.device._appliance_query = False
+        with (
+            patch.object(self.device, "build_query", return_value=[cmd]),
+            patch.object(self.device, "build_send") as build_send_mock,
+        ):
+            self.device.refresh_status()
+
+        build_send_mock.assert_called_once_with(cmd, query=True)
+
     def test_parse_message(self) -> None:
         """Test parse message."""
         with (
@@ -442,6 +494,33 @@ class TestMideaDevice:
                 side_effect=[{"power": True}, {}, NotImplementedError()],
             ):
                 assert self.device.parse_message(bytes([])) == MessageResult.SUCCESS
+
+    def test_parse_message_without_appliance_preprocess(self) -> None:
+        """Test parse_message processes payload when appliance query is disabled."""
+        message = bytearray([0x0] * 72)
+        message[4] = 72
+        self.device._appliance_query = False
+        with (
+            patch.object(
+                self.device,
+                "fetch_v2_message",
+                return_value=([message], b""),
+            ),
+            patch.object(
+                self.device._security,
+                "aes_decrypt",
+                return_value=bytearray([0x1] * 16),
+            ),
+            patch.object(
+                self.device,
+                "process_message",
+                return_value={"power": True},
+            ) as process_message_mock,
+        ):
+            self.device._device_protocol_version = ProtocolVersion.V2
+            assert self.device.parse_message(bytes([])) == MessageResult.SUCCESS
+
+        process_message_mock.assert_called_once()
 
     def test_pre_process_message(self) -> None:
         """Test pre process message."""
@@ -516,6 +595,13 @@ class TestMideaDevice:
             self.device.open()
             assert self.device._is_run is True
 
+    def test_open_noop_when_already_running(self) -> None:
+        """Test open does nothing when the thread is already marked running."""
+        self.device._is_run = True
+        with patch("threading.Thread.start") as start_mock:
+            self.device.open()
+        start_mock.assert_not_called()
+
     def test_close(self) -> None:
         """Test close."""
         with patch.object(self.device, "_socket") as socket_mock:
@@ -523,6 +609,13 @@ class TestMideaDevice:
             self.device.close()
             assert self.device._is_run is False
             socket_mock.close.assert_called()
+
+    def test_close_noop_when_not_running(self) -> None:
+        """Test close does nothing when the thread is already stopped."""
+        self.device._is_run = False
+        with patch.object(self.device, "close_socket") as close_socket_mock:
+            self.device.close()
+        close_socket_mock.assert_not_called()
 
     def test_close_socket_close_oserror(self) -> None:
         """Test close_socket swallows OSError raised by socket.close()."""
@@ -533,6 +626,39 @@ class TestMideaDevice:
         socket_mock.close.assert_called_once()
         assert self.device._socket is None
 
+    def test_close_socket_without_socket_clears_connection_state(self) -> None:
+        """Test close_socket clears connection state when no socket exists."""
+        self.device._socket = None
+        self.device._buffer = b"stale"
+        self.device._unsupported_protocol = ["old"]
+        self.device.close_socket()
+        assert self.device._buffer == b""
+        assert self.device._unsupported_protocol == []
+
+    def test_close_socket_close_value_error(self) -> None:
+        """Test close_socket swallows ValueError raised by socket.close()."""
+        socket_mock = MagicMock()
+        socket_mock.close.side_effect = ValueError("invalid file descriptor")
+        self.device._socket = socket_mock
+        self.device.close_socket()
+        socket_mock.close.assert_called_once()
+        assert self.device._socket is None
+
+    def test_close_socket_does_not_clear_replaced_socket(self) -> None:
+        """Test close_socket only clears the same socket it captured."""
+        old_socket = MagicMock()
+        new_socket: Any = MagicMock()
+
+        def replace_socket() -> None:
+            self.device._socket = new_socket
+
+        old_socket.close.side_effect = replace_socket
+        self.device._socket = old_socket
+        self.device.close_socket()
+
+        old_socket.close.assert_called_once()
+        assert self.device._socket is new_socket
+
     def test_set_ip(self) -> None:
         """Test set ip."""
         with patch.object(self.device, "_socket") as socket_mock:
@@ -541,11 +667,26 @@ class TestMideaDevice:
             socket_mock.close.assert_called()
             assert self.device._ip_address == "10.0.0.1"
 
+    def test_set_ip_noop_when_unchanged(self) -> None:
+        """Test set_ip_address does not close the socket when IP is unchanged."""
+        with patch.object(self.device, "close_socket") as close_socket_mock:
+            self.device.set_ip_address("192.168.1.100")
+        close_socket_mock.assert_not_called()
+
     def test_set_mac(self) -> None:
         """Test set mac."""
         assert self.device.mac == "1234567890ab"
         self.device.set_mac("9234567890ab")
         assert self.device.mac == "9234567890ab"
+
+    def test_enable_device(self) -> None:
+        """Test deprecated enable_device delegates to set_available."""
+        with pytest.warns(DeprecationWarning, match="enable_device"):
+            self.device.enable_device(True)
+        assert self.device.available is True
+        with pytest.warns(DeprecationWarning, match="enable_device"):
+            self.device.enable_device(False)
+        assert self.device.available is False
 
     def test_should_run(self) -> None:
         """Test _should_run reflects _is_run."""
@@ -606,6 +747,67 @@ class TestMideaDevice:
 
         assert sleep_calls == [1]
         assert self.device._socket is None
+
+    def test_connect_loop_does_not_close_socket_replaced_during_failed_connect(
+        self,
+    ) -> None:
+        """Test _connect_loop failure handling keeps a concurrently replaced socket."""
+        new_socket: Any = MagicMock()
+        self.device._is_run = True
+        self.device._socket = None
+        self.device._buffer = b"active"
+        self.device._unsupported_protocol = ["new"]
+
+        def failed_connect(**_kwargs: object) -> bool:
+            self.device._socket = new_socket
+            return False
+
+        with (
+            patch.object(self.device, "connect", side_effect=failed_connect),
+            patch("time.sleep"),
+        ):
+            self.device._connect_loop()
+
+        new_socket.close.assert_not_called()
+        assert self.device._socket is new_socket
+        assert self.device._buffer == b"active"
+        assert self.device._unsupported_protocol == ["new"]
+
+    def test_connect_loop_skips_connect_after_stop_request(self) -> None:
+        """Test _connect_loop skips connect if _should_run turns false."""
+        self.device._is_run = True
+        self.device._socket = None
+
+        def stop_before_connect() -> bool:
+            self.device._is_run = False
+            return False
+
+        with (
+            patch.object(self.device, "_should_run", side_effect=stop_before_connect),
+            patch.object(self.device, "connect") as connect_mock,
+        ):
+            self.device._connect_loop()
+
+        connect_mock.assert_not_called()
+
+    def test_connect_loop_sleep_backoff_can_finish_without_stop(self) -> None:
+        """Test _connect_loop can finish the retry sleep without early stop."""
+        self.device._is_run = True
+        self.device._socket = None
+        sleep_calls: list[float] = []
+
+        def finish_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+            if len(sleep_calls) == 5:
+                self.device._socket = MagicMock()
+
+        with (
+            patch.object(self.device, "connect", return_value=False),
+            patch("time.sleep", side_effect=finish_sleep),
+        ):
+            self.device._connect_loop()
+
+        assert sleep_calls == [1, 1, 1, 1, 1]
 
     def test_run_breaks_when_stopped_during_connect_loop(self) -> None:
         """Test run exits immediately if closed while _connect_loop runs."""

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -547,15 +547,6 @@ class TestMideaDevice:
         self.device.set_mac("9234567890ab")
         assert self.device.mac == "9234567890ab"
 
-    def test_enable_device(self) -> None:
-        """Test deprecated enable_device delegates to set_available."""
-        with pytest.warns(DeprecationWarning, match="enable_device"):
-            self.device.enable_device(True)
-        assert self.device.available is True
-        with pytest.warns(DeprecationWarning, match="enable_device"):
-            self.device.enable_device(False)
-        assert self.device.available is False
-
     def test_should_run(self) -> None:
         """Test _should_run reflects _is_run."""
         self.device._is_run = True

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -1,5 +1,6 @@
 """Midea Lan device test."""
 
+import threading
 from typing import Any, ClassVar
 from unittest.mock import MagicMock, patch
 
@@ -248,6 +249,41 @@ class TestMideaDevice:
 
         authenticate_mock.assert_not_called()
         refresh_mock.assert_not_called()
+        assert self.device.available is False
+
+    def test_connect_loop_discards_connection_closed_before_install(self) -> None:
+        """Test close() during connect prevents a connected socket from surviving."""
+        socket_mock = MagicMock()
+        close_started = threading.Event()
+        close_finished = threading.Event()
+        close_thread: threading.Thread | None = None
+
+        def close_device() -> None:
+            close_started.set()
+            self.device.close()
+            close_finished.set()
+
+        def create_socket(*_args: object) -> MagicMock:
+            nonlocal close_thread
+            close_thread = threading.Thread(target=close_device)
+            close_thread.start()
+            assert close_started.wait(1)
+            assert not close_finished.wait(0.01)
+            return socket_mock
+
+        self.device._is_run = True
+        self.device._device_protocol_version = ProtocolVersion.V2
+        with (
+            patch("socket.socket", side_effect=create_socket),
+            patch.object(self.device, "refresh_status"),
+        ):
+            self.device._connect_loop()
+
+        assert close_thread is not None
+        close_thread.join(1)
+        assert close_finished.is_set()
+        socket_mock.close.assert_called_once()
+        assert self.device._socket is None
         assert self.device.available is False
 
     def test_authenticate(self) -> None:


### PR DESCRIPTION
1. close socket catch error, fix https://github.com/wuwentao/midea_ac_lan/issues/975
2. log level update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when connecting, reconnecting, and disconnecting devices.
  - Prevented connection changes from disrupting active device communication.
  - Improved handling of failed authentication, unsupported protocols, and device queries.
  - Corrected command failure and refresh-status messages.
  - Improved resilience when connection resources cannot be closed cleanly.
  - Expanded coverage for device lifecycle and connection edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->