### PR TITLE
test(a1): cover remaining a1 branches

### DIFF
--- a/tests/devices/a1/device_a1_test.py
+++ b/tests/devices/a1/device_a1_test.py
@@ -120,6 +120,48 @@ class TestMideaA1Device:
             assert new_status[DeviceAttributes.mode.value] == "Manual"
             assert new_status[DeviceAttributes.fan_speed.value] == "Auto"
             assert new_status[DeviceAttributes.tank_full.value]
+            assert not self.device.make_message_set().pump_enable
+
+    def test_process_message_without_pump_enable(self) -> None:
+        """Test process message without a pump_enable attribute."""
+        with patch("midealan.devices.a1.MessageA1Response") as mock_message_response:
+            mock_message = mock_message_response.return_value
+            mock_message.protocol_version = ProtocolVersion.V3
+            mock_message.power = True
+            mock_message.prompt_tone = True
+            mock_message.fan_speed = 40
+            mock_message.target_humidity = 40
+            mock_message.mode = 1
+            mock_message.pump = True
+            mock_message.tank = 60
+            mock_message.water_level_set = "50"
+            mock_message.pump_enable = True
+            self.device.process_message(b"")
+
+        response = bytearray(15)
+        response[0] = 0xB0
+        response[1] = 0x01
+        response[2] = 0x34
+        response[3] = 0x12
+        response[5] = 0x01
+        response[6] = 0x01
+        header = bytearray(
+            [
+                0xAA,
+                0x00,
+                0xA1,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+                0x03,
+            ],
+        )
+        new_status = self.device.process_message(bytes(header + response))
+        assert new_status == {}
+        assert self.device.make_message_set().pump_enable
 
     def test_build_query(self) -> None:
         """Test build query."""
@@ -162,31 +204,44 @@ class TestMideaA1Device:
         """Test set attribute."""
         with patch.object(self.device, "build_send") as mock_build_send:
             self.device.set_attribute(DeviceAttributes.mode, "Continuous")
-            mock_build_send.assert_called_once()
+            assert mock_build_send.call_args.args[0].mode == 2
 
             self.device.set_attribute(DeviceAttributes.mode, "Auto")
-            mock_build_send.assert_called()
+            assert mock_build_send.call_args.args[0].mode == 3
 
             self.device.set_attribute(DeviceAttributes.fan_speed, "Medium")
-            mock_build_send.assert_called()
+            assert mock_build_send.call_args.args[0].fan_speed == 60
 
             self.device.set_attribute(DeviceAttributes.fan_speed, "Auto")
-            mock_build_send.assert_called()
+            assert mock_build_send.call_args.args[0].fan_speed == 102
 
             self.device.set_attribute(DeviceAttributes.water_level_set, "75")
-            mock_build_send.assert_called()
+            assert mock_build_send.call_args.args[0].water_level_set == 75
 
             self.device.set_attribute(DeviceAttributes.water_level_set, "25")
-            mock_build_send.assert_called()
+            assert mock_build_send.call_args.args[0].water_level_set == 25
 
             self.device.set_attribute(DeviceAttributes.prompt_tone, True)
-            mock_build_send.assert_called()
+            assert mock_build_send.call_count == 6
+            assert self.device.attributes[DeviceAttributes.prompt_tone] is True
 
             self.device.set_attribute(DeviceAttributes.swing, True)
-            mock_build_send.assert_called()
+            assert mock_build_send.call_args.args[0].swing is True
 
             self.device.set_attribute(DeviceAttributes.pump, True)
-            mock_build_send.assert_called()
+            assert mock_build_send.call_args.args[0].pump is True
+
+    def test_set_attribute_ignores_invalid_values(self) -> None:
+        """Test set attribute keeps defaults for invalid values."""
+        with patch.object(self.device, "build_send") as mock_build_send:
+            self.device.set_attribute(DeviceAttributes.mode, "Invalid Mode")
+            self.device.set_attribute(DeviceAttributes.fan_speed, "Turbo")
+            self.device.set_attribute(DeviceAttributes.water_level_set, "10")
+
+            assert mock_build_send.call_count == 3
+            assert mock_build_send.call_args_list[0].args[0].mode == 1
+            assert mock_build_send.call_args_list[1].args[0].fan_speed == 60
+            assert mock_build_send.call_args_list[2].args[0].water_level_set == 50
 
     def test_set_customize(self) -> None:
         """Test set customize with valid speeds and modes."""
@@ -239,4 +294,14 @@ class TestMideaA1Device:
             customize = '{"prompt_tone": "false"}'
             self.device.set_customize(customize)
             assert self.device.attributes[DeviceAttributes.prompt_tone] is True
+            mock_update_all.assert_not_called()
+
+    def test_set_customize_ignores_empty_and_empty_object(self) -> None:
+        """Test set customize ignores empty input and an empty JSON object."""
+        with patch.object(self.device, "update_all") as mock_update_all:
+            self.device.set_customize("")
+            mock_update_all.assert_not_called()
+
+        with patch.object(self.device, "update_all") as mock_update_all:
+            self.device.set_customize("{}")
             mock_update_all.assert_not_called()

--- a/tests/devices/a1/message_a1_test.py
+++ b/tests/devices/a1/message_a1_test.py
@@ -95,6 +95,32 @@ class TestMessageNewProtocolQuery:
         )
         assert query.body[:-2] == expected_body
 
+    def test_new_protocol_query_body_without_light(self) -> None:
+        """Test new protocol query body without light in the response."""
+        header = bytearray(
+            [
+                0xAA,
+                0x00,
+                0xA1,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+                0x03,
+            ],
+        )
+        body = bytearray(10)
+        body[0] = 0xB0
+        body[1] = 0x01
+        body[2] = 0x34
+        body[3] = 0x12
+        body[5] = 0x01
+        body[6] = 0x01
+        response = MessageA1Response(header + body)
+        assert not hasattr(response, "light")
+
 
 class TestMessageSet:
     """Test Message Set."""
@@ -230,6 +256,33 @@ class TestMessageA1Response:
         response = MessageA1Response(header + body)
         assert hasattr(response, "light")
         assert response.light
+
+    def test_a1_notify2_ignored_when_body_type_is_not_a0(self) -> None:
+        """Test notify2 messages with non-A0 bodies fall through unchanged."""
+        header = bytearray(
+            [
+                0xAA,
+                0x00,
+                0xA1,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+                0x05,
+            ],
+        )
+        body = bytearray(8)
+        body[0] = 0xB0
+        body[1] = 0x01
+        body[2] = 0x5B
+        body[3] = 0x00
+        body[5] = 0x01
+        body[6] = 0x01
+        response = MessageA1Response(header + body)
+        assert not hasattr(response, "light")
+        assert not hasattr(response, "power")
 
     def test_a1_general_notify_response(self) -> None:
         """Test general notify response."""


### PR DESCRIPTION
## Summary
- cover the remaining A1 branch coverage gaps
- assert the encoded MessageSet values for each setter call
- preserve pump_enable coverage when the field is disabled or absent

## Tests
- env UV_CACHE_DIR=/private/tmp/midea-local-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/midea-local-pycache uv run python -m pytest tests/devices/a1/ --cov=midealan.devices.a1 --cov-branch --cov-report term-missing

Generated by Codex GPT-5.