### PR TITLE
refactor: rename class name

### DIFF
--- a/midealan/devices/a1/message.py
+++ b/midealan/devices/a1/message.py
@@ -97,7 +97,7 @@ class MessageQuery(MessageA1Base):
         )
 
 
-class MessageNewProtocolQuery(MessageA1Base):
+class NewProtocolQuery(MessageA1Base):
     """Message A1 new protocol query."""
 
     def __init__(self, protocol_version: ProtocolVersion) -> None:
@@ -186,7 +186,7 @@ class MessageSet(MessageA1Base):
         )
 
 
-class MessageNewProtocolSet(MessageA1Base):
+class NewProtocolSet(MessageA1Base):
     """Message A1 new protocol set."""
 
     def __init__(self, protocol_version: ProtocolVersion) -> None:

--- a/midealan/devices/ac/__init__.py
+++ b/midealan/devices/ac/__init__.py
@@ -12,43 +12,43 @@ from midealan.device import MideaDevice, MideaDeviceInitKwargs
 from midealan.message import ListTypes
 
 from .message import (
+    CapabilitiesAdditionalQuery,
+    CapabilitiesQuery,
+    GroupOneQuery,
+    GroupSevenQuery,
+    GroupTwoQuery,
+    GroupZeroQuery,
+    HumidityQuery,
     MessageACResponse,
-    MessageCapabilitiesAdditionalQuery,
-    MessageCapabilitiesQuery,
-    MessageGeneralSet,
-    MessageGroupOneQuery,
-    MessageGroupSevenQuery,
-    MessageGroupTwoQuery,
-    MessageGroupZeroQuery,
-    MessageHumidityQuery,
-    MessageNewProtocolQuery,
-    MessageNewProtocolSelfCleanQuery,
-    MessageNewProtocolSet,
-    MessagePowerQuery,
     MessageQuery,
-    MessageSubProtocolFreshAirSet,
-    MessageSubProtocolQuery,
-    MessageSubProtocolQuery10,
-    MessageSubProtocolQuery11,
-    MessageSubProtocolQuery30,
+    MessageSet,
     MessageSubProtocolSet,
-    MessageToggleDisplay,
+    NewProtocolQuery,
+    NewProtocolSelfCleanQuery,
+    NewProtocolSet,
+    PowerQuery,
+    SubProtocolFreshAirSet,
+    SubProtocolQuery,
+    SubProtocolQuery10,
+    SubProtocolQuery11,
+    SubProtocolQuery30,
+    ToggleDisplay,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 ACQuery = (
-    MessageSubProtocolQuery
+    SubProtocolQuery
     | MessageQuery
-    | MessageNewProtocolQuery
-    | MessagePowerQuery
-    | MessageHumidityQuery
-    | MessageGroupZeroQuery
-    | MessageGroupOneQuery
-    | MessageGroupTwoQuery
-    | MessageGroupSevenQuery
-    | MessageCapabilitiesQuery
-    | MessageCapabilitiesAdditionalQuery
+    | NewProtocolQuery
+    | PowerQuery
+    | HumidityQuery
+    | GroupZeroQuery
+    | GroupOneQuery
+    | GroupTwoQuery
+    | GroupSevenQuery
+    | CapabilitiesQuery
+    | CapabilitiesAdditionalQuery
 )
 
 # AC mode constants
@@ -378,29 +378,29 @@ class MideaACDevice(MideaDevice):
             # its own identity so an unsupported response for one group does not
             # suppress later status groups.
             return [
-                MessageSubProtocolQuery10(self._message_protocol_version),
-                MessageSubProtocolQuery11(self._message_protocol_version),
-                MessageSubProtocolQuery30(self._message_protocol_version),
+                SubProtocolQuery10(self._message_protocol_version),
+                SubProtocolQuery11(self._message_protocol_version),
+                SubProtocolQuery30(self._message_protocol_version),
             ]
         queries: list[ACQuery] = [
             MessageQuery(self._message_protocol_version),
-            MessageNewProtocolQuery(
+            NewProtocolQuery(
                 self._message_protocol_version,
                 supports_rate_select=self._capabilities.get("rate_select", False),
             ),
             # Queried on its own so an empty response for the combined
             # new-protocol query does not suppress the self-clean state.
-            MessageNewProtocolSelfCleanQuery(self._message_protocol_version),
-            MessagePowerQuery(self._message_protocol_version),
-            MessageHumidityQuery(self._message_protocol_version),
-            MessageGroupZeroQuery(self._message_protocol_version),
+            NewProtocolSelfCleanQuery(self._message_protocol_version),
+            PowerQuery(self._message_protocol_version),
+            HumidityQuery(self._message_protocol_version),
+            GroupZeroQuery(self._message_protocol_version),
             # Devices that do not answer a group query are detected during the
             # initial protocol check and the query is skipped from then on.
-            MessageGroupOneQuery(self._message_protocol_version),
-            MessageGroupTwoQuery(self._message_protocol_version),
-            MessageGroupSevenQuery(self._message_protocol_version),
-            MessageCapabilitiesQuery(self._message_protocol_version),
-            MessageCapabilitiesAdditionalQuery(self._message_protocol_version),
+            GroupOneQuery(self._message_protocol_version),
+            GroupTwoQuery(self._message_protocol_version),
+            GroupSevenQuery(self._message_protocol_version),
+            CapabilitiesQuery(self._message_protocol_version),
+            CapabilitiesAdditionalQuery(self._message_protocol_version),
         ]
         return queries
 
@@ -602,9 +602,9 @@ class MideaACDevice(MideaDevice):
             DeviceAttributes.max_temperature.value: maximum,
         }
 
-    def make_message_set(self) -> MessageGeneralSet:
+    def make_message_set(self) -> MessageSet:
         """Midea AC device make message set."""
-        message = MessageGeneralSet(self._message_protocol_version)
+        message = MessageSet(self._message_protocol_version)
         message.power = self._attributes[DeviceAttributes.power]
         message.prompt_tone = self._attributes[DeviceAttributes.prompt_tone]
         message.mode = self._attributes[DeviceAttributes.mode]
@@ -632,9 +632,9 @@ class MideaACDevice(MideaDevice):
         self,
         attr: str,
         value: bool | float | str,
-    ) -> MessageNewProtocolSet:
+    ) -> NewProtocolSet:
         """Midea AC device make newprotocol message set."""
-        message = MessageNewProtocolSet(self._message_protocol_version)
+        message = NewProtocolSet(self._message_protocol_version)
 
         # wind_lr_angle
         if attr == DeviceAttributes.wind_lr_angle:
@@ -728,7 +728,7 @@ class MideaACDevice(MideaDevice):
         self,
         attr: str,
         value: bool | float | str,
-    ) -> MessageSubProtocolFreshAirSet:
+    ) -> SubProtocolFreshAirSet:
         """Build a BB fresh-air intake or exhaust single-control command."""
         exhaust = attr in {
             DeviceAttributes.fresh_air_exhaust_power,
@@ -778,16 +778,16 @@ class MideaACDevice(MideaDevice):
             if requested_speed is not None:
                 power = requested_speed > 0
                 speed = requested_speed or current_speed
-        return MessageSubProtocolFreshAirSet(
+        return SubProtocolFreshAirSet(
             self._message_protocol_version,
             power,
             speed,
             exhaust=exhaust,
         )
 
-    def make_message_uniq_set(self) -> MessageSubProtocolSet | MessageGeneralSet:
+    def make_message_uniq_set(self) -> MessageSubProtocolSet | MessageSet:
         """Midea AC device make message unique set."""
-        message: MessageSubProtocolSet | MessageGeneralSet
+        message: MessageSubProtocolSet | MessageSet
         if self._used_subprotocol:
             message = self.make_subprotocol_message_set()
         else:
@@ -798,11 +798,11 @@ class MideaACDevice(MideaDevice):
         """Midea AC device set attribute."""
         # if nat a sensor
         message: (
-            MessageToggleDisplay
-            | MessageNewProtocolSet
-            | MessageSubProtocolFreshAirSet
+            ToggleDisplay
+            | NewProtocolSet
+            | SubProtocolFreshAirSet
             | MessageSubProtocolSet
-            | MessageGeneralSet
+            | MessageSet
             | None
         ) = None
         optimistic_self_clean: bool | None = None
@@ -841,7 +841,7 @@ class MideaACDevice(MideaDevice):
                 if bool(value) != bool(
                     self._attributes[DeviceAttributes.screen_display],
                 ):
-                    message = MessageToggleDisplay(self._message_protocol_version)
+                    message = ToggleDisplay(self._message_protocol_version)
                     message.prompt_tone = self._attributes[DeviceAttributes.prompt_tone]
             elif self._model_capabilities.has_bb_fresh_air and attr in {
                 DeviceAttributes.fresh_air_power,
@@ -885,7 +885,7 @@ class MideaACDevice(MideaDevice):
                     DeviceAttributes.eco_mode,
                 ]:
                     message.boost_mode = False
-                    if isinstance(message, MessageGeneralSet):
+                    if isinstance(message, MessageSet):
                         message.power_saving = False
                     message.sleep_mode = False
                     message.eco_mode = False
@@ -927,9 +927,7 @@ class MideaACDevice(MideaDevice):
         zone: int | None = None,  # noqa: ARG002
     ) -> None:
         """Midea AC device set target temperature."""
-        message: MessageSubProtocolSet | MessageGeneralSet = (
-            self.make_message_uniq_set()
-        )
+        message: MessageSubProtocolSet | MessageSet = self.make_message_uniq_set()
         message.target_temperature = target_temperature
         if mode is not None:
             message.power = True
@@ -938,10 +936,8 @@ class MideaACDevice(MideaDevice):
 
     def set_swing(self, swing_vertical: bool, swing_horizontal: bool) -> None:
         """Midea AC device set swing."""
-        message: MessageSubProtocolSet | MessageGeneralSet = (
-            self.make_message_uniq_set()
-        )
-        if isinstance(message, MessageGeneralSet):
+        message: MessageSubProtocolSet | MessageSet = self.make_message_uniq_set()
+        if isinstance(message, MessageSet):
             message.swing_vertical = swing_vertical
             message.swing_horizontal = swing_horizontal
         self.build_send(message)

--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -300,7 +300,7 @@ class MessageQuery(MessageACBase):
         return query_body
 
 
-class MessageCapabilitiesQuery(MessageACBase):
+class CapabilitiesQuery(MessageACBase):
     """AC message capabilities query(queryType == "all_first_frame")."""
 
     def __init__(
@@ -323,7 +323,7 @@ class MessageCapabilitiesQuery(MessageACBase):
         return bytearray([0x01, 0x00])
 
 
-class MessageCapabilitiesAdditionalQuery(MessageCapabilitiesQuery):
+class CapabilitiesAdditionalQuery(CapabilitiesQuery):
     """AC message capabilities additional query(queryType == "all_second_frame")."""
 
     def __init__(
@@ -337,7 +337,7 @@ class MessageCapabilitiesAdditionalQuery(MessageCapabilitiesQuery):
         )
 
 
-class MessageGroupDataQuery(MessageACBase):
+class GroupDataQuery(MessageACBase):
     """AC message group data query(queryType == "group_data_<group>")."""
 
     _group = 0
@@ -364,43 +364,43 @@ class MessageGroupDataQuery(MessageACBase):
         return body
 
 
-class MessageGroupZeroQuery(MessageGroupDataQuery):
+class GroupZeroQuery(GroupDataQuery):
     """AC message power query(queryType == "group_data_zero")."""
 
     _group = 0
 
 
-class MessageGroupOneQuery(MessageGroupDataQuery):
+class GroupOneQuery(GroupDataQuery):
     """AC message compressor query(queryType == "group_data_one")."""
 
     _group = 1
 
 
-class MessageGroupTwoQuery(MessageGroupDataQuery):
+class GroupTwoQuery(GroupDataQuery):
     """AC message indoor fan query(queryType == "group_data_two")."""
 
     _group = 2
 
 
-class MessagePowerQuery(MessageGroupDataQuery):
+class PowerQuery(GroupDataQuery):
     """AC message power query(queryType == "group_data_four")."""
 
     _group = 4
 
 
-class MessageHumidityQuery(MessageGroupDataQuery):
+class HumidityQuery(GroupDataQuery):
     """AC message query indoor humidity(queryType == "group_data_five")."""
 
     _group = 5
 
 
-class MessageGroupSevenQuery(MessageGroupDataQuery):
+class GroupSevenQuery(GroupDataQuery):
     """AC message compressor power query(queryType == "group_data_seven")."""
 
     _group = 7
 
 
-class MessageToggleDisplay(MessageACBase):
+class ToggleDisplay(MessageACBase):
     """AC message toggle display."""
 
     def __init__(self, protocol_version: int) -> None:
@@ -440,7 +440,7 @@ class MessageToggleDisplay(MessageACBase):
         )
 
 
-class MessageNewProtocolQuery(MessageACBase):
+class NewProtocolQuery(MessageACBase):
     """AC message new protocol query."""
 
     _query_params: tuple[int, ...] = (
@@ -490,7 +490,7 @@ class MessageNewProtocolQuery(MessageACBase):
         return _body
 
 
-class MessageNewProtocolSelfCleanQuery(MessageNewProtocolQuery):
+class NewProtocolSelfCleanQuery(NewProtocolQuery):
     """AC message new protocol self-clean query.
 
     A device answers with an empty parameter list when a query carries a tag it
@@ -546,7 +546,7 @@ class MessageSubProtocol(MessageACBase):
         return _body
 
 
-class MessageSubProtocolQuery(MessageSubProtocol):
+class SubProtocolQuery(MessageSubProtocol):
     """AC message sub protocol query."""
 
     def __init__(
@@ -562,7 +562,7 @@ class MessageSubProtocolQuery(MessageSubProtocol):
         )
 
 
-class MessageSubProtocolQuery10(MessageSubProtocolQuery):
+class SubProtocolQuery10(SubProtocolQuery):
     """AC sub protocol indoor status query."""
 
     def __init__(self, protocol_version: int) -> None:
@@ -570,7 +570,7 @@ class MessageSubProtocolQuery10(MessageSubProtocolQuery):
         super().__init__(protocol_version, ListTypes.X10)
 
 
-class MessageSubProtocolQuery11(MessageSubProtocolQuery):
+class SubProtocolQuery11(SubProtocolQuery):
     """AC sub protocol basic status query."""
 
     def __init__(self, protocol_version: int) -> None:
@@ -578,7 +578,7 @@ class MessageSubProtocolQuery11(MessageSubProtocolQuery):
         super().__init__(protocol_version, ListTypes.X11)
 
 
-class MessageSubProtocolQuery30(MessageSubProtocolQuery):
+class SubProtocolQuery30(SubProtocolQuery):
     """AC sub protocol outdoor status query."""
 
     def __init__(self, protocol_version: int) -> None:
@@ -670,7 +670,7 @@ class MessageSubProtocolSet(MessageSubProtocol):
         )
 
 
-class MessageSubProtocolFreshAirSet(MessageSubProtocol):
+class SubProtocolFreshAirSet(MessageSubProtocol):
     """AC BB C0/02 single-control fresh-air command."""
 
     def __init__(
@@ -721,7 +721,7 @@ class MessageSubProtocolFreshAirSet(MessageSubProtocol):
         return body
 
 
-class MessageGeneralSet(MessageACBase):
+class MessageSet(MessageACBase):
     """AC message general set."""
 
     def __init__(self, protocol_version: int) -> None:
@@ -817,7 +817,7 @@ class MessageGeneralSet(MessageACBase):
         )
 
 
-class MessageNewProtocolSet(MessageACBase):
+class NewProtocolSet(MessageACBase):
     """AC message new protocol set."""
 
     def __init__(self, protocol_version: int) -> None:
@@ -965,7 +965,7 @@ class MessageNewProtocolSet(MessageACBase):
         return payload
 
 
-class XA0MessageBody(MessageBody):
+class XA0Body(MessageBody):
     """AC A0 message body."""
 
     def __init__(self, body: bytearray) -> None:
@@ -1042,7 +1042,7 @@ class XMessageBody(MessageBody):
         return int(temp_integer) + decimal * 0.1
 
 
-class XA1MessageBody(XMessageBody):
+class XA1Body(XMessageBody):
     """AC A1 message body."""
 
     def __init__(self, body: bytearray) -> None:
@@ -1060,8 +1060,8 @@ class XA1MessageBody(XMessageBody):
         self.indoor_humidity = body[17] if body[17] != 0 else None
 
 
-class XBXMessageBody(NewProtocolMessageBody):
-    """AC BX message body. body[0] b0/b1, body[1] propertyNumber, cursor 2."""
+class PropertiesBody(NewProtocolMessageBody):
+    """AC Bx message body. body[0] b0/b1, body[1] propertyNumber, cursor 2."""
 
     def __init__(
         self,
@@ -1069,7 +1069,7 @@ class XBXMessageBody(NewProtocolMessageBody):
         bt: int,
         new_protocol_temperature: bool = False,
     ) -> None:
-        """Initialize AC BX message body."""
+        """Initialize AC Bx message body."""
         super().__init__(body, bt)
 
         params = self.parse()
@@ -1179,11 +1179,11 @@ class XBXMessageBody(NewProtocolMessageBody):
         return True
 
 
-class XB5MessageBody(NewProtocolMessageBody):
-    """AC B5 message body. body[0] b5, body[1] propertyNumber, cursor 2."""
+class CapabilityBody(NewProtocolMessageBody):
+    """AC B5 capability response body. body[0] b5, body[1] propertyNumber."""
 
     def __init__(self, body: bytearray, bt: int) -> None:
-        """Initialize AC BX message body."""
+        """Initialize AC B5 capability response message body."""
         super().__init__(body, bt)
 
         params = self.parse()
@@ -1266,7 +1266,7 @@ class XB5MessageBody(NewProtocolMessageBody):
         self.capabilities = caps
 
 
-class XC0MessageBody(XMessageBody):
+class StateBody(XMessageBody):
     """AC C0 message body."""
 
     def __init__(self, body: bytearray) -> None:
@@ -1329,7 +1329,7 @@ class XC0MessageBody(XMessageBody):
             self.fresh_filter_timeout = (body[13] & 0x40) >> 6
 
 
-class XC1MessageBody(MessageBody):
+class GroupBody(MessageBody):
     """AC C1 message body."""
 
     def __init__(self, body: bytearray, analysis_method: int = 3) -> None:
@@ -1484,7 +1484,7 @@ class XC1MessageBody(MessageBody):
         return cls.parse_value(analysis_method, databytes) / divisor
 
 
-class XBBMessageBody(MessageBody):
+class SubProtocolBody(MessageBody):
     """AC BB message body."""
 
     def __init__(self, body: bytearray) -> None:
@@ -1589,16 +1589,16 @@ class MessageACResponse(MessageResponse):
         super().__init__(message)
         # dataType 0x05 and messageBytes[0] 0xA0
         if self.message_type == MessageType.notify2 and self.body_type == ListTypes.A0:
-            self.set_body(XA0MessageBody(super().body))
+            self.set_body(XA0Body(super().body))
         # dataType 0x04 and messageBytes[0] 0xA1
         elif (
             self.message_type == MessageType.notify1 and self.body_type == ListTypes.A1
         ):
-            self.set_body(XA1MessageBody(super().body))
-        # parse MessageCapabilitiesQuery/MessageCapabilitiesAdditionalQuery response
+            self.set_body(XA1Body(super().body))
+        # parse CapabilitiesQuery/CapabilitiesAdditionalQuery response
         # dataType 0x03 and messageBytes[0] 0xB5
         elif self.message_type == MessageType.query and self.body_type == ListTypes.B5:
-            self.set_body(XB5MessageBody(super().body, self.body_type))
+            self.set_body(CapabilityBody(super().body, self.body_type))
         # dataType 0x05 and messageBytes[0] 0xB5
         # dataType 0x02 and messageBytes[0] 0xB0 (set result Unidentified protocol)
         # dataType 0x03 and messageBytes[0] 0xB1
@@ -1608,7 +1608,11 @@ class MessageACResponse(MessageResponse):
             MessageType.notify2,
         ] and self.body_type in [ListTypes.B0, ListTypes.B1, ListTypes.B5]:
             self.set_body(
-                XBXMessageBody(super().body, self.body_type, new_protocol_temperature),
+                PropertiesBody(
+                    super().body,
+                    self.body_type,
+                    new_protocol_temperature,
+                ),
             )
         # dataType 0x02 and messageBytes[0] 0xC0
         # dataType 0x03 and messageBytes[0] 0xC0
@@ -1616,10 +1620,10 @@ class MessageACResponse(MessageResponse):
             self.message_type in [MessageType.query, MessageType.set]
             and self.body_type == ListTypes.C0
         ):
-            self.set_body(XC0MessageBody(super().body))
+            self.set_body(StateBody(super().body))
         # messageBytes[0] 0xC1
         elif self.message_type == MessageType.query and self.body_type == ListTypes.C1:
-            self.set_body(XC1MessageBody(super().body, power_analysis_method))
+            self.set_body(GroupBody(super().body, power_analysis_method))
         elif (
             self.message_type
             in [MessageType.set, MessageType.query, MessageType.notify2]
@@ -1627,6 +1631,6 @@ class MessageACResponse(MessageResponse):
             and len(super().body) >= BB_MIN_BODY_LENGTH
         ):
             self.used_subprotocol = True
-            self.set_body(XBBMessageBody(super().body))
+            self.set_body(SubProtocolBody(super().body))
 
         self.set_attr()

--- a/midealan/devices/e2/__init__.py
+++ b/midealan/devices/e2/__init__.py
@@ -11,10 +11,10 @@ from midealan.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import (
     MessageE2Response,
-    MessageNewProtocolSet,
     MessagePower,
     MessageQuery,
     MessageSet,
+    NewProtocolSet,
 )
 
 
@@ -221,7 +221,7 @@ class MideaE2Device(MideaDevice):
 
     def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea E2 device set attribute."""
-        message: MessagePower | MessageSet | MessageNewProtocolSet | None = None
+        message: MessagePower | MessageSet | NewProtocolSet | None = None
         if attr not in [
             DeviceAttributes.heating,
             DeviceAttributes.keep_warm,
@@ -252,7 +252,7 @@ class MideaE2Device(MideaDevice):
                     return
                 setattr(message, str(attr), value)
             else:
-                message = MessageNewProtocolSet(self._message_protocol_version)
+                message = NewProtocolSet(self._message_protocol_version)
                 setattr(message, str(attr), value)
             self.build_send(message)
 

--- a/midealan/devices/e2/message.py
+++ b/midealan/devices/e2/message.py
@@ -74,7 +74,7 @@ class MessagePower(MessageE2Base):
         return bytearray([0x01])
 
 
-class MessageNewProtocolSet(MessageE2Base):
+class NewProtocolSet(MessageE2Base):
     """E2 message new protocol set(T_0000_E2_24.lua:flag == false: else)."""
 
     def __init__(self, protocol_version: int) -> None:

--- a/midealan/devices/e3/__init__.py
+++ b/midealan/devices/e3/__init__.py
@@ -10,10 +10,10 @@ from midealan.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import (
     MessageE3Response,
-    MessageNewProtocolSet,
     MessagePower,
     MessageQuery,
     MessageSet,
+    NewProtocolSet,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -110,7 +110,7 @@ class MideaE3Device(MideaDevice):
 
     def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea E3 device set attribute."""
-        message: MessagePower | MessageSet | MessageNewProtocolSet | None = None
+        message: MessagePower | MessageSet | NewProtocolSet | None = None
         if attr not in [
             DeviceAttributes.burning_state,
             DeviceAttributes.current_temperature,
@@ -125,7 +125,7 @@ class MideaE3Device(MideaDevice):
                 message = self.make_message_set()
                 setattr(message, str(attr), value)
             else:
-                message = MessageNewProtocolSet(self._message_protocol_version)
+                message = NewProtocolSet(self._message_protocol_version)
                 message.key = str(attr)
                 message.value = value
             self.build_send(message)

--- a/midealan/devices/e3/message.py
+++ b/midealan/devices/e3/message.py
@@ -131,7 +131,7 @@ class MessageSet(MessageE3Base):
         )
 
 
-class MessageNewProtocolSet(MessageE3Base):
+class NewProtocolSet(MessageE3Base):
     """E3 message new protocol set."""
 
     def __init__(self, protocol_version: int) -> None:

--- a/tests/devices/a1/message_a1_test.py
+++ b/tests/devices/a1/message_a1_test.py
@@ -142,6 +142,12 @@ class TestNewProtocolSet:
         msg_set.light = True
         expected_body = bytearray(b"\xb0\x01[\x00\x01\x01")
         assert msg_set.body[:-2] == expected_body
+        msg_set.light = False
+        expected_body = bytearray(b"\xb0\x01[\x00\x01\x00")
+        assert msg_set.body[:-2] == expected_body
+        msg_set.light = None
+        expected_body = bytearray(b"\xb0\x00")
+        assert msg_set.body[:-2] == expected_body
 
 
 class TestMessageA1Response:
@@ -164,6 +170,7 @@ class TestMessageA1Response:
             ],
         )
         body = bytearray(21)
+        body[0] = 0xA0
         body[1] = 0b00000001  # Power on (1)
         body[2] = 0b00000010  # Mode (2)
         body[3] = 0b00000100  # Fan speed (4)

--- a/tests/devices/a1/message_a1_test.py
+++ b/tests/devices/a1/message_a1_test.py
@@ -6,10 +6,10 @@ from midealan.const import ProtocolVersion
 from midealan.devices.a1.message import (
     MessageA1Base,
     MessageA1Response,
-    MessageNewProtocolQuery,
-    MessageNewProtocolSet,
     MessageQuery,
     MessageSet,
+    NewProtocolQuery,
+    NewProtocolSet,
     NewProtocolTags,
 )
 from midealan.message import ListTypes, MessageType
@@ -84,12 +84,12 @@ class TestMessageQuery:
         assert query.body[:-2] == expected_body
 
 
-class TestMessageNewProtocolQuery:
+class TestNewProtocolQuery:
     """Test Message New Protocol Query."""
 
     def test_new_protocol_query_body(self) -> None:
         """Test new protocol query body."""
-        query = MessageNewProtocolQuery(protocol_version=ProtocolVersion.V1)
+        query = NewProtocolQuery(protocol_version=ProtocolVersion.V1)
         expected_body = bytearray(
             [0xB1, 1, NewProtocolTags.light & 0xFF, NewProtocolTags.light >> 8],
         )
@@ -133,12 +133,12 @@ class TestMessageSet:
         assert msg_set.body[:-2] == expected_body
 
 
-class TestMessageNewProtocolSet:
+class TestNewProtocolSet:
     """Test Message New Protocol Set."""
 
     def test_new_protocol_set_body(self) -> None:
         """Test new protocol set body."""
-        msg_set = MessageNewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg_set = NewProtocolSet(protocol_version=ProtocolVersion.V1)
         msg_set.light = True
         expected_body = bytearray(b"\xb0\x01[\x00\x01\x01")
         assert msg_set.body[:-2] == expected_body

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -8,25 +8,25 @@ import pytest
 from midealan.const import ProtocolVersion
 from midealan.devices.ac import DeviceAttributes, MideaACDevice
 from midealan.devices.ac.message import (
-    MessageCapabilitiesAdditionalQuery,
-    MessageCapabilitiesQuery,
-    MessageGroupOneQuery,
-    MessageGroupSevenQuery,
-    MessageGroupTwoQuery,
-    MessageGroupZeroQuery,
-    MessageHumidityQuery,
-    MessageNewProtocolQuery,
-    MessageNewProtocolSelfCleanQuery,
-    MessagePowerQuery,
+    CapabilitiesAdditionalQuery,
+    CapabilitiesQuery,
+    GroupOneQuery,
+    GroupSevenQuery,
+    GroupTwoQuery,
+    GroupZeroQuery,
+    HumidityQuery,
     MessageQuery,
-    MessageSubProtocolFreshAirSet,
-    MessageSubProtocolQuery,
-    MessageSubProtocolQuery10,
-    MessageSubProtocolQuery11,
-    MessageSubProtocolQuery30,
-    MessageToggleDisplay,
+    NewProtocolQuery,
+    NewProtocolSelfCleanQuery,
     NewProtocolTags,
     PowerFormats,
+    PowerQuery,
+    SubProtocolFreshAirSet,
+    SubProtocolQuery,
+    SubProtocolQuery10,
+    SubProtocolQuery11,
+    SubProtocolQuery30,
+    ToggleDisplay,
 )
 from midealan.message import ListTypes, MessageBase
 
@@ -216,7 +216,7 @@ class TestMideaACDevice:
 
         The firmware exposes a toggle-only command, so setting the switch to
         its current state must send nothing; only a differing request emits a
-        single MessageToggleDisplay.
+        single ToggleDisplay.
         https://github.com/wuwentao/midea_ac_lan/issues/623
         """
         with patch.object(self.device, "build_send") as mock_build_send:
@@ -228,7 +228,7 @@ class TestMideaACDevice:
             # Currently off: turning on sends one toggle.
             self.device.set_attribute(DeviceAttributes.screen_display.value, True)
             mock_build_send.assert_called_once()
-            assert isinstance(mock_build_send.call_args[0][0], MessageToggleDisplay)
+            assert isinstance(mock_build_send.call_args[0][0], ToggleDisplay)
 
             mock_build_send.reset_mock()
 
@@ -240,7 +240,7 @@ class TestMideaACDevice:
             # Currently on: turning off sends one toggle.
             self.device.set_attribute(DeviceAttributes.screen_display.value, False)
             mock_build_send.assert_called_once()
-            assert isinstance(mock_build_send.call_args[0][0], MessageToggleDisplay)
+            assert isinstance(mock_build_send.call_args[0][0], ToggleDisplay)
 
     def test_set_attribute_eco_mode_resets_exclusive_modes(self) -> None:
         """Test eco mode set resets comfort and frost protect on general set."""
@@ -305,24 +305,24 @@ class TestMideaACDevice:
         self.device._used_subprotocol = True
         queries = self.device.build_query()
         assert len(queries) == 3
-        assert isinstance(queries[0], MessageSubProtocolQuery)
-        assert isinstance(queries[1], MessageSubProtocolQuery)
-        assert isinstance(queries[2], MessageSubProtocolQuery)
+        assert isinstance(queries[0], SubProtocolQuery)
+        assert isinstance(queries[1], SubProtocolQuery)
+        assert isinstance(queries[2], SubProtocolQuery)
 
         self.device._used_subprotocol = False
         queries = self.device.build_query()
         assert len(queries) == 11
         assert isinstance(queries[0], MessageQuery)
-        assert isinstance(queries[1], MessageNewProtocolQuery)
-        assert isinstance(queries[2], MessageNewProtocolSelfCleanQuery)
-        assert isinstance(queries[3], MessagePowerQuery)
-        assert isinstance(queries[4], MessageHumidityQuery)
-        assert isinstance(queries[5], MessageGroupZeroQuery)
-        assert isinstance(queries[6], MessageGroupOneQuery)
-        assert isinstance(queries[7], MessageGroupTwoQuery)
-        assert isinstance(queries[8], MessageGroupSevenQuery)
-        assert isinstance(queries[9], MessageCapabilitiesQuery)
-        assert isinstance(queries[10], MessageCapabilitiesAdditionalQuery)
+        assert isinstance(queries[1], NewProtocolQuery)
+        assert isinstance(queries[2], NewProtocolSelfCleanQuery)
+        assert isinstance(queries[3], PowerQuery)
+        assert isinstance(queries[4], HumidityQuery)
+        assert isinstance(queries[5], GroupZeroQuery)
+        assert isinstance(queries[6], GroupOneQuery)
+        assert isinstance(queries[7], GroupTwoQuery)
+        assert isinstance(queries[8], GroupSevenQuery)
+        assert isinstance(queries[9], CapabilitiesQuery)
+        assert isinstance(queries[10], CapabilitiesAdditionalQuery)
 
     def test_build_query_omits_rate_select_until_capability_confirmed(self) -> None:
         """Test rate_select stays out of the B1 query until b5_electricity confirms it.
@@ -333,16 +333,12 @@ class TestMideaACDevice:
         self.device._used_subprotocol = False
         assert self.device.capabilities == {}
         queries = self.device.build_query()
-        new_protocol_query = next(
-            q for q in queries if isinstance(q, MessageNewProtocolQuery)
-        )
+        new_protocol_query = next(q for q in queries if isinstance(q, NewProtocolQuery))
         assert NewProtocolTags.rate_select not in new_protocol_query._body
 
         self.device._capabilities["rate_select"] = True
         queries = self.device.build_query()
-        new_protocol_query = next(
-            q for q in queries if isinstance(q, MessageNewProtocolQuery)
-        )
+        new_protocol_query = next(q for q in queries if isinstance(q, NewProtocolQuery))
         assert NewProtocolTags.rate_select in new_protocol_query._body
 
     def test_bb_model_builds_distinct_queries_and_attributes(self) -> None:
@@ -352,9 +348,9 @@ class TestMideaACDevice:
         queries = device.build_query()
 
         assert [type(query) for query in queries] == [
-            MessageSubProtocolQuery10,
-            MessageSubProtocolQuery11,
-            MessageSubProtocolQuery30,
+            SubProtocolQuery10,
+            SubProtocolQuery11,
+            SubProtocolQuery30,
         ]
         assert DeviceAttributes.compressor_frequency in device.attributes
         assert DeviceAttributes.target_compressor_frequency in device.attributes
@@ -387,9 +383,7 @@ class TestMideaACDevice:
         assert not any(
             isinstance(
                 query,
-                MessageSubProtocolQuery10
-                | MessageSubProtocolQuery11
-                | MessageSubProtocolQuery30,
+                SubProtocolQuery10 | SubProtocolQuery11 | SubProtocolQuery30,
             )
             for query in queries
         )
@@ -456,14 +450,14 @@ class TestMideaACDevice:
         with patch.object(device, "build_send") as build_send:
             device.set_attribute(DeviceAttributes.fresh_air_mode, "medium")
             intake = build_send.call_args.args[0]
-            assert isinstance(intake, MessageSubProtocolFreshAirSet)
+            assert isinstance(intake, SubProtocolFreshAirSet)
             assert intake.power is True
             assert intake.speed == 60
             assert intake.exhaust is False
 
             device.set_attribute(DeviceAttributes.fresh_air_exhaust_mode, "high")
             exhaust = build_send.call_args.args[0]
-            assert isinstance(exhaust, MessageSubProtocolFreshAirSet)
+            assert isinstance(exhaust, SubProtocolFreshAirSet)
             assert exhaust.power is True
             assert exhaust.speed == 80
             assert exhaust.exhaust is True
@@ -481,7 +475,7 @@ class TestMideaACDevice:
             device.set_attribute(DeviceAttributes.fresh_air_exhaust_power, True)
 
         message = build_send.call_args.args[0]
-        assert isinstance(message, MessageSubProtocolFreshAirSet)
+        assert isinstance(message, SubProtocolFreshAirSet)
         assert message.power is True
         assert message.speed == 80
         assert message.exhaust is True
@@ -492,14 +486,14 @@ class TestMideaACDevice:
         with patch.object(device, "build_send") as build_send:
             device.set_attribute(DeviceAttributes.fresh_air_fan_speed, 55)
             intake = build_send.call_args.args[0]
-            assert isinstance(intake, MessageSubProtocolFreshAirSet)
+            assert isinstance(intake, SubProtocolFreshAirSet)
             assert intake.power is True
             assert intake.speed == 55
             assert intake.exhaust is False
 
             device.set_attribute(DeviceAttributes.fresh_air_exhaust_speed, 30)
             exhaust = build_send.call_args.args[0]
-            assert isinstance(exhaust, MessageSubProtocolFreshAirSet)
+            assert isinstance(exhaust, SubProtocolFreshAirSet)
             assert exhaust.power is True
             assert exhaust.speed == 30
             assert exhaust.exhaust is True

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -5,32 +5,32 @@ import pytest
 from midealan.const import ProtocolVersion
 from midealan.crc8 import calculate
 from midealan.devices.ac.message import (
+    CapabilitiesQuery,
+    GroupDataQuery,
+    GroupOneQuery,
+    GroupSevenQuery,
+    GroupTwoQuery,
+    GroupZeroQuery,
+    HumidityQuery,
     MessageA0LongQuery,
     MessageA0Query,
     MessageACBase,
     MessageACResponse,
-    MessageCapabilitiesQuery,
-    MessageGeneralSet,
-    MessageGroupDataQuery,
-    MessageGroupOneQuery,
-    MessageGroupSevenQuery,
-    MessageGroupTwoQuery,
-    MessageGroupZeroQuery,
-    MessageHumidityQuery,
-    MessageNewProtocolQuery,
-    MessageNewProtocolSelfCleanQuery,
-    MessageNewProtocolSet,
-    MessagePowerQuery,
     MessageQuery,
+    MessageSet,
     MessageSubProtocol,
-    MessageSubProtocolFreshAirSet,
-    MessageSubProtocolQuery10,
-    MessageSubProtocolQuery11,
-    MessageSubProtocolQuery30,
     MessageSubProtocolSet,
-    MessageToggleDisplay,
+    NewProtocolQuery,
+    NewProtocolSelfCleanQuery,
+    NewProtocolSet,
     NewProtocolTags,
     PowerFormats,
+    PowerQuery,
+    SubProtocolFreshAirSet,
+    SubProtocolQuery10,
+    SubProtocolQuery11,
+    SubProtocolQuery30,
+    ToggleDisplay,
 )
 from midealan.message import ListTypes, MessageBase, MessageType
 
@@ -104,12 +104,12 @@ class TestMessageQuery:
         assert msg.body[:-2] == expected_body
 
 
-class TestMessageCapabilitiesQuery:
+class TestCapabilitiesQuery:
     """Test Message Capabilities Query."""
 
     def test_capabilities_query_body(self) -> None:
         """Test capabilities query body."""
-        msg = MessageCapabilitiesQuery(ProtocolVersion.V1, False)
+        msg = CapabilitiesQuery(ProtocolVersion.V1, False)
         expected_body = bytearray(
             [0xB5, 0x01, 0x00],
         )
@@ -117,7 +117,7 @@ class TestMessageCapabilitiesQuery:
 
     def test_capabilities_query_body_additional(self) -> None:
         """Test capabilities query body."""
-        msg = MessageCapabilitiesQuery(ProtocolVersion.V1, True)
+        msg = CapabilitiesQuery(ProtocolVersion.V1, True)
         expected_body = bytearray(
             [0xB5, 0x01, 0x01, 0x01],
         )
@@ -141,33 +141,33 @@ class TestMessageA0Query:
         assert msg.body[:-2] == expected_body
 
 
-class TestMessagePowerQuery:
+class TestPowerQuery:
     """Test Message Power Query."""
 
     def test_power_query_body(self) -> None:
         """Test power query body."""
-        msg = MessagePowerQuery(protocol_version=ProtocolVersion.V1)
+        msg = PowerQuery(protocol_version=ProtocolVersion.V1)
         expected_body = bytearray([0x41, 0x21, 0x01, 0x44, 0x00, 0x01])
         assert msg.body[:-1] == expected_body
 
 
-class TestMessageGroupDataQuery:
+class TestGroupDataQuery:
     """Test Message Group Data Query."""
 
     @pytest.mark.parametrize(
         ("message_class", "group"),
         [
-            (MessageGroupZeroQuery, 0),
-            (MessageGroupOneQuery, 1),
-            (MessageGroupTwoQuery, 2),
-            (MessagePowerQuery, 4),
-            (MessageHumidityQuery, 5),
-            (MessageGroupSevenQuery, 7),
+            (GroupZeroQuery, 0),
+            (GroupOneQuery, 1),
+            (GroupTwoQuery, 2),
+            (PowerQuery, 4),
+            (HumidityQuery, 5),
+            (GroupSevenQuery, 7),
         ],
     )
     def test_group_query_body(
         self,
-        message_class: type[MessageGroupDataQuery],
+        message_class: type[GroupDataQuery],
         group: int,
     ) -> None:
         """Test that every group query encodes its group number."""
@@ -176,32 +176,32 @@ class TestMessageGroupDataQuery:
         assert msg.body[:-1] == expected_body
 
 
-class TestMessageGroupZeroQuery:
+class TestGroupZeroQuery:
     """Test Message Group Zero Query."""
 
     def test_group_zero_query_body(self) -> None:
         """Test group zero query body."""
-        msg = MessageGroupZeroQuery(protocol_version=ProtocolVersion.V1)
+        msg = GroupZeroQuery(protocol_version=ProtocolVersion.V1)
         expected_body = bytearray([0x41, 0x21, 0x01, 0x40, 0x00, 0x01])
         assert msg.body[:-1] == expected_body
 
 
-class TestMessageHumidityQuery:
+class TestHumidityQuery:
     """Test Message Humidity Query."""
 
     def test_humidity_query_body(self) -> None:
         """Test humidity query body."""
-        msg = MessageHumidityQuery(protocol_version=ProtocolVersion.V1)
+        msg = HumidityQuery(protocol_version=ProtocolVersion.V1)
         expected_body = bytearray([0x41, 0x21, 0x01, 0x45, 0x00, 0x01])
         assert msg.body[:-1] == expected_body
 
 
-class TestMessageToggleDisplay:
+class TestToggleDisplay:
     """Test Message Toggle Display."""
 
     def test_toggle_disply_body(self) -> None:
         """Test toggle display body."""
-        msg = MessageToggleDisplay(protocol_version=ProtocolVersion.V1)
+        msg = ToggleDisplay(protocol_version=ProtocolVersion.V1)
         expected_body = bytearray(
             [
                 0x41,
@@ -255,7 +255,7 @@ class TestMessageToggleDisplay:
         assert msg.body[:-2] == expected_body
 
 
-class TestMessageNewProtocolQuery:
+class TestNewProtocolQuery:
     """Test Message New Protocol Query."""
 
     def test_new_protocol_query_body(self) -> None:
@@ -265,7 +265,7 @@ class TestMessageNewProtocolQuery:
         via the B5 b5_electricity capability; devices that never advertise it
         don't answer the query.
         """
-        msg = MessageNewProtocolQuery(protocol_version=ProtocolVersion.V1)
+        msg = NewProtocolQuery(protocol_version=ProtocolVersion.V1)
         expected_body = bytearray(
             [
                 0xB1,
@@ -301,7 +301,7 @@ class TestMessageNewProtocolQuery:
         self,
     ) -> None:
         """Test rate_select is appended once the device has advertised support."""
-        msg = MessageNewProtocolQuery(
+        msg = NewProtocolQuery(
             protocol_version=ProtocolVersion.V1,
             supports_rate_select=True,
         )
@@ -340,7 +340,7 @@ class TestMessageNewProtocolQuery:
 
     def test_new_protocol_self_clean_query_body(self) -> None:
         """Test new protocol self-clean query body."""
-        msg = MessageNewProtocolSelfCleanQuery(protocol_version=ProtocolVersion.V1)
+        msg = NewProtocolSelfCleanQuery(protocol_version=ProtocolVersion.V1)
         expected_body = bytearray(
             [
                 0xB1,
@@ -352,7 +352,7 @@ class TestMessageNewProtocolQuery:
         assert msg.body[:-2] == expected_body
 
 
-class TestMessageNewProtocolSetOutSilent:
+class TestNewProtocolSetOutSilent:
     """Test Message New Protocol Set for out_silent."""
 
     @pytest.mark.parametrize(
@@ -361,7 +361,7 @@ class TestMessageNewProtocolSetOutSilent:
     )
     def test_out_silent_on_off(self, value: bool, expected_byte: int) -> None:
         """Test out_silent set to on/off sends correct byte."""
-        msg = MessageNewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
         msg.out_silent = value
         body = msg.body
         assert body[0] == 0xB0
@@ -373,14 +373,14 @@ class TestMessageNewProtocolSetOutSilent:
 
     def test_out_silent_none_not_packed(self) -> None:
         """Test out_silent None does not add to payload."""
-        msg = MessageNewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
         # out_silent defaults to None, should not be packed
         body = msg.body
         assert body[0] == 0xB0
         assert body[1] == 0x00  # 0 params packed
 
 
-class TestMessageNewProtocolSetAngles:
+class TestNewProtocolSetAngles:
     """Test Message New Protocol Set for wind angles and rate select."""
 
     @pytest.mark.parametrize(
@@ -389,7 +389,7 @@ class TestMessageNewProtocolSetAngles:
     )
     def test_wind_lr_angle(self, value: int, expected_byte: int) -> None:
         """Test wind_lr_angle set sends correct byte."""
-        msg = MessageNewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
         # source annotates wind_lr_angle as bytes | None but the device sets ints
         setattr(msg, "wind_lr_angle", value)  # noqa: B010
         body = msg.body
@@ -406,7 +406,7 @@ class TestMessageNewProtocolSetAngles:
     )
     def test_wind_ud_angle(self, value: int, expected_byte: int) -> None:
         """Test wind_ud_angle set sends correct byte."""
-        msg = MessageNewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
         # source annotates wind_ud_angle as bytes | None but the device sets ints
         setattr(msg, "wind_ud_angle", value)  # noqa: B010
         body = msg.body
@@ -419,7 +419,7 @@ class TestMessageNewProtocolSetAngles:
 
     def test_rate_select(self) -> None:
         """Test rate_select set sends correct byte."""
-        msg = MessageNewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
         msg.rate_select = 60
         body = msg.body
         assert body[0] == 0xB0
@@ -455,26 +455,26 @@ class TestMessageSubProtocol:
     def test_distinct_query_classes(self) -> None:
         """Test BB queries have independent protocol identities."""
         queries = [
-            MessageSubProtocolQuery10(ProtocolVersion.V1),
-            MessageSubProtocolQuery11(ProtocolVersion.V1),
-            MessageSubProtocolQuery30(ProtocolVersion.V1),
+            SubProtocolQuery10(ProtocolVersion.V1),
+            SubProtocolQuery11(ProtocolVersion.V1),
+            SubProtocolQuery30(ProtocolVersion.V1),
         ]
 
         assert [query.body[5] for query in queries] == [0x10, 0x11, 0x30]
         assert len({query.__class__.__name__ for query in queries}) == 3
 
 
-class TestMessageGroupOneQuery:
+class TestGroupOneQuery:
     """Test AC C1 group 0x41 query."""
 
     def test_query_body(self) -> None:
         """Test exact group 0x41 query body."""
-        message = MessageGroupOneQuery(ProtocolVersion.V1)
+        message = GroupOneQuery(ProtocolVersion.V1)
 
         assert message.body.hex() == "4121014100013c"
 
 
-class TestMessageSubProtocolFreshAirSet:
+class TestSubProtocolFreshAirSet:
     """Test BB fresh-air single-control commands."""
 
     @pytest.mark.parametrize(
@@ -534,7 +534,7 @@ class TestMessageSubProtocolFreshAirSet:
         expected: str,
     ) -> None:
         """Test exact intake and exhaust command bytes."""
-        message = MessageSubProtocolFreshAirSet(
+        message = SubProtocolFreshAirSet(
             ProtocolVersion.V1,
             power,
             speed,
@@ -624,12 +624,12 @@ class TestMessageSubProtocolSet:
         assert msg.body[:-2] == expected_body
 
 
-class TestMessageGeneralSet:
+class TestMessageSet:
     """Test Message General Set."""
 
     def test_general_set_body(self) -> None:
         """Test general set body."""
-        msg = MessageGeneralSet(protocol_version=ProtocolVersion.V1)
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
         expected_body = bytearray(
             [
                 0x40,
@@ -2070,8 +2070,8 @@ class TestMessageACResponse:
         assert not hasattr(response, "outdoor_temperature")
 
 
-class TestMessageNewProtocolSetNewFeatures:
-    """Test MessageNewProtocolSet for sound and self_clean."""
+class TestNewProtocolSetNewFeatures:
+    """Test NewProtocolSet for sound and self_clean."""
 
     @pytest.mark.parametrize(
         ("value", "expected_byte"),
@@ -2079,7 +2079,7 @@ class TestMessageNewProtocolSetNewFeatures:
     )
     def test_sound_on_off(self, value: bool, expected_byte: int) -> None:
         """Test sound set to on/off sends correct byte."""
-        msg = MessageNewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
         msg.sound = value
         body = msg.body
         assert body[0] == 0xB0
@@ -2095,7 +2095,7 @@ class TestMessageNewProtocolSetNewFeatures:
     )
     def test_self_clean_on_off(self, value: bool, expected_byte: int) -> None:
         """Test self_clean set to on/off sends correct byte."""
-        msg = MessageNewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
         msg.self_clean = value
         body = msg.body
         assert body[0] == 0xB0
@@ -2106,8 +2106,8 @@ class TestMessageNewProtocolSetNewFeatures:
         assert body[5] == expected_byte
 
 
-class TestMessageGeneralSetAnion:
-    """Test MessageGeneralSet anion (purifier) bit."""
+class TestMessageSetAnion:
+    """Test MessageSet anion (purifier) bit."""
 
     @pytest.mark.parametrize(
         ("value", "expected_bit"),
@@ -2115,6 +2115,6 @@ class TestMessageGeneralSetAnion:
     )
     def test_anion_bit_in_body(self, value: bool, expected_bit: int) -> None:
         """Test anion sets bit 0x20 in body byte index 8."""
-        msg = MessageGeneralSet(protocol_version=ProtocolVersion.V1)
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
         msg.anion = value
         assert msg._body[8] & 0x20 == expected_bit

--- a/tests/devices/e2/device_e2_test.py
+++ b/tests/devices/e2/device_e2_test.py
@@ -13,10 +13,10 @@ from midealan.devices.e2 import (
     OldProtocol,
 )
 from midealan.devices.e2.message import (
-    MessageNewProtocolSet,
     MessagePower,
     MessageQuery,
     MessageSet,
+    NewProtocolSet,
 )
 
 
@@ -268,7 +268,7 @@ class TestMideaE2Device:
             device.set_attribute(DeviceAttributes.target_temperature.value, 45)
             mock_build_send.assert_called_once()
             message = mock_build_send.call_args[0][0]
-        assert isinstance(message, MessageNewProtocolSet)
+        assert isinstance(message, NewProtocolSet)
         assert message.target_temperature == 45
         assert message._body == bytearray([0x07, 45])
 
@@ -314,5 +314,5 @@ class TestMideaE2Device:
             device.set_attribute(DeviceAttributes.sterilization.value, True)
             mock_build_send.assert_called_once()
             message = mock_build_send.call_args[0][0]
-        assert isinstance(message, MessageNewProtocolSet)
+        assert isinstance(message, NewProtocolSet)
         assert message.sterilization is True

--- a/tests/devices/e2/message_e2_test.py
+++ b/tests/devices/e2/message_e2_test.py
@@ -7,10 +7,10 @@ from midealan.devices.e2.message import (
     E2GeneralMessageBody,
     MessageE2Base,
     MessageE2Response,
-    MessageNewProtocolSet,
     MessagePower,
     MessageQuery,
     MessageSet,
+    NewProtocolSet,
 )
 from midealan.message import ListTypes, MessageType
 
@@ -66,7 +66,7 @@ class TestMessagePower:
         assert msg.body_type == ListTypes.X02
 
 
-class TestMessageNewProtocolSet:
+class TestNewProtocolSet:
     """Test E2 Message New Protocol Set."""
 
     @pytest.mark.parametrize(
@@ -106,7 +106,7 @@ class TestMessageNewProtocolSet:
         byte13: int,
     ) -> None:
         """Test new protocol set body for each single attribute."""
-        msg = MessageNewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
         setattr(msg, attr, value)
         assert msg._body == bytearray([byte12, byte13])
 
@@ -116,7 +116,7 @@ class TestMessageNewProtocolSet:
     )
     def test_body_memory(self, memory: bool, flag: int) -> None:
         """Test new protocol set body for the memory command."""
-        msg = MessageNewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
         msg.memory = memory
         assert msg._body == bytearray(
             [0x03, 0x00, 0x00, flag, 0x00, 0x00, 0x00, 0x00, 0x00],
@@ -124,7 +124,7 @@ class TestMessageNewProtocolSet:
 
     def test_body_defaults(self) -> None:
         """Test new protocol set body with no attribute set."""
-        msg = MessageNewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
         assert msg._body == bytearray([0x00, 0x00])
 
 

--- a/tests/devices/e3/device_e3_test.py
+++ b/tests/devices/e3/device_e3_test.py
@@ -7,10 +7,10 @@ import pytest
 from midealan.const import ProtocolVersion
 from midealan.devices.e3 import DeviceAttributes, MideaE3Device
 from midealan.devices.e3.message import (
-    MessageNewProtocolSet,
     MessagePower,
     MessageQuery,
     MessageSet,
+    NewProtocolSet,
 )
 from midealan.message import MessageType
 
@@ -188,7 +188,7 @@ class TestMideaE3Device:
             self.device.set_attribute(attr.value, value)
             mock_build_send.assert_called_once()
             message = mock_build_send.call_args[0][0]
-            assert isinstance(message, MessageNewProtocolSet)
+            assert isinstance(message, NewProtocolSet)
             assert message.key == attr.value
             assert message.value == value
 
@@ -202,7 +202,7 @@ class TestMideaE3Device:
             )
             mock_build_send.assert_called_once()
             message = mock_build_send.call_args[0][0]
-            assert isinstance(message, MessageNewProtocolSet)
+            assert isinstance(message, NewProtocolSet)
             assert message.value == 80.0
 
     @pytest.mark.parametrize(

--- a/tests/devices/e3/message_e3_test.py
+++ b/tests/devices/e3/message_e3_test.py
@@ -5,10 +5,10 @@ import pytest
 from midealan.const import ProtocolVersion
 from midealan.devices.e3.message import (
     MessageE3Base,
-    MessageNewProtocolSet,
     MessagePower,
     MessageQuery,
     MessageSet,
+    NewProtocolSet,
 )
 from midealan.message import ListTypes, MessageType
 
@@ -84,7 +84,7 @@ class TestMessageSet:
         assert msg.body_type == ListTypes.X04
 
 
-class TestMessageNewProtocolSet:
+class TestNewProtocolSet:
     """Test E3 Message New Protocol Set."""
 
     @pytest.mark.parametrize(
@@ -104,7 +104,7 @@ class TestMessageNewProtocolSet:
         expected_value: int,
     ) -> None:
         """Test new protocol set body for each parameter."""
-        msg = MessageNewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
         msg.key = key
         msg.value = value
         expected = bytearray([expected_key, expected_value] + [0x00] * 17)


### PR DESCRIPTION
rename most of the ac device class name, also sync with the latest name for exist device.
use replace in files to do these actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Standardized protocol message names across supported device integrations.
  - Clarified names for capability, power, humidity, group, state, and subprotocol messages.
  - Preserved existing command behavior, payload encoding, and device functionality.

- **Tests**
  - Updated coverage to use the standardized message names.
  - Continued validating protocol payloads, device commands, feature support, and response parsing.
  - Expanded coverage for new-protocol light settings, including disabled and unspecified values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->