### PR TITLE
fix(fa): add opt-in mode override for fan devices

### DIFF
--- a/midealan/devices/fa/__init__.py
+++ b/midealan/devices/fa/__init__.py
@@ -104,6 +104,7 @@ class MideaFADevice(MideaDevice):
         )
         self._default_speed_count = 3
         self._speed_count: int = self._default_speed_count
+        self._mode_set_overrides: dict[int, int] = {}
         self.set_customize(customize)
 
     @property
@@ -314,6 +315,7 @@ class MideaFADevice(MideaDevice):
             if value in MideaFADevice._modes:
                 message = MessageSet(self._message_protocol_version, self.subtype)
                 message.mode = MideaFADevice._modes.index(str(value))
+                message.mode_set_overrides = self._mode_set_overrides
         elif not (attr == DeviceAttributes.fan_speed and value == 0):
             message = MessageSet(self._message_protocol_version, self.subtype)
             setattr(message, str(attr), value)
@@ -328,16 +330,23 @@ class MideaFADevice(MideaDevice):
             message.fan_speed = fan_speed
         if mode is not None and mode in MideaFADevice._modes:
             message.mode = MideaFADevice._modes.index(mode)
+            message.mode_set_overrides = self._mode_set_overrides
         self.build_send(message)
 
     def set_customize(self, customize: str) -> None:
         """Set customize."""
         self._speed_count = self._default_speed_count
+        self._mode_set_overrides = {}
         if customize and len(customize) > 0:
             try:
                 params = json.loads(customize)
                 if params and "speed_count" in params:
                     self._speed_count = params.get("speed_count")
+                if params and "mode_set_overrides" in params:
+                    self._mode_set_overrides = {
+                        int(k): int(v)
+                        for k, v in params.get("mode_set_overrides").items()
+                    }
             except Exception:
                 _LOGGER.exception("[%s] Set customize error", self.device_id)
             self.update_all({"speed_count": self._speed_count})

--- a/midealan/devices/fa/__init__.py
+++ b/midealan/devices/fa/__init__.py
@@ -342,20 +342,30 @@ class MideaFADevice(MideaDevice):
     ) -> dict[int, int]:
         """Return the {mode index: body[3]} table, or {} if a value is not a byte.
 
-        Each value is written straight into the set body, so one outside 0..255
-        would raise on the bytearray assignment and lose the command.
+        Each value is written straight into the set body, so anything `int()`
+        would silently reshape into a byte - a fraction, a bool, a number
+        outside 0..255 - is rejected here rather than sent as some other byte
+        or raised on the bytearray assignment, losing the command.
         """
-        parsed = {int(k): int(v) for k, v in overrides.items()}
-        out_of_range = {
-            mode: value
-            for mode, value in parsed.items()
-            if not MIN_MODE_SET_OVERRIDE <= value <= MAX_MODE_SET_OVERRIDE
-        }
-        if out_of_range:
+        parsed: dict[int, int] = {}
+        rejected: dict[str, Any] = {}
+        for key, value in overrides.items():
+            if isinstance(value, bool) or (
+                isinstance(value, float) and not value.is_integer()
+            ):
+                rejected[key] = value
+                continue
+            converted = int(value)
+            if not MIN_MODE_SET_OVERRIDE <= converted <= MAX_MODE_SET_OVERRIDE:
+                rejected[key] = value
+                continue
+            parsed[int(key)] = converted
+        if rejected:
             _LOGGER.error(
-                "[%s] mode_set_overrides values must be 0..255, ignoring the table: %s",
+                "[%s] mode_set_overrides values must be whole numbers in 0..255, "
+                "ignoring the table: %s",
                 self.device_id,
-                out_of_range,
+                rejected,
             )
             return {}
         return parsed

--- a/midealan/devices/fa/__init__.py
+++ b/midealan/devices/fa/__init__.py
@@ -12,6 +12,9 @@ from .message import MessageFAResponse, MessageQuery, MessageSet
 
 _LOGGER = logging.getLogger(__name__)
 
+MIN_MODE_SET_OVERRIDE = 0x00
+MAX_MODE_SET_OVERRIDE = 0xFF
+
 
 class DeviceAttributes(StrEnum):
     """Midea FA device attributes."""
@@ -333,6 +336,30 @@ class MideaFADevice(MideaDevice):
             message.mode_set_overrides = self._mode_set_overrides
         self.build_send(message)
 
+    def _parse_mode_set_overrides(
+        self,
+        overrides: dict[str, Any],
+    ) -> dict[int, int]:
+        """Return the {mode index: body[3]} table, or {} if a value is not a byte.
+
+        Each value is written straight into the set body, so one outside 0..255
+        would raise on the bytearray assignment and lose the command.
+        """
+        parsed = {int(k): int(v) for k, v in overrides.items()}
+        out_of_range = {
+            mode: value
+            for mode, value in parsed.items()
+            if not MIN_MODE_SET_OVERRIDE <= value <= MAX_MODE_SET_OVERRIDE
+        }
+        if out_of_range:
+            _LOGGER.error(
+                "[%s] mode_set_overrides values must be 0..255, ignoring the table: %s",
+                self.device_id,
+                out_of_range,
+            )
+            return {}
+        return parsed
+
     def set_customize(self, customize: str) -> None:
         """Set customize."""
         self._speed_count = self._default_speed_count
@@ -343,10 +370,9 @@ class MideaFADevice(MideaDevice):
                 if params and "speed_count" in params:
                     self._speed_count = params.get("speed_count")
                 if params and "mode_set_overrides" in params:
-                    self._mode_set_overrides = {
-                        int(k): int(v)
-                        for k, v in params.get("mode_set_overrides").items()
-                    }
+                    self._mode_set_overrides = self._parse_mode_set_overrides(
+                        params.get("mode_set_overrides"),
+                    )
             except Exception:
                 _LOGGER.exception("[%s] Set customize error", self.device_id)
             self.update_all({"speed_count": self._speed_count})

--- a/midealan/devices/fa/message.py
+++ b/midealan/devices/fa/message.py
@@ -84,6 +84,7 @@ class MessageSet(MessageFABase):
         self.humidify: bool | None = None
         self.waterions: bool | None = None
         self.display_on_off: bool | None = None
+        self.mode_set_overrides: dict[int, int] | None = None
 
     @property
     def _body(self) -> bytearray:  # noqa: C901
@@ -177,7 +178,12 @@ class MessageSet(MessageFABase):
             else:
                 _body_return[2] = 2
         if self.mode is not None:
-            _body_return[3] = 1 | (((self.mode + 1) << 1) & 0x1E)
+            override = (self.mode_set_overrides or {}).get(self.mode)
+            _body_return[3] = (
+                override
+                if override is not None
+                else 1 | (((self.mode + 1) << 1) & 0x1E)
+            )
         if self.fan_speed is not None and 1 <= self.fan_speed <= MAX_FAN_SPEED:
             _body_return[4] = self.fan_speed
         if self.oscillate is not None:

--- a/tests/devices/fa/device_fa_test.py
+++ b/tests/devices/fa/device_fa_test.py
@@ -466,6 +466,34 @@ class TestMideaFADevice:
             assert mock_build_send.call_args[0][0].mode is None
 
     @pytest.mark.parametrize(
+        ("customize", "expected_overrides", "expected_body"),
+        [
+            pytest.param("", {}, 0x09, id="no_override"),
+            pytest.param(
+                '{"mode_set_overrides": {"3": 41}}',
+                {3: 41},
+                0x29,
+                id="with_override",
+            ),
+        ],
+    )
+    def test_turn_on_mode_set_overrides(
+        self,
+        customize: str,
+        expected_overrides: dict[int, int],
+        expected_body: int,
+    ) -> None:
+        """Test turn on carries the override table, the second wiring path."""
+        self.device.set_customize(customize)
+        with patch.object(self.device, "build_send") as mock_build_send:
+            self.device.turn_on(mode="Comfort")
+            mock_build_send.assert_called_once()
+            message = mock_build_send.call_args[0][0]
+            assert message.mode == 3
+            assert message.mode_set_overrides == expected_overrides
+            assert message._body[3] == expected_body
+
+    @pytest.mark.parametrize(
         ("customize", "expected_speed_count"),
         [
             pytest.param('{"speed_count": 5}', 5, id="speed_count"),

--- a/tests/devices/fa/device_fa_test.py
+++ b/tests/devices/fa/device_fa_test.py
@@ -388,12 +388,34 @@ class TestMideaFADevice:
             mock_build_send.assert_called_once()
             assert mock_build_send.call_args[0][0].fan_speed == 3
 
-    def test_set_attribute_mode(self) -> None:
-        """Test set attribute mode."""
+    @pytest.mark.parametrize(
+        ("customize", "mode_name", "expected_mode", "expected_overrides"),
+        [
+            pytest.param("", "Sleep", 2, {}, id="no_override"),
+            pytest.param(
+                '{"mode_set_overrides": {"3": 41}}',
+                "Comfort",
+                3,
+                {3: 41},
+                id="with_override",
+            ),
+        ],
+    )
+    def test_set_attribute_mode(
+        self,
+        customize: str,
+        mode_name: str,
+        expected_mode: int,
+        expected_overrides: dict[int, int],
+    ) -> None:
+        """Test set attribute mode, with and without a customized override table."""
+        self.device.set_customize(customize)
         with patch.object(self.device, "build_send") as mock_build_send:
-            self.device.set_attribute(DeviceAttributes.mode.value, "Sleep")
+            self.device.set_attribute(DeviceAttributes.mode.value, mode_name)
             mock_build_send.assert_called_once()
-            assert mock_build_send.call_args[0][0].mode == 2
+            message = mock_build_send.call_args[0][0]
+            assert message.mode == expected_mode
+            assert message.mode_set_overrides == expected_overrides
             mock_build_send.reset_mock()
 
             self.device.set_attribute(DeviceAttributes.mode.value, "invalid")
@@ -443,17 +465,27 @@ class TestMideaFADevice:
             mock_build_send.assert_called_once()
             assert mock_build_send.call_args[0][0].mode is None
 
-    def test_set_customize(self) -> None:
+    @pytest.mark.parametrize(
+        ("customize", "expected_speed_count"),
+        [
+            pytest.param('{"speed_count": 5}', 5, id="speed_count"),
+            pytest.param("{}", 3, id="empty_params"),
+            pytest.param("{", 3, id="invalid_json"),
+        ],
+    )
+    def test_set_customize(
+        self,
+        customize: str,
+        expected_speed_count: int,
+    ) -> None:
         """Test set customize."""
-        self.device.set_customize('{"speed_count": 5}')
-        assert self.device.speed_count == 5
+        self.device.set_customize(customize)
+        assert self.device.speed_count == expected_speed_count
 
-    def test_set_customize_empty_params(self) -> None:
-        """Test set customize with an empty JSON object."""
+    def test_set_customize_mode_set_overrides(self) -> None:
+        """Test set customize parses and resets the mode set override table."""
+        self.device.set_customize('{"mode_set_overrides": {"3": 41}}')
+        assert self.device._mode_set_overrides == {3: 41}
+
         self.device.set_customize("{}")
-        assert self.device.speed_count == 3
-
-    def test_set_customize_invalid(self) -> None:
-        """Test set customize with invalid JSON keeps defaults."""
-        self.device.set_customize("{")
-        assert self.device.speed_count == 3
+        assert self.device._mode_set_overrides == {}

--- a/tests/devices/fa/device_fa_test.py
+++ b/tests/devices/fa/device_fa_test.py
@@ -495,17 +495,19 @@ class TestMideaFADevice:
         [
             pytest.param('{"mode_set_overrides": {"3": 256}}', id="above_a_byte"),
             pytest.param('{"mode_set_overrides": {"3": -1}}', id="below_a_byte"),
+            pytest.param('{"mode_set_overrides": {"3": 1.5}}', id="fraction"),
+            pytest.param('{"mode_set_overrides": {"3": true}}', id="bool"),
             pytest.param(
                 '{"mode_set_overrides": {"3": 41, "4": 256}}',
                 id="one_entry_out_of_range",
             ),
         ],
     )
-    def test_set_customize_mode_set_overrides_out_of_range(
+    def test_set_customize_mode_set_overrides_not_a_byte(
         self,
         customize: str,
     ) -> None:
-        """Test an override outside 0..255 is rejected, not carried into a set."""
+        """Test an override that is not a byte is rejected, not carried into a set."""
         self.device.set_customize(customize)
         assert self.device._mode_set_overrides == {}
 
@@ -515,3 +517,8 @@ class TestMideaFADevice:
             message = mock_build_send.call_args[0][0]
             assert message.mode_set_overrides == {}
             assert message._body[3] == 0x09
+
+    def test_set_customize_mode_set_overrides_integral_float(self) -> None:
+        """Test a float that is a whole number is still a usable byte."""
+        self.device.set_customize('{"mode_set_overrides": {"3": 41.0}}')
+        assert self.device._mode_set_overrides == {3: 41}

--- a/tests/devices/fa/device_fa_test.py
+++ b/tests/devices/fa/device_fa_test.py
@@ -489,3 +489,29 @@ class TestMideaFADevice:
 
         self.device.set_customize("{}")
         assert self.device._mode_set_overrides == {}
+
+    @pytest.mark.parametrize(
+        "customize",
+        [
+            pytest.param('{"mode_set_overrides": {"3": 256}}', id="above_a_byte"),
+            pytest.param('{"mode_set_overrides": {"3": -1}}', id="below_a_byte"),
+            pytest.param(
+                '{"mode_set_overrides": {"3": 41, "4": 256}}',
+                id="one_entry_out_of_range",
+            ),
+        ],
+    )
+    def test_set_customize_mode_set_overrides_out_of_range(
+        self,
+        customize: str,
+    ) -> None:
+        """Test an override outside 0..255 is rejected, not carried into a set."""
+        self.device.set_customize(customize)
+        assert self.device._mode_set_overrides == {}
+
+        with patch.object(self.device, "build_send") as mock_build_send:
+            self.device.set_attribute(DeviceAttributes.mode.value, "Comfort")
+            mock_build_send.assert_called_once()
+            message = mock_build_send.call_args[0][0]
+            assert message.mode_set_overrides == {}
+            assert message._body[3] == 0x09

--- a/tests/devices/fa/message_fa_test.py
+++ b/tests/devices/fa/message_fa_test.py
@@ -91,11 +91,25 @@ class TestMessageSet:
         msg.lock = lock
         assert msg._body[2] == expected
 
-    def test_body_mode(self) -> None:
-        """Test set body mode."""
+    @pytest.mark.parametrize(
+        ("mode", "mode_set_overrides", "expected"),
+        [
+            pytest.param(2, None, 0x07, id="no_override"),
+            pytest.param(3, {3: 0x29}, 0x29, id="override_match"),
+            pytest.param(2, {3: 0x29}, 0x07, id="override_not_matching"),
+        ],
+    )
+    def test_body_mode(
+        self,
+        mode: int,
+        mode_set_overrides: dict[int, int] | None,
+        expected: int,
+    ) -> None:
+        """Test set body mode, with and without a customized override table."""
         msg = MessageSet(ProtocolVersion.V1, 1)
-        msg.mode = 2
-        assert msg._body[3] == 0x07
+        msg.mode = mode
+        msg.mode_set_overrides = mode_set_overrides
+        assert msg._body[3] == expected
 
     def test_body_fan_speed_valid(self) -> None:
         """Test set body with a valid fan speed."""


### PR DESCRIPTION
## Summary

Port of [midea-lan/midea-local#686](https://github.com/midea-lan/midea-local/pull/686) (*fix(fa): add opt-in mode override for fan devices*), which fixes [midea-lan/midea-local#504](https://github.com/midea-lan/midea-local/issues/504) (*FA: Normal mode cannot be set on some fans*). It was merged there after this repository was split off, so `midealan` does not carry it.

On some FA fans a mode is not selected by the `(mode + 1) << 1` nibble the library emits. On a Midea tower fan (model 56000211) the state byte is `body[4]`: bit 0 is power, bits 1-4 are `mode + 1`. "Normal" reads back from the device as `0x29` — power, the nibble, **and bit `0x20`**. The setter is

```python
_body_return[3] = 1 | (((self.mode + 1) << 1) & 0x1E)
```

whose `0x1E` mask can never emit `0x20`, so it sends `0x09` and the fan ignores it — the device echoes its previous mode back unchanged, and the mode is unreachable from the integration.

This adds `mode_set_overrides` to the FA `customize` JSON: a `{mode index: body[3]}` map consulted before the masked default, in the same opt-in style as `speed_count` (and as `prompt_tone` in #25). Devices that do not set it are unaffected — the default path is unchanged.

The flag has to be per-mode rather than always-on: setting `0x20` on every mode was tested on the device and the fan then went to Normal whatever mode was requested. So `0x20` does not add to the nibble, it overrides it.

## Usage

In the device's `customize` field — here mode index 3 needs `body[3] = 0x29`:

```json
{"mode_set_overrides": {"3": 41}}
```

Each value is written straight into the set body, so the table is validated on parse: anything `int()` would silently reshape into a byte — a bool, a non-integral float (`int(1.5) == 1`), or a number outside `0..255`, which would raise on the `bytearray` assignment in `MessageSet._body` — is logged and drops the whole table, so the device falls back to the default masked encoding rather than sending a mode nobody asked for or nothing at all. An integral float (`41.0`) is a usable byte and is kept. That validation is the one place this port goes beyond midea-local#686, which stores the values unchecked; the same guard is now open against that repository as [midea-lan/midea-local#693](https://github.com/midea-lan/midea-local/pull/693).

## Test plan

- [x] `uv run python -m pytest ./tests/` — 1592 passed
- [x] `uv run ruff check .`, `uv run ruff format --check` on the changed files, `uv run mypy midealan` (clean), `uv run pylint --rcfile=pylintrc midealan` (10.00/10)
- [x] Parametrized the existing FA mode/customize tests to cover both the default and the override path, including a mode index the table does not name
- [x] Covered both wiring paths — `set_attribute` and `turn_on` — asserting the resulting `_body[3]` (`0x29` with the override, `0x09` without), each verified to fail with its assignment removed
- [x] Covered override values that are not bytes (`256`, `-1`, `1.5`, `true`, and a table mixing a valid entry with an invalid one) — the table is dropped and the default encoding stands; `41.0` is covered as a value that must still parse
- [x] Verified against the real device in both directions on `midea-local` main: with `{"mode_set_overrides": {"3": 41}}` the mode reads back applied; with `{}` it silently keeps the previous mode, as before

One note for anyone using this on that fan: `_modes[3]` is labelled `"Comfort"`, and on this model that entry is what the appliance calls Normal, so the HA dropdown still reads "Comfort". This PR does not touch the mode table.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for customized mode-setting overrides on Midea FA devices.
  * Device commands now apply configured mode-specific values when setting modes or powering on.
  * Customization accepts valid mode mappings, including whole-number values.

* **Bug Fixes**
  * Invalid, boolean, fractional, and out-of-range values are rejected and discarded.
  * Overrides reset when customization is reapplied, preventing outdated settings from affecting commands.

* **Tests**
  * Expanded coverage for default, customized, empty, invalid, and out-of-range configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


