### PR TITLE
fix(ac): guard XA1Body parsing against short notify bodies

### DIFF
--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -18,6 +18,8 @@ from midealan.message import (
 
 _LOGGER = logging.getLogger(__name__)
 
+A1_MIN_BODY_LENGTH = 18
+
 BB_AC_MODES = [0, 3, 1, 2, 4, 5]
 BB_MIN_BODY_LENGTH = 21
 BB_FRESH_AIR_SWITCH_INDEX = 45
@@ -1591,9 +1593,20 @@ class MessageACResponse(MessageResponse):
             self.set_body(XA0Body(super().body))
         # dataType 0x04 and messageBytes[0] 0xA1
         elif (
-            self.message_type == MessageType.notify1 and self.body_type == ListTypes.A1
+            self.message_type == MessageType.notify1
+            and self.body_type == ListTypes.A1
+            and len(super().body) >= A1_MIN_BODY_LENGTH
         ):
             self.set_body(XA1Body(super().body))
+        elif (
+            self.message_type == MessageType.notify1 and self.body_type == ListTypes.A1
+        ):
+            _LOGGER.debug(
+                "Skipping notify1 A1 body too short to parse (%d < %d bytes): %s",
+                len(super().body),
+                A1_MIN_BODY_LENGTH,
+                super().body.hex(),
+            )
         # parse CapabilitiesQuery/CapabilitiesAdditionalQuery response
         # dataType 0x03 and messageBytes[0] 0xB5
         elif self.message_type == MessageType.query and self.body_type == ListTypes.B5:

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -5,6 +5,7 @@ import pytest
 from midealan.const import ProtocolVersion
 from midealan.crc8 import calculate
 from midealan.devices.ac.message import (
+    A1_MIN_BODY_LENGTH,
     CapabilitiesQuery,
     GroupDataQuery,
     GroupOneQuery,
@@ -796,6 +797,46 @@ class TestMessageACResponse:
         assert response.indoor_temperature == -1.3  # ((49 - 50) / 2) - 0.3 = -1.3
         assert hasattr(response, "outdoor_temperature")
         assert response.outdoor_temperature == -6.5  # ((40 - 50) / 2) - 1.5 = -6.5
+
+    def test_message_notify1_a1_short_body(self) -> None:
+        """Test Message parse notify1 A1 with a body too short to parse."""
+        self.header[9] = 0x04
+        # Real frame from a 00000Q1B / subtype 44204 unit: 7-byte body
+        # (last byte is the checksum and is stripped by MessageResponse).
+        # XA1MessageBody reads up to body[17], so it must be skipped, not parsed.
+        body = bytearray([0xA1, 0x00, 0x03, 0x8A, 0x95, 0xB6, 0xC1, 0x02])
+        response = MessageACResponse(self.header + body)
+
+        assert not hasattr(response, "indoor_temperature")
+        assert not hasattr(response, "outdoor_temperature")
+        assert not hasattr(response, "indoor_humidity")
+        assert not hasattr(response, "current_work_time")
+
+    def test_message_notify1_a1_body_length_boundary(self) -> None:
+        """Test Message parse notify1 A1 boundary at A1_MIN_BODY_LENGTH."""
+        self.header[9] = 0x04
+
+        # One byte short of the minimum: skipped, and must not raise.
+        # +1 accounts for the trailing checksum byte stripped by MessageResponse.
+        body = bytearray(A1_MIN_BODY_LENGTH - 1 + 1)
+        body[0] = 0xA1
+        response = MessageACResponse(self.header + body)
+        assert not hasattr(response, "indoor_temperature")
+
+        # Exactly the minimum: parsed.
+        body = bytearray(A1_MIN_BODY_LENGTH + 1)
+        body[0] = 0xA1
+        body[13] = 100  # Indoor temperature byte
+        body[14] = 60  # Outdoor temperature byte
+        body[17] = 50  # Indoor humidity byte
+        response = MessageACResponse(self.header + body)
+
+        assert hasattr(response, "indoor_temperature")
+        assert response.indoor_temperature == 25.0  # (100 - 50) / 2
+        assert hasattr(response, "outdoor_temperature")
+        assert response.outdoor_temperature == 5.0  # (60 - 50) / 2
+        assert hasattr(response, "indoor_humidity")
+        assert response.indoor_humidity == 50
 
     def test_message_query_b5(self) -> None:
         """Test message query b5."""


### PR DESCRIPTION
## Problem

`MessageACResponse` dispatches any `notify1` + `0xA1` message straight to `XA1Body` without
checking the body length, but `XA1Body.__init__` unconditionally reads up to `body[17]`.

My AC (model `00000Q1B`, subtype `44204`, device protocol 3) emits a **7-byte** 0xA1 body every
~30 minutes, which raises `IndexError` on every single one:

```
ERROR (Sala de Estar) [midealan.device] [<device-id>] Error in process message
aa11ac00000000000304a100038a95b6c102, model 00000Q1B, subtype 44204,
device protocol 3, message procol 0
Traceback (most recent call last):
  File "midealan/device.py", line 537, in parse_message
  File "midealan/devices/ac/__init__.py", line 409, in process_message
  File "midealan/devices/ac/message.py", line 1596, in __init__
    self.set_body(XA1Body(super().body))
  File "midealan/devices/ac/message.py", line 1053, in __init__
    (((body[9] << 8) & 0xFF00) | (body[10] & 0x00FF)) * 60 * 24
IndexError: bytearray index out of range
```

Decoded with the library's own framing (`HEADER_LENGTH = 10`, `body = message[10:-1]`):

```
total length      = 18 bytes
message_type      = 0x04  (notify1)
body_type         = 0xA1
body length       = 7 bytes   <-- parser needs >= 18
```

The exception is caught and logged by `parse_message`, so the device keeps working and the
entity stays available — the practical impact is a recurring ERROR + traceback in the log.

Note the sibling `0xBB` branch already has exactly this kind of guard
(`len(super().body) >= BB_MIN_BODY_LENGTH`); the `0xA1` branch just never got one.

## Fix

Mirrors the existing `BB_MIN_BODY_LENGTH` pattern: adds `A1_MIN_BODY_LENGTH = 18` and guards the
dispatch, plus a `_LOGGER.debug` on the skip path so a short frame is visible when debugging
rather than silently dropped.

18 is the highest unconditional index in `XA1Body.__init__` (`body[17]`, for `indoor_humidity`),
so nothing that parsed before stops parsing.

## Upstream

This is a port of https://github.com/midea-lan/midea-local/pull/691, which was reviewed by
@chemelli74 and @rokam and merged there (commit 3297742), closing
https://github.com/midea-lan/midea-local/issues/688. Same change, adapted to this fork's naming
(`XA1Body` instead of `XA1MessageBody`).

Since `midea_ac_lan` pins `midea-lan`, that upstream fix does not reach this integration's
users — hence this PR.

## Tests

Two cases added to `TestMessageACResponse`, the same ones merged upstream. They **fail without
the guard** (`IndexError` at `body[17]`) and pass with it, so they pin the regression rather
than just passing:

- `test_message_notify1_a1_short_body` — uses the real 7-byte frame captured from my unit
- `test_message_notify1_a1_body_length_boundary` — 17 bytes skipped, 18 bytes parsed

## Verification

On `b660f85` with this patch applied:

| Check | Result |
|---|---|
| `pytest tests/` (full suite) | 1628 passed |
| `pytest tests/devices/ac/` | 146 passed |
| `ruff check` | All checks passed |
| `ruff format --check` | already formatted |
| `mypy --strict` on the changed module | no issues found |

Debug logging fires exactly where expected and stays quiet otherwise:

| body | expected | result |
|---|---|---|
| 7 bytes (real frame from my unit) | log | `Skipping notify1 A1 body too short to parse (7 < 18 bytes): a100038a95b6c1` |
| 17 bytes | log | logged |
| 18 bytes (the limit) | no log, parsed | parsed |
| 20 bytes (well-formed) | no log, parsed | `indoor=25.0 outdoor=5.0 humidity=50` |

I've also been running this patch on my live Home Assistant (HA Core 2026.8.2, HA OS 18.2,
Python 3.14.6, `midea_ac_lan` 2026.8.0) since yesterday morning. Before the patch the log had
one ERROR per ~30 min cycle without fail; since then, none — while the climate entity kept
updating normally throughout, so it's the guard working rather than the device dropping off.

## Note on a related pattern

While testing I noticed `0xA0` (also an unsolicited notify) and `0xC0` raise the same way on
short bodies — `IndexError` at `boost_mode`, reading `body[10]`. I'm deliberately keeping this
PR to A1 only. Happy to open a separate issue with the sweep and tracebacks if that's useful;
I only have one unit, so I can't produce a real short A0 frame, only synthetic ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of shortened A1 device responses by safely ignoring incomplete data.
  * Valid responses at the minimum supported length continue to provide temperature and humidity readings.
  * Added diagnostic logging for skipped responses to aid troubleshooting.

* **Tests**
  * Added coverage for truncated and minimum-length A1 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->