### PR TITLE
fix(fa): support extended fan modes

### DIFF
--- a/midealan/devices/fa/__init__.py
+++ b/midealan/devices/fa/__init__.py
@@ -62,21 +62,29 @@ class MideaFADevice(MideaDevice):
         "Reserved",
         "Both",
     ]
-    _modes: ClassVar[list[str]] = [
-        "Normal",
-        "Natural",
-        "Sleep",
-        "Comfort",
-        "Silent",
-        "Baby",
-        "Induction",
-        "Circulation",
-        "Strong",
-        "Soft",
-        "Customize",
-        "Warm",
-        "Smart",
-    ]
+    _modes: ClassVar[dict[int, str]] = {
+        0x00: "Invalid",
+        0x01: "Normal",
+        0x02: "Natural",
+        0x03: "Sleep",
+        0x04: "Comfort",
+        0x05: "Mute",
+        0x06: "Baby",
+        0x07: "Feel",
+        0x08: "Storm",
+        0x09: "Strong",
+        0x0A: "Soft",
+        0x0B: "Customize",
+        0x0C: "Warm",
+        0x0D: "Smart",
+        0x0E: "Ionic",
+        0x0F: "AI_Smart",
+        0x10: "Double_Area",
+        0x11: "Purified_Wind",
+        0x12: "Sleeping_Wind",
+        0x13: "Purify_Only",
+        0x14: "Self_Selection",
+    }
 
     def __init__(
         self,
@@ -129,7 +137,7 @@ class MideaFADevice(MideaDevice):
     @property
     def preset_modes(self) -> list[str]:
         """Return a list of preset modes."""
-        return self._modes
+        return list(MideaFADevice._modes.values())
 
     def build_query(self) -> list[MessageQuery]:
         """Midea FA device build query."""
@@ -163,10 +171,7 @@ class MideaFADevice(MideaDevice):
                     else:
                         self._attributes[status] = None
                 elif status == DeviceAttributes.mode:
-                    if value < len(MideaFADevice._modes):
-                        self._attributes[status] = MideaFADevice._modes[value]
-                    else:
-                        self._attributes[status] = None
+                    self._attributes[status] = MideaFADevice._modes.get(value)
                 elif status == DeviceAttributes.power:
                     self._attributes[status] = value
                     if not value:
@@ -311,9 +316,12 @@ class MideaFADevice(MideaDevice):
             message.fan_speed = int(value)
             message.power = True
         elif attr == DeviceAttributes.mode:
-            if value in MideaFADevice._modes:
+            if value in MideaFADevice._modes.values():
                 message = MessageSet(self._message_protocol_version, self.subtype)
-                message.mode = MideaFADevice._modes.index(str(value))
+                message.mode = MideaFADevice.get_dict_key_by_value(
+                    "_modes",
+                    str(value),
+                )
         elif not (attr == DeviceAttributes.fan_speed and value == 0):
             message = MessageSet(self._message_protocol_version, self.subtype)
             setattr(message, str(attr), value)
@@ -326,8 +334,8 @@ class MideaFADevice(MideaDevice):
         message.power = True
         if fan_speed is not None:
             message.fan_speed = fan_speed
-        if mode is not None and mode in MideaFADevice._modes:
-            message.mode = MideaFADevice._modes.index(mode)
+        if mode is not None and mode in MideaFADevice._modes.values():
+            message.mode = MideaFADevice.get_dict_key_by_value("_modes", mode)
         self.build_send(message)
 
     def set_customize(self, customize: str) -> None:

--- a/midealan/devices/fa/message.py
+++ b/midealan/devices/fa/message.py
@@ -177,7 +177,7 @@ class MessageSet(MessageFABase):
             else:
                 _body_return[2] = 2
         if self.mode is not None:
-            _body_return[3] = 1 | (((self.mode + 1) << 1) & 0x1E)
+            _body_return[3] = 1 | ((self.mode << 1) & 0x3E)
         if self.fan_speed is not None and 1 <= self.fan_speed <= MAX_FAN_SPEED:
             _body_return[4] = self.fan_speed
         if self.oscillate is not None:
@@ -228,9 +228,7 @@ class FAGeneralMessageBody(MessageBody):
         else:
             self.child_lock = False
         self.power = (body[4] & 0x01) > 0
-        mode = (body[4] & 0x1E) >> 1
-        if mode > 0:
-            self.mode = mode - 1
+        self.mode = (body[4] & 0x3E) >> 1
         fan_speed = body[5]
         if 1 <= fan_speed <= MAX_FAN_SPEED:
             self.fan_speed = fan_speed

--- a/tests/devices/fa/device_fa_test.py
+++ b/tests/devices/fa/device_fa_test.py
@@ -90,8 +90,9 @@ class TestMideaFADevice:
             "Reserved",
             "Both",
         ]
-        assert self.device.preset_modes[0] == "Normal"
-        assert len(self.device.preset_modes) == 13
+
+        assert self.device.preset_modes[0] == "Invalid"
+        assert len(self.device.preset_modes) == 21
 
     def test_build_query(self) -> None:
         """Test build query."""
@@ -132,7 +133,7 @@ class TestMideaFADevice:
     def test_notify_response_out_of_range_values(self) -> None:
         """Test notify1 response with out-of-range values mapped to None."""
         body = bytearray(36)
-        body[4] = 0x1F  # power on, mode raw 15 -> 14 -> out of range
+        body[4] = 0x2B  # power on, mode raw 21 -> out of range
         body[5] = 27  # fan speed out of range -> 0
         body[8] = 0x7F  # oscillate on, angle 7 and mode 7 out of range
         body[25] = 20  # tilting angle out of range
@@ -165,7 +166,7 @@ class TestMideaFADevice:
         assert self.device.attributes[DeviceAttributes.humidify] is False
         assert self.device.attributes[DeviceAttributes.waterions] is False
         assert self.device.attributes[DeviceAttributes.display_on_off] is False
-        assert DeviceAttributes.mode.value not in new_status
+        assert new_status[DeviceAttributes.mode.value] == "Invalid"
 
     def test_unexpected_response(self) -> None:
         """Test notify2 response is not parsed."""
@@ -393,7 +394,12 @@ class TestMideaFADevice:
         with patch.object(self.device, "build_send") as mock_build_send:
             self.device.set_attribute(DeviceAttributes.mode.value, "Sleep")
             mock_build_send.assert_called_once()
-            assert mock_build_send.call_args[0][0].mode == 2
+            assert mock_build_send.call_args[0][0].mode == 3
+            mock_build_send.reset_mock()
+
+            self.device.set_attribute(DeviceAttributes.mode.value, "Ionic")
+            mock_build_send.assert_called_once()
+            assert mock_build_send.call_args[0][0].mode == 14
             mock_build_send.reset_mock()
 
             self.device.set_attribute(DeviceAttributes.mode.value, "invalid")
@@ -436,7 +442,7 @@ class TestMideaFADevice:
             message = mock_build_send.call_args[0][0]
             assert message.power is True
             assert message.fan_speed == 3
-            assert message.mode == 0
+            assert message.mode == 1
             mock_build_send.reset_mock()
 
             self.device.turn_on(mode="invalid")

--- a/tests/devices/fa/message_fa_test.py
+++ b/tests/devices/fa/message_fa_test.py
@@ -91,11 +91,18 @@ class TestMessageSet:
         msg.lock = lock
         assert msg._body[2] == expected
 
-    def test_body_mode(self) -> None:
+    @pytest.mark.parametrize(
+        ("mode", "expected"),
+        [
+            (3, 0x07),  # Sleep
+            (20, 0x29),  # Self_Selection
+        ],
+    )
+    def test_body_mode(self, mode: int, expected: int) -> None:
         """Test set body mode."""
         msg = MessageSet(ProtocolVersion.V1, 1)
-        msg.mode = 2
-        assert msg._body[3] == 0x07
+        msg.mode = mode
+        assert msg._body[3] == expected
 
     def test_body_fan_speed_valid(self) -> None:
         """Test set body with a valid fan speed."""
@@ -188,12 +195,12 @@ class TestFAGeneralMessageBody:
         body = FAGeneralMessageBody(bytearray(10))
         assert body.child_lock is False
         assert body.power is False
+        assert body.mode == 0
         assert body.fan_speed == 0
         assert body.tilting_angle == 0
         assert body.humidify is False
         assert body.waterions is False
         assert body.display_on_off is False
-        assert not hasattr(body, "mode")
 
 
 class TestMessageFAResponse:
@@ -210,8 +217,19 @@ class TestMessageFAResponse:
         )
         assert getattr(msg, "power", None) is True
         assert getattr(msg, "child_lock", None) is True
-        assert getattr(msg, "mode", None) == 0
+        assert getattr(msg, "mode", None) == 1
         assert getattr(msg, "fan_speed", None) == 3
+
+    def test_query_response_extended_mode(self) -> None:
+        """Test parsing an extended FA mode."""
+        body = bytearray(36)
+        body[4] = 0x29  # Self_Selection
+
+        msg = MessageFAResponse(
+            _build_message(ProtocolVersion.V1, MessageType.query, body),
+        )
+
+        assert getattr(msg, "mode", None) == 20
 
     def test_notify2_response_ignored(self) -> None:
         """Test notify2 response is not parsed."""


### PR DESCRIPTION
## Summary

Update FA mode handling based on the modes implementation from #13.

FA modes now use their actual protocol values directly instead of the previous
zero-based values caused by `self.mode = mode - 1`.

## Changes

- Add the full FA mode table from #13
- Use the full 5-bit mode field
- Remove the `+1` / `-1` offset when encoding and decoding modes
- Add tests for extended modes including Ionic and Self_Selection

## Testing

- `uv run prek run --all-files`
- `uv run python -m pytest ./tests/`
- 1662 tests passed

Related: #13