### PR TITLE
fix(device): recover from a device that supports no query protocol

### DIFF
--- a/midealan/device.py
+++ b/midealan/device.py
@@ -396,9 +396,10 @@ class MideaDevice(threading.Thread):
 
     def refresh_status(self, check_protocol: bool = False) -> None:
         """Refresh device status."""
-        cmds: list = self.build_query()
+        real_cmds: list = self.build_query()
+        cmds = real_cmds
         if self._appliance_query:
-            cmds = [MessageQueryAppliance(self.device_type), *cmds]
+            cmds = [MessageQueryAppliance(self.device_type), *real_cmds]
         error_count = 0
         _LOGGER.debug(
             "[%s] refresh_status with cmds: %s, check_protocol %s, "
@@ -447,7 +448,8 @@ class MideaDevice(threading.Thread):
                     # only catch TimoutError for check_protocol
                     # unexpected exception in recv/settimeout, catch by main loop
                     except TimeoutError:
-                        error_count += 1
+                        if cmd in real_cmds:
+                            error_count += 1
                         self._unsupported_protocol.append(cmd.__class__.__name__)
                         _LOGGER.debug(
                             "[%s] Does not supports the protocol %s, cmd %s, ignored",
@@ -457,7 +459,8 @@ class MideaDevice(threading.Thread):
                         )
                     except ResponseException:
                         # parse msg error
-                        error_count += 1
+                        if cmd in real_cmds:
+                            error_count += 1
                         _LOGGER.debug(
                             "[%s] refresh_status ResponseException %s, cmd %s",
                             self._device_id,
@@ -470,9 +473,15 @@ class MideaDevice(threading.Thread):
                     self._device_id,
                     cmd,
                 )
-                error_count += 1
-            # all the query failed
-            if error_count == len(cmds):
+                if cmd in real_cmds:
+                    error_count += 1
+            # All the REAL status queries failed. The appliance query is excluded: it
+            # answers even when the device serves no status protocol, so counting it
+            # left error_count one short of len(cmds) and the failure was masked --
+            # connect() returned True and the device came up available with no data.
+            # `real_cmds and` keeps the check vacuously false for a device whose
+            # build_query() is empty, which would otherwise raise on 0 == 0.
+            if real_cmds and error_count == len(real_cmds):
                 _LOGGER.warning(
                     "[%s] all the query cmds failed %s, please report bug",
                     self._device_id,
@@ -687,6 +696,10 @@ class MideaDevice(threading.Thread):
                 sock = self._socket
             if sock is None or self._socket is sock:
                 self._unsupported_protocol = []
+                # Re-arm the appliance query too. It is cleared in
+                # pre_process_message and was never set back, so a reconnected device
+                # would skip protocol detection and re-probe with build_query() alone.
+                self._appliance_query = True
                 self._buffer = b""
         if sock is not None:
             try:
@@ -831,11 +844,18 @@ class MideaDevice(threading.Thread):
                     self.close_socket()
                     break
                 except NoSupportedProtocol:
+                    # Drop the socket and reconnect, as every other exception here
+                    # does. Continuing on the same socket could never recover: once
+                    # every command is in _unsupported_protocol, refresh_status takes
+                    # the SKIP branch for all of them and performs NO socket I/O, so
+                    # no socket error can ever be raised to break the loop and the
+                    # device stayed stuck until Home Assistant restarted.
+                    # close_socket() clears _unsupported_protocol and re-arms
+                    # _appliance_query, so the reconnect is a genuine fresh probe --
+                    # the same effect as the user power-cycling the device.
                     _LOGGER.debug("[%s] No Supported protocol", self._device_id)
-                    # sleep 1 seconds to prevent high cpu usage in for loop
-                    time.sleep(1)
-                    # ignore and continue loop
-                    continue
+                    self.close_socket()
+                    break
                 except ConnectionResetError:  # refresh_status -> build_send exception
                     _LOGGER.debug("[%s] Connection reset by peer", self._device_id)
                     self.close_socket()

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -1,5 +1,6 @@
 """Midea Lan device test."""
 
+import contextlib
 import threading
 from typing import Any, ClassVar
 from unittest.mock import MagicMock, patch
@@ -437,8 +438,12 @@ class TestMideaDevice:
             self.device.refresh_status()  # build_query not implemented
 
         socket_mock = MagicMock()
+        # One REAL status query rather than the appliance query, so the command count
+        # per refresh_status is unchanged and the mock side_effects still line up.
+        self.device._appliance_query = False
+        real_cmd = MagicMock()
         with (
-            patch.object(self.device, "build_query", return_value=[]),
+            patch.object(self.device, "build_query", return_value=[real_cmd]),
             patch.object(
                 socket_mock,
                 "recv",
@@ -480,6 +485,278 @@ class TestMideaDevice:
                 self.device.refresh_status(True)  # Timeout
             with pytest.raises(NoSupportedProtocol):
                 self.device.refresh_status(True)  # Unsupported protocol
+
+    def test_appliance_query_success_does_not_mask_failed_status_queries(
+        self,
+    ) -> None:
+        """A successful appliance query must not hide every status query failing.
+
+        The appliance query answers even when the device serves no status protocol.
+        Counting it toward error_count left the total one short of len(cmds), so
+        NoSupportedProtocol was never raised, connect() returned True, and the device
+        came up available with data that never updated.
+        """
+        socket_mock = MagicMock()
+        real_cmd = MagicMock()
+        with (
+            patch.object(self.device, "build_query", return_value=[real_cmd]),
+            patch.object(
+                socket_mock,
+                "recv",
+                side_effect=[bytearray([0x0]), TimeoutError()],
+            ),
+            patch.object(self.device, "build_send", return_value=None),
+            patch.object(
+                self.device,
+                "parse_message",
+                side_effect=[MessageResult.SUCCESS],
+            ),
+        ):
+            self.device._socket = socket_mock
+            assert self.device._appliance_query is True
+            with pytest.raises(NoSupportedProtocol):
+                self.device.refresh_status(True)
+
+    def test_appliance_query_failure_alone_does_not_fail_the_device(self) -> None:
+        """A failed appliance query must not count against the status queries.
+
+        Ungated, its timeout increments error_count to 1, which already equals
+        len(real_cmds) on the first iteration -- so a device whose real status query
+        works perfectly well would be declared to support no protocol at all.
+        """
+        socket_mock = MagicMock()
+        real_cmd = MagicMock()
+        with (
+            patch.object(self.device, "build_query", return_value=[real_cmd]),
+            patch.object(
+                socket_mock,
+                "recv",
+                side_effect=[TimeoutError(), bytearray([0x0])],
+            ),
+            patch.object(self.device, "build_send", return_value=None),
+            patch.object(
+                self.device,
+                "parse_message",
+                side_effect=[MessageResult.SUCCESS],
+            ),
+        ):
+            self.device._socket = socket_mock
+            assert self.device._appliance_query is True
+            self.device.refresh_status(True)  # must not raise
+            # The timed-out appliance query must still be blacklisted, which is what
+            # stops it being re-sent on the next refresh. close_socket() re-arms
+            # _appliance_query, so this list is the only thing holding it back on a
+            # device that never answers it.
+            assert "MessageQueryAppliance" in self.device._unsupported_protocol
+
+    def test_garbled_appliance_reply_does_not_fail_the_device(self) -> None:
+        """Third path into the same trap: a ResponseException on the appliance query.
+
+        A V3 decode returning an error for the appliance reply raises
+        ResponseException. Ungated that increments too, so with one real command the
+        per-iteration check raises on the appliance iteration -- before the real query
+        has even been sent -- tearing down a device whose status queries are fine.
+        """
+        socket_mock = MagicMock()
+        real_cmd = MagicMock()
+        with (
+            patch.object(self.device, "build_query", return_value=[real_cmd]),
+            patch.object(
+                socket_mock,
+                "recv",
+                side_effect=[bytearray([0x0]), bytearray([0x0])],
+            ),
+            patch.object(self.device, "build_send", return_value=None),
+            patch.object(
+                self.device,
+                "parse_message",
+                # appliance reply is garbled, the real query answers cleanly
+                side_effect=[MessageResult.ERROR, MessageResult.SUCCESS],
+            ),
+        ):
+            self.device._socket = socket_mock
+            self.device.refresh_status(True)  # must not raise
+
+    def test_skipped_appliance_query_does_not_fail_the_device(self) -> None:
+        """Same, via the "already unsupported, SKIP" branch.
+
+        Once the appliance query is blacklisted it takes the SKIP path, which also
+        increments error_count. Ungated that alone reaches len(real_cmds) and fails a
+        healthy device.
+        """
+        socket_mock = MagicMock()
+        real_cmd = MagicMock()
+        self.device._unsupported_protocol = ["MessageQueryAppliance"]
+        with (
+            patch.object(self.device, "build_query", return_value=[real_cmd]),
+            patch.object(socket_mock, "recv", side_effect=[bytearray([0x0])]),
+            patch.object(self.device, "build_send", return_value=None),
+            patch.object(
+                self.device,
+                "parse_message",
+                side_effect=[MessageResult.SUCCESS],
+            ),
+        ):
+            self.device._socket = socket_mock
+            self.device.refresh_status(True)  # must not raise
+
+    def test_empty_build_query_does_not_raise(self) -> None:
+        """A device with no status queries must not report every query as failed.
+
+        With build_query() empty, error_count and len(real_cmds) are both 0. Without
+        the `real_cmds and` guard that compares equal and raises, failing a connect
+        whose only command -- the appliance query -- had succeeded.
+        """
+        socket_mock = MagicMock()
+        with (
+            patch.object(self.device, "build_query", return_value=[]),
+            patch.object(socket_mock, "recv", side_effect=[bytearray([0x0])]),
+            patch.object(self.device, "build_send", return_value=None),
+            patch.object(
+                self.device,
+                "parse_message",
+                side_effect=[MessageResult.SUCCESS],
+            ),
+        ):
+            self.device._socket = socket_mock
+            self.device.refresh_status(True)
+
+    def test_run_loop_reconnects_when_no_protocol_is_supported(self) -> None:
+        """NoSupportedProtocol must drop the socket, like every other error here.
+
+        Continuing on the same socket could never recover: once every command is in
+        _unsupported_protocol, refresh_status takes the SKIP branch for all of them
+        and performs no socket I/O, so no socket error can ever be raised to break
+        the loop. The device stayed stuck until Home Assistant restarted.
+
+        The discriminator is how many times the refresh is attempted: breaking out
+        reconnects after one, whereas continuing spins on the same dead socket. A
+        socket mock is required -- without one the loop raises SocketException at the
+        top and never reaches this handler at all.
+        """
+        attempts = 0
+        connects = 0
+
+        def refresh(_now: float) -> None:
+            nonlocal attempts
+            attempts += 1
+            # Guarantee termination if the break is ever removed. It has to be an
+            # exception the loop does NOT handle: the inner `while True` never
+            # consults _is_run, so clearing that would spin forever instead of
+            # failing.
+            if attempts > 3:
+                raise SystemExit
+            raise NoSupportedProtocol
+
+        def connect_loop() -> None:
+            # Let the outer loop run once more so the RECONNECT is observable, then
+            # stop the service. Ending it inside close_socket() instead would exit
+            # before _connect_loop() could be reached, which is what made the old
+            # version of this test prove only that the socket was dropped.
+            nonlocal connects
+            connects += 1
+            if connects == 2:
+                self.device._is_run = False
+
+        with (
+            patch.object(self.device, "_connect_loop", side_effect=connect_loop),
+            # _should_run() is deliberately NOT patched: the outer loop reads
+            # _is_run directly, but the early `if not self._should_run(): break`
+            # right after _connect_loop() is what lets connect_loop() stop the
+            # service. Patching it to True would defer the stop by one refresh
+            # cycle (the outer `while` still exits), failing `attempts == 1`.
+            patch.object(self.device, "_check_refresh", side_effect=refresh),
+            patch.object(self.device, "close_socket") as close_mock,
+        ):
+            self.device._socket = MagicMock()
+            self.device._is_run = True
+            with contextlib.suppress(SystemExit):
+                self.device.run()
+
+        assert attempts == 1
+        # The point of the fix: the socket is dropped AND the loop dials again.
+        # Asserting only the first would pass even if recovery never happened.
+        assert connects == 2
+        close_mock.assert_called_once()
+
+    def test_one_failing_query_among_several_does_not_fail_the_device(self) -> None:
+        """Only ALL the status queries failing may raise.
+
+        Every other test here uses a single status query, which cannot tell
+        accumulation apart from assignment: with `error_count = 1` instead of `+= 1`
+        the check still passes for one command but can never be reached for a real
+        device -- an AC builds eleven -- so the whole guard would be inert. And with
+        the count over-incremented, "all failed" silently becomes "any failed", so one
+        timed-out group query during the initial probe fails connect() and a working
+        device never comes online.
+        """
+        socket_mock = MagicMock()
+        # Distinct classes on purpose: _unsupported_protocol keys off
+        # cmd.__class__.__name__, so two MagicMocks would share a name and the second
+        # would take the "already unsupported, SKIP" path instead of the one under
+        # test.
+        cmd_ok = type("QueryOk", (), {})()
+        cmd_bad = type("QueryBad", (), {})()
+        with (
+            patch.object(
+                self.device,
+                "build_query",
+                return_value=[cmd_ok, cmd_bad],
+            ),
+            patch.object(
+                socket_mock,
+                "recv",
+                # appliance ok, first real ok, second real times out
+                side_effect=[bytearray([0x0]), bytearray([0x0]), TimeoutError()],
+            ),
+            patch.object(self.device, "build_send", return_value=None),
+            patch.object(
+                self.device,
+                "parse_message",
+                side_effect=[MessageResult.SUCCESS, MessageResult.SUCCESS],
+            ),
+        ):
+            self.device._socket = socket_mock
+            self.device.refresh_status(True)  # must not raise
+
+    def test_all_queries_failing_among_several_raises(self) -> None:
+        """The sibling of the above: every real query failing must still raise."""
+        socket_mock = MagicMock()
+        cmd_a = type("QueryA", (), {})()
+        cmd_b = type("QueryB", (), {})()
+        with (
+            patch.object(self.device, "build_query", return_value=[cmd_a, cmd_b]),
+            patch.object(
+                socket_mock,
+                "recv",
+                side_effect=[bytearray([0x0]), TimeoutError(), TimeoutError()],
+            ),
+            patch.object(self.device, "build_send", return_value=None),
+            patch.object(
+                self.device,
+                "parse_message",
+                side_effect=[MessageResult.SUCCESS],
+            ),
+        ):
+            self.device._socket = socket_mock
+            with pytest.raises(NoSupportedProtocol):
+                self.device.refresh_status(True)
+            # Both must have failed on their own timeout. If they shared a class name
+            # the second would take the SKIP path, consuming only two of the three
+            # recv side effects and testing a different branch than this one claims.
+            assert self.device._unsupported_protocol == ["QueryA", "QueryB"]
+            assert socket_mock.recv.call_count == 3
+
+    def test_close_socket_rearms_appliance_query(self) -> None:
+        """close_socket must re-arm the appliance query for the next connection.
+
+        _appliance_query is cleared in pre_process_message and was never set back, so
+        a reconnected device skipped protocol detection entirely.
+        """
+        self.device._socket = None
+        self.device._appliance_query = False
+        self.device.close_socket()
+        assert self.device._appliance_query is True
 
     def test_refresh_status_without_appliance_or_protocol_check(self) -> None:
         """Test refresh_status can send queries without response validation."""
@@ -880,21 +1157,25 @@ class TestMideaDevice:
 
         def fake_connect_loop() -> None:
             connect_loop_calls["n"] += 1
-            if connect_loop_calls["n"] > 5:
+            if connect_loop_calls["n"] > 6:
                 self.device._is_run = False
 
+        # NoSupportedProtocol now closes the socket and breaks rather than continuing
+        # on the same one, so it gets its own pass at the end -- if it stayed mid-pass
+        # it would end that pass early and the SUCCESS/heartbeat-timeout script below
+        # would never run.
         check_refresh_side_effect = (
             [None, None, None, None]  # passes 1-4: no refresh due
-            + [NoSupportedProtocol()]  # pass 5, iter a: continue
-            + [None]  # pass 5, iter b: refresh ok, then SUCCESS recv
-            + [None] * RESPONSE_TIMEOUT  # pass 5, iters c..: timeouts
+            + [None]  # pass 5, iter a: refresh ok, then SUCCESS recv
+            + [None] * RESPONSE_TIMEOUT  # pass 5, iters b..: timeouts
+            + [NoSupportedProtocol()]  # pass 6: close_socket + break
         )
         recv_side_effect = [
             b"",  # pass 1: empty -> ConnectionResetError
             b"\x01",  # pass 2: parsed as ERROR
             OSError("boom"),  # pass 3
             ValueError("boom"),  # pass 4
-            b"\x01",  # pass 5, iter b: parsed as SUCCESS
+            b"\x01",  # pass 5, iter a: parsed as SUCCESS
             *([TimeoutError()] * RESPONSE_TIMEOUT),  # pass 5: hits the threshold
         ]
         parse_message_side_effect = [MessageResult.ERROR, MessageResult.SUCCESS]
@@ -918,7 +1199,7 @@ class TestMideaDevice:
         ):
             self.device.run()
 
-        assert connect_loop_calls["n"] == 6
+        assert connect_loop_calls["n"] == 7
         assert self.device._is_run is False
 
     def test_set_attribute(self) -> None:


### PR DESCRIPTION
Fixes #26.

Both changes you agreed to, plus the one they depend on.

## 1. The appliance query masked failed status queries

Ported from midea-lan/midea-local#690, which closed midea-lan/midea-local#575.

`MessageQueryAppliance` is prepended to `cmds` and answers even when the device serves no status protocol, so it counted toward `error_count` and left the total one short of `len(cmds)`. `NoSupportedProtocol` was never raised, `connect()` returned `True`, and the device came up **available with data that never updated**.

`error_count` now counts only the real status queries, guarded with `real_cmds and` so a device whose `build_query()` is empty isn't failed by `0 == 0`.

## 2. Once that is reported honestly, the device gets stuck

This is the root cause you asked to prioritise. In the run loop:

```python
except SocketException:      close_socket(); break     # -> reconnect
except ConnectionResetError: close_socket(); break     # -> reconnect
except OSError:              close_socket(); break     # -> reconnect
except NoSupportedProtocol:  time.sleep(1); continue   # <- same socket, forever
```

Continuing could never recover. With every command in `_unsupported_protocol`, `refresh_status` takes the SKIP branch for all of them and performs **no socket I/O at all** — so no socket error can ever be raised to break the loop, and the device stayed stuck until Home Assistant restarted. It now drops the socket and reconnects like the others, paced by the existing `_connect_loop` sleep.

## 3. `close_socket()` didn't re-arm the appliance query

Which is what makes (2) work. `close_socket()` already cleared `_unsupported_protocol`, but `_appliance_query` is set at `__init__`, cleared in `pre_process_message`, and never set back — so a reconnected device would have skipped protocol detection and re-probed with `build_query()` alone. Re-arming it there makes the reconnect a genuine fresh probe: the same effect as a user power-cycling the device, without needing the user.

That answers option 4 from your list using the machinery already present, rather than a new state machine or config.

## Tests

9 added, 2 existing updated. Each is confirmed to **fail** if the behaviour it describes is removed — I mutated all of them and checked, rather than assuming coverage. `device.py` stays at **100%** statement and branch coverage.

New:

- appliance success no longer masks a failed status query
- a failed appliance query alone doesn't fail a healthy device — via timeout, via a garbled reply (`ResponseException`), and via the "already unsupported, SKIP" branch. These are three separate code paths and each needed its own test; ungated, any of them alone reaches `len(real_cmds)` on the appliance iteration and tears down a device whose status queries work
- one failing query among several doesn't raise, and all of them failing does. Every other test here uses a single command, which cannot tell accumulation from assignment: with `error_count = 1` the guard still passes for one command but could never fire for a real device — an AC builds eleven — so the whole fix would have been silently inert in production
- an empty `build_query()` doesn't raise
- `close_socket()` re-arms `_appliance_query`
- the run loop reconnects rather than spinning

Updated:

- `test_refresh_status` patched `build_query` to `[]`, which by design no longer raises. It now uses one real status query, keeping the command count per call unchanged so the existing mock `side_effect` sequences still line up.
- `test_run_message_loop_branches` scripted `NoSupportedProtocol` as a mid-pass `continue`. With the `break` it ends that pass early, so the rest of its script — the SUCCESS recv and the heartbeat-timeout sequence — silently stopped executing and took `device.py` off 100%. The handler now gets its own pass at the end.

## Checks

`pytest ./tests/` 1635 passed · `device.py` coverage 100% (439 statements, 130 branches, none missed) · `ruff check` passed · `ruff format` clean, the two README files it flags are pre-existing on `main` · `mypy midealan` strict, no issues · `pylint` 10.00/10.

## Caveat

My own device has never entered this state — I found it by reading `refresh_status`, not from a failure here. So these are driven through `refresh_status` and the run loop directly, not against real hardware in that condition. If you have a device that reproduces it, that would be worth confirming against before release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device status detection so unsupported protocols are identified reliably.
  - Prevented appliance discovery responses from masking status-query failures.
  - Improved handling of malformed, skipped, partial, and failed status responses.
  - Improved accuracy when reporting device status after mixed query results.

- **Reliability**
  - Automatically reconnects when no supported protocol remains.
  - Refreshes protocol discovery after reconnecting.
  - Improved socket cleanup and reconnection behavior for unavailable devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
