### PR TITLE
fix(cloud): use the v2 getToken endpoint for the Meiju cloud

### DIFF
--- a/midealan/cloud.py
+++ b/midealan/cloud.py
@@ -451,6 +451,65 @@ class MeijuCloud(MideaCloud):
             return homes
         return None
 
+    async def get_cloud_keys(self, appliance_id: int) -> dict[int, dict[str, Any]]:
+        """Get keys for device from the Meiju cloud.
+
+        Meiju retired the `/v1/iot/secure/getToken` endpoint the base class uses:
+        its gateway now answers `{"code": 40404}` / "the access address does not
+        exist", so no keys come back at all and every V3 device fails to
+        authenticate with "Can't get available token from Midea server".
+
+        The replacement is `/v2/iot/secure/getToken`, which additionally requires
+        `homegroupId` and expects `applianceCodes` as a list -- passing the plain
+        string the v1 endpoint accepted makes it answer `1002 none parameter is
+        found`.
+
+        Falls back to the inherited v1 implementation when v2 yields nothing, so
+        this stays a no-op for clouds or accounts the old endpoint still serves.
+        """
+        homes = await self.list_home()
+        result: dict[int, dict[str, Any]] = {}
+        for home_id in homes or {}:
+            for method in [1, 2]:
+                udp_id = self._security.get_udp_id(appliance_id, method)
+                data = self._make_general_data()
+                data.update(
+                    {
+                        "homegroupId": str(home_id),
+                        "udpid": udp_id,
+                        "applianceCodes": [str(appliance_id)],
+                    },
+                )
+                response = await self._api_request(
+                    endpoint="/v2/iot/secure/getToken",
+                    data=data,
+                )
+                _LOGGER.debug(
+                    "Response from get_cloud_keys() for appliance_id %s "
+                    "in home %s with method %s: %s",
+                    appliance_id,
+                    home_id,
+                    method,
+                    response,
+                )
+                if response and "tokenlist" in response:
+                    for token in response["tokenlist"]:
+                        if token["udpId"] == udp_id:
+                            result[method] = {
+                                "token": token["token"].lower(),
+                                "key": token["key"].lower(),
+                            }
+            if result:
+                break
+        if not result:
+            _LOGGER.debug(
+                "v2 getToken returned no keys for appliance_id %s, "
+                "falling back to the v1 endpoint",
+                appliance_id,
+            )
+            return await super().get_cloud_keys(appliance_id)
+        return result
+
     async def list_appliances(
         self,
         home_id: str | None,

--- a/midealan/cloud.py
+++ b/midealan/cloud.py
@@ -484,21 +484,22 @@ class MeijuCloud(MideaCloud):
                     endpoint="/v2/iot/secure/getToken",
                     data=data,
                 )
+                # Log only the entry count: the payload carries token/key material.
+                tokens = (response or {}).get("tokenlist") or []
                 _LOGGER.debug(
-                    "Response from get_cloud_keys() for appliance_id %s "
-                    "in home %s with method %s: %s",
+                    "get_cloud_keys() v2 for appliance_id %s in home %s "
+                    "with method %s returned %s token entries",
                     appliance_id,
                     home_id,
                     method,
-                    response,
+                    len(tokens),
                 )
-                if response and "tokenlist" in response:
-                    for token in response["tokenlist"]:
-                        if token["udpId"] == udp_id:
-                            result[method] = {
-                                "token": token["token"].lower(),
-                                "key": token["key"].lower(),
-                            }
+                for token in tokens:
+                    if token["udpId"] == udp_id:
+                        result[method] = {
+                            "token": token["token"].lower(),
+                            "key": token["key"].lower(),
+                        }
             if result:
                 break
         if not result:

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -211,14 +211,17 @@ class CloudTest(IsolatedAsyncioTestCase):
         response = Mock()
         response.read = AsyncMock(
             side_effect=[
+                # get_cloud_keys() lists homes first, then queries the v2
+                # endpoint per method until one home returns keys.
+                self.responses["meijucloud_list_home.json"],
                 self.responses["meijucloud_get_keys1.json"],
                 self.responses["meijucloud_get_keys2.json"],
+                self.responses["meijucloud_list_home.json"],
                 self.responses["meijucloud_get_keys1.json"],
                 self.responses["cloud_invalid_response.json"],
+                self.responses["meijucloud_list_home.json"],
                 self.responses["cloud_invalid_response.json"],
                 self.responses["meijucloud_get_keys2.json"],
-                self.responses["cloud_invalid_response.json"],
-                self.responses["cloud_invalid_response.json"],
             ],
         )
         session.request = AsyncMock(return_value=response)
@@ -260,6 +263,66 @@ class CloudTest(IsolatedAsyncioTestCase):
         keys = await cloud.get_default_keys()
         assert len(keys) == 1
         assert keys == DEFAULT_KEYS
+
+    async def test_meijucloud_get_keys_v2_fallback_to_v1(self) -> None:
+        """Test MeijuCloud falls back to the v1 endpoint when v2 returns nothing."""
+        session = Mock()
+        response = Mock()
+        response.read = AsyncMock(
+            side_effect=[
+                self.responses["meijucloud_list_home.json"],
+                # v2, home 1: both methods come back empty
+                self.responses["cloud_invalid_response.json"],
+                self.responses["cloud_invalid_response.json"],
+                # v2, home 2: same
+                self.responses["cloud_invalid_response.json"],
+                self.responses["cloud_invalid_response.json"],
+                # v1 fallback
+                self.responses["meijucloud_get_keys1.json"],
+                self.responses["meijucloud_get_keys2.json"],
+            ],
+        )
+        session.request = AsyncMock(return_value=response)
+        cloud = get_midea_cloud(
+            "美的美居",
+            session=session,
+            account="account",
+            password="password",
+        )
+        assert cloud is not None
+
+        keys: dict = await cloud.get_cloud_keys(100)
+        assert keys[1]["token"] == "method1_return_token1"
+        assert keys[1]["key"] == "method1_return_key1"
+        assert keys[2]["token"] == "method2_return_token2"
+        assert keys[2]["key"] == "method2_return_key2"
+        assert len(keys) == 2
+
+    async def test_meijucloud_get_keys_no_home(self) -> None:
+        """Test MeijuCloud get_cloud_keys when the home list is unavailable."""
+        session = Mock()
+        response = Mock()
+        response.read = AsyncMock(
+            side_effect=[
+                # list_home fails, so v2 is skipped entirely
+                self.responses["cloud_invalid_response.json"],
+                # v1 fallback
+                self.responses["meijucloud_get_keys1.json"],
+                self.responses["cloud_invalid_response.json"],
+            ],
+        )
+        session.request = AsyncMock(return_value=response)
+        cloud = get_midea_cloud(
+            "美的美居",
+            session=session,
+            account="account",
+            password="password",
+        )
+        assert cloud is not None
+
+        keys: dict = await cloud.get_cloud_keys(100)
+        assert keys[1]["token"] == "method1_return_token1"
+        assert len(keys) == 1
 
     async def test_meijucloud_list_home(self) -> None:
         """Test MeijuCloud list_home."""

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -25,6 +25,14 @@ from midealan.cloud import (
 )
 from midealan.exceptions import ElementMissing
 
+# ``CloudSecurity.get_udp_id(100, method)``. Hard-coded on purpose: deriving them
+# with the same helper the implementation calls would not catch a request that
+# sends the wrong method's UDP ID.
+UDP_IDS = {
+    1: "dec4da86e0aeefadde14a4e553680b9b",
+    2: "b2dd199071d527a33c8239833a5bf5fb",
+}
+
 
 def _token_requests(session: Mock) -> list[tuple[str, dict]]:
     """Return (url, payload) for every getToken request the client actually sent.
@@ -287,9 +295,13 @@ class CloudTest(IsolatedAsyncioTestCase):
         assert requests
         for url, payload in requests:
             assert url.endswith("/v2/iot/secure/getToken")
-            assert payload["homegroupId"]
-            assert payload["udpid"]
             assert payload["applianceCodes"] == ["100"]
+        # Each of the three lookups stops at the first home that returns a key,
+        # so the exact sequence is home "1" x method 1, method 2 -- three times.
+        assert [(p["homegroupId"], p["udpid"]) for _url, p in requests] == [
+            ("1", UDP_IDS[1]),
+            ("1", UDP_IDS[2]),
+        ] * 3
 
     async def test_meijucloud_get_keys_v2_fallback_to_v1(self) -> None:
         """Test MeijuCloud falls back to the v1 endpoint when v2 returns nothing."""
@@ -329,13 +341,21 @@ class CloudTest(IsolatedAsyncioTestCase):
         requests = _token_requests(session)
         v2 = [r for r in requests if r[0].endswith("/v2/iot/secure/getToken")]
         v1 = [r for r in requests if r[0].endswith("/v1/iot/secure/getToken")]
-        assert len(v2) == 4
-        assert len(v1) == 2
         for _url, payload in v2:
             assert payload["applianceCodes"] == ["100"]
         for _url, payload in v1:
             # the inherited v1 implementation sends the plain string form
             assert payload["applianceCodes"] == "100"
+        # Both homes are tried, each with both methods, in order.
+        assert [(p["homegroupId"], p["udpid"]) for _url, p in v2] == [
+            ("1", UDP_IDS[1]),
+            ("1", UDP_IDS[2]),
+            ("2", UDP_IDS[1]),
+            ("2", UDP_IDS[2]),
+        ]
+        # v1 keeps the method-specific UDP ID but carries no home.
+        assert [p["udpid"] for _url, p in v1] == [UDP_IDS[1], UDP_IDS[2]]
+        assert all("homegroupId" not in p for _url, p in v1)
 
     async def test_meijucloud_get_keys_no_home(self) -> None:
         """Test MeijuCloud get_cloud_keys when the home list is unavailable."""

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -1,5 +1,6 @@
 """Test cloud."""
 
+import json
 from hashlib import md5
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -23,6 +24,22 @@ from midealan.cloud import (
     get_preset_account_cloud,
 )
 from midealan.exceptions import ElementMissing
+
+
+def _token_requests(session: Mock) -> list[tuple[str, dict]]:
+    """Return (url, payload) for every getToken request the client actually sent.
+
+    The response side_effect only controls what comes back; these assertions
+    pin down what goes out, so a regression to the v1 endpoint or to a
+    string-valued ``applianceCodes`` cannot pass silently.
+    """
+    out = []
+    for call in session.request.await_args_list:
+        url = call.args[1] if len(call.args) > 1 else call.kwargs.get("url", "")
+        if "getToken" not in url:
+            continue
+        out.append((url, json.loads(call.kwargs["data"])))
+    return out
 
 
 class CloudTest(IsolatedAsyncioTestCase):
@@ -264,6 +281,16 @@ class CloudTest(IsolatedAsyncioTestCase):
         assert len(keys) == 1
         assert keys == DEFAULT_KEYS
 
+        # Pin the outbound contract: every lookup must hit v2 and send
+        # homegroupId + udpid + a list-valued applianceCodes.
+        requests = _token_requests(session)
+        assert requests
+        for url, payload in requests:
+            assert url.endswith("/v2/iot/secure/getToken")
+            assert payload["homegroupId"]
+            assert payload["udpid"]
+            assert payload["applianceCodes"] == ["100"]
+
     async def test_meijucloud_get_keys_v2_fallback_to_v1(self) -> None:
         """Test MeijuCloud falls back to the v1 endpoint when v2 returns nothing."""
         session = Mock()
@@ -298,6 +325,18 @@ class CloudTest(IsolatedAsyncioTestCase):
         assert keys[2]["key"] == "method2_return_key2"
         assert len(keys) == 2
 
+        # v2 is tried for both homes x both methods, then v1 once per method.
+        requests = _token_requests(session)
+        v2 = [r for r in requests if r[0].endswith("/v2/iot/secure/getToken")]
+        v1 = [r for r in requests if r[0].endswith("/v1/iot/secure/getToken")]
+        assert len(v2) == 4
+        assert len(v1) == 2
+        for _url, payload in v2:
+            assert payload["applianceCodes"] == ["100"]
+        for _url, payload in v1:
+            # the inherited v1 implementation sends the plain string form
+            assert payload["applianceCodes"] == "100"
+
     async def test_meijucloud_get_keys_no_home(self) -> None:
         """Test MeijuCloud get_cloud_keys when the home list is unavailable."""
         session = Mock()
@@ -323,6 +362,12 @@ class CloudTest(IsolatedAsyncioTestCase):
         keys: dict = await cloud.get_cloud_keys(100)
         assert keys[1]["token"] == "method1_return_token1"
         assert len(keys) == 1
+
+        # No home list means v2 is skipped entirely; only v1 is called.
+        requests = _token_requests(session)
+        assert requests
+        for url, _payload in requests:
+            assert url.endswith("/v1/iot/secure/getToken")
 
     async def test_meijucloud_list_home(self) -> None:
         """Test MeijuCloud list_home."""


### PR DESCRIPTION
Fixes #43.

## Problem

The Meiju cloud retired `/v1/iot/secure/getToken`; its gateway answers
`{"code":40404,"msg":"调用业务系统异常(访问地址不存在)"}` for that alias. So
`MideaCloud.get_cloud_keys()` returns `{}` for Meiju accounts and **no V3 device can be
added at all** (`Can't get available token from Midea server` in `midea_ac_lan`).
Login and the appliance listing still work — only token retrieval is broken.

Issue #43 has the full diagnosis, including how the replacement endpoint and its payload
were identified from the gateway's own error codes.

## Change

Override `get_cloud_keys()` on `MeijuCloud`:

- POST to `/v2/iot/secure/getToken` instead of the v1 path
- add `homegroupId` (from the existing `list_home()`) to the payload
- send `applianceCodes` as a **list** — v2 rejects the plain string v1 accepted with
  `1002 none parameter is found`
- iterate homes, stopping at the first one that returns keys
- **fall back to `super().get_cloud_keys()` whenever v2 yields nothing**, so this is a
  no-op for any account or deployment the v1 endpoint still serves, and it degrades
  gracefully if `list_home()` fails

Scoped to `MeijuCloud` only — `SmartHomeCloud` and `MideaAirCloud` are untouched, since I
can only test against a mainland-China Meiju account.

## Verification

- Real account, real hardware: token/key from the v2 endpoint authenticate against an AC
  (`0xAC`, KFR-26G/N8ZJA3) and a microwave oven (`0xB0`, PG2333W); both then run in
  `midea_ac_lan` with 49 and 10 live entities.
- `python -m pytest ./tests/` — 1630 passed, coverage 99% overall.
- `prek run --all-files` — ruff check/format, prettier, pyupgrade, codespell, mypy
  (strict), pylint all pass.
- Tests: updated `test_meijucloud_get_keys` for the new request sequence, and added
  `test_meijucloud_get_keys_v2_fallback_to_v1` and `test_meijucloud_get_keys_no_home`
  to cover both fallback paths. No new fixtures needed — v2 returns the same
  `tokenlist` shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved cloud key retrieval when token responses are missing or empty.
  * Reduced exposure of sensitive token and key details in diagnostic logs by recording entry counts instead.
  * Improved reliability across supported connection methods, timeout scenarios, and fallback behavior.
  * Preserved existing token matching and key extraction behavior.
  * Improved handling of unavailable login responses and incomplete downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->