### PR TITLE
refactor: remove bt/body_type

### DIFF
--- a/midealan/devices/a1/message.py
+++ b/midealan/devices/a1/message.py
@@ -243,9 +243,9 @@ class A1GeneralMessageBody(MessageBody):
 class A1NewProtocolMessageBody(NewProtocolMessageBody):
     """A1 new protocol message body."""
 
-    def __init__(self, body: bytearray, bt: int) -> None:
+    def __init__(self, body: bytearray) -> None:
         """Initialize A1 new protocol message body."""
-        super().__init__(body, bt)
+        super().__init__(body)
         params = self.parse()
         if NewProtocolTags.light in params:
             self.light = params[NewProtocolTags.light][0] > 0
@@ -263,7 +263,7 @@ class MessageA1Response(MessageResponse):
             MessageType.notify1,
         ]:
             if self.body_type in [ListTypes.B0, ListTypes.B1, ListTypes.B5]:
-                self.set_body(A1NewProtocolMessageBody(super().body, self.body_type))
+                self.set_body(A1NewProtocolMessageBody(super().body))
             else:
                 self.set_body(A1GeneralMessageBody(super().body))
         elif (

--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -1066,11 +1066,10 @@ class XBXMessageBody(NewProtocolMessageBody):
     def __init__(
         self,
         body: bytearray,
-        bt: int,
         new_protocol_temperature: bool = False,
     ) -> None:
         """Initialize AC BX message body."""
-        super().__init__(body, bt)
+        super().__init__(body)
 
         params = self.parse()
         if NewProtocolTags.indirect_wind in params:
@@ -1109,7 +1108,7 @@ class XBXMessageBody(NewProtocolMessageBody):
             self.sound = params[NewProtocolTags.buzzer_all][0] > 0
         if NewProtocolTags.error_code_query in params:
             self.error_code = params[NewProtocolTags.error_code_query][0]
-        if NewProtocolTags.self_clean in params and bt != ListTypes.B5:
+        if NewProtocolTags.self_clean in params and self.body_type != ListTypes.B5:
             # A B5 body carries this tag as a capability flag (always 1 when the
             # model supports self-clean), so only B0/B1 bodies report live state.
             self.self_clean_active: bool = params[NewProtocolTags.self_clean][0] > 0
@@ -1182,9 +1181,9 @@ class XBXMessageBody(NewProtocolMessageBody):
 class XB5MessageBody(NewProtocolMessageBody):
     """AC B5 message body. body[0] b5, body[1] propertyNumber, cursor 2."""
 
-    def __init__(self, body: bytearray, bt: int) -> None:
+    def __init__(self, body: bytearray) -> None:
         """Initialize AC BX message body."""
-        super().__init__(body, bt)
+        super().__init__(body)
 
         params = self.parse()
         # parse b5 protocol, github issue https://github.com/wuwentao/midea_ac_lan/issues/673
@@ -1598,7 +1597,7 @@ class MessageACResponse(MessageResponse):
         # parse MessageCapabilitiesQuery/MessageCapabilitiesAdditionalQuery response
         # dataType 0x03 and messageBytes[0] 0xB5
         elif self.message_type == MessageType.query and self.body_type == ListTypes.B5:
-            self.set_body(XB5MessageBody(super().body, self.body_type))
+            self.set_body(XB5MessageBody(super().body))
         # dataType 0x05 and messageBytes[0] 0xB5
         # dataType 0x02 and messageBytes[0] 0xB0 (set result Unidentified protocol)
         # dataType 0x03 and messageBytes[0] 0xB1
@@ -1608,7 +1607,7 @@ class MessageACResponse(MessageResponse):
             MessageType.notify2,
         ] and self.body_type in [ListTypes.B0, ListTypes.B1, ListTypes.B5]:
             self.set_body(
-                XBXMessageBody(super().body, self.body_type, new_protocol_temperature),
+                XBXMessageBody(super().body, new_protocol_temperature),
             )
         # dataType 0x02 and messageBytes[0] 0xC0
         # dataType 0x03 and messageBytes[0] 0xC0

--- a/midealan/message.py
+++ b/midealan/message.py
@@ -825,13 +825,20 @@ class NewProtocolPackLength(IntEnum):
 class NewProtocolMessageBody(MessageBody):
     """New protocol message body."""
 
-    def __init__(self, body: bytearray, bt: int) -> None:
+    def __init__(self, body: bytearray) -> None:
         """Initialize new protocol message body."""
         super().__init__(body)
-        if bt == ListTypes.B5:
+        if self.body_type == ListTypes.B5:
             self._pack_len = NewProtocolPackLength.FOUR
+        elif self.body_type in [ListTypes.B0, ListTypes.B1]:
+            self._pack_len = NewProtocolPackLength.FIVE
         else:
             self._pack_len = NewProtocolPackLength.FIVE
+            _LOGGER.debug(
+                "unknown body type %s, set len to %s",
+                self.body_type,
+                self._pack_len,
+            )
 
     @staticmethod
     def pack(param: int, value: bytearray, pack_len: int = 4) -> bytearray:

--- a/midealan/message.py
+++ b/midealan/message.py
@@ -842,7 +842,20 @@ class NewProtocolMessageBody(MessageBody):
 
     @staticmethod
     def pack(param: int, value: bytearray, pack_len: int = 4) -> bytearray:
-        """Pack for new protocol."""
+        """Pack for new protocol.
+
+        Note: pack() defaults to the 4-byte format, while parse() infers the
+        length from body_type and uses the 5-byte format for B0/B1 bodies (and
+        for unknown types). This read/write asymmetry is intentional and
+        pre-existing: all current AC (devices/ac/message.py) and A1
+        (devices/a1/message.py) set-message producers build B0 set bodies with
+        the default pack_len=4, and real devices accept that wire format. The
+        5-byte branch here is therefore not exercised by any device today; it
+        exists only to mirror the 5-byte layout that parse() reads back from
+        B0/B1 notify/response bodies. Do not switch the producers to pack_len=5
+        without first confirming the on-wire format against a real device, as it
+        would change the bytes sent and may break working appliances.
+        """
         length = len(value)
         if pack_len == NewProtocolPackLength.FOUR:
             stream = bytearray([param & 0xFF, param >> 8, length]) + value
@@ -860,6 +873,10 @@ class NewProtocolMessageBody(MessageBody):
     def parse(self) -> dict[int, bytearray]:
         """Parse new protocol body."""
         result = {}
+        # Initialize before the try so a body too short to hold the param count
+        # (e.g. bytearray([0xB1])) returns {} instead of leaving param_count
+        # unbound for the debug log below (would raise UnboundLocalError).
+        param_count = 0
         try:
             pos = 2  # # 跳过协议头(b1)和参数数量
             param_count = self.data[1]  # 参数数量

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -377,34 +377,42 @@ class TestNewProtocolMessageBody:
 
     def test_parse(self) -> None:
         """Test parse with 4 and 5 bytes pack length."""
+        # test B5 body with 4 bytes pack length
         body = NewProtocolMessageBody(
-            bytearray([0xB1, 0x01, 0x34, 0x12, 0x01, 0xAA]),
-            ListTypes.B5,
+            bytearray([0xB5, 0x01, 0x34, 0x12, 0x01, 0xAA]),
         )
         assert body.parse() == {0x1234: bytearray([0xAA])}
+        # test B1 body with 5 bytes pack length
         body = NewProtocolMessageBody(
             bytearray([0xB1, 0x01, 0x34, 0x12, 0x00, 0x01, 0xAA]),
-            ListTypes.B1,
+        )
+        assert body.parse() == {0x1234: bytearray([0xAA])}
+        # test B0 body with 5 bytes pack length
+        body = NewProtocolMessageBody(
+            bytearray([0xB0, 0x01, 0x34, 0x12, 0x00, 0x01, 0xAA]),
+        )
+        assert body.parse() == {0x1234: bytearray([0xAA])}
+        # test unknown B9 body with 5 bytes pack length
+        body = NewProtocolMessageBody(
+            bytearray([0xB9, 0x01, 0x34, 0x12, 0x00, 0x01, 0xAA]),
         )
         assert body.parse() == {0x1234: bytearray([0xAA])}
 
     def test_parse_truncated_param(self) -> None:
         """Test parse stops when a declared param is missing."""
         body = NewProtocolMessageBody(
-            bytearray([0xB1, 0x02, 0x01, 0x00, 0x01, 0xAA]),
-            ListTypes.B5,
+            bytearray([0xB5, 0x02, 0x01, 0x00, 0x01, 0xAA]),
         )
         assert body.parse() == {0x0001: bytearray([0xAA])}
 
     def test_parse_truncated_after_param_id(self) -> None:
         """Test parse stops when the body ends after the param id."""
-        body = NewProtocolMessageBody(bytearray([0xB1, 0x01, 0x01, 0x00]), ListTypes.B5)
+        body = NewProtocolMessageBody(bytearray([0xB1, 0x01, 0x01, 0x00]))
         assert body.parse() == {}
-        body = NewProtocolMessageBody(bytearray([0xB1, 0x01, 0x01, 0x00]), ListTypes.B1)
+        body = NewProtocolMessageBody(bytearray([0xB1, 0x01, 0x01, 0x00]))
         assert body.parse() == {}
         body = NewProtocolMessageBody(
             bytearray([0xB1, 0x01, 0x01, 0x00, 0x00]),
-            ListTypes.B1,
         )
         assert body.parse() == {}
 
@@ -412,7 +420,6 @@ class TestNewProtocolMessageBody:
         """Test parse stops when the value is shorter than its length."""
         body = NewProtocolMessageBody(
             bytearray([0xB1, 0x01, 0x01, 0x00, 0x05, 0xAA]),
-            ListTypes.B5,
         )
         assert body.parse() == {}
 
@@ -420,7 +427,6 @@ class TestNewProtocolMessageBody:
         """Test parse skips params with a zero length value."""
         body = NewProtocolMessageBody(
             bytearray([0xB1, 0x01, 0x01, 0x00, 0x00]),
-            ListTypes.B5,
         )
         assert body.parse() == {}
 
@@ -431,7 +437,7 @@ class TestNewProtocolMessageBody:
         leaves `param_count` unbound, so the debug log after the handler
         raises UnboundLocalError instead of returning an empty result.
         """
-        body = NewProtocolMessageBody(bytearray([0xB1]), ListTypes.B5)
+        body = NewProtocolMessageBody(bytearray([0xB1]))
         with pytest.raises(UnboundLocalError):
             body.parse()
 

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -406,11 +406,12 @@ class TestNewProtocolMessageBody:
         assert body.parse() == {0x0001: bytearray([0xAA])}
 
     def test_parse_truncated_after_param_id(self) -> None:
-        """Test parse stops when the body ends after the param id."""
+        """Test parse stops at two distinct 5-byte truncation boundaries."""
+        # B1 -> 5-byte format. Body ends right after the param id, before the
+        # fixed 0x00 skip byte can be read.
         body = NewProtocolMessageBody(bytearray([0xB1, 0x01, 0x01, 0x00]))
         assert body.parse() == {}
-        body = NewProtocolMessageBody(bytearray([0xB1, 0x01, 0x01, 0x00]))
-        assert body.parse() == {}
+        # Body ends after the fixed 0x00 skip byte, before the length byte.
         body = NewProtocolMessageBody(
             bytearray([0xB1, 0x01, 0x01, 0x00, 0x00]),
         )
@@ -425,21 +426,21 @@ class TestNewProtocolMessageBody:
 
     def test_parse_zero_length_value(self) -> None:
         """Test parse skips params with a zero length value."""
+        # B1 -> 5-byte format: param 0x1234, fixed 0x00, then length 0x00.
         body = NewProtocolMessageBody(
-            bytearray([0xB1, 0x01, 0x01, 0x00, 0x00]),
+            bytearray([0xB1, 0x01, 0x34, 0x12, 0x00, 0x00]),
         )
         assert body.parse() == {}
 
     def test_parse_non_standard_short_body(self) -> None:
-        """Test parse with a body too short to hold the param count.
+        """Test parse returns {} for a body too short to hold the param count.
 
-        Source quirk (midealan/message.py:886-898): the IndexError handler
-        leaves `param_count` unbound, so the debug log after the handler
-        raises UnboundLocalError instead of returning an empty result.
+        A body such as bytearray([0xB1]) has no parameter-count byte, so
+        parse() catches the IndexError and returns an empty result instead of
+        raising UnboundLocalError from the trailing debug log.
         """
         body = NewProtocolMessageBody(bytearray([0xB1]))
-        with pytest.raises(UnboundLocalError):
-            body.parse()
+        assert body.parse() == {}
 
 
 class TestMessageResponse:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized message and message-body names across A1 and AC device protocols.
  * Simplified message construction by removing redundant body-type parameters.
  * Improved parsing of capability, live-state, truncated, undersized, and zero-length message bodies.
  * Enhanced handling for B0, B1, B5, and unknown message types.

* **Tests**
  * Added coverage for protocol format detection, additional message types, and edge-case parsing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->