### PR TITLE
fix(c3): correct outdoor fan speed parsing and add regression coverage

### DIFF
--- a/midealan/devices/c3/message.py
+++ b/midealan/devices/c3/message.py
@@ -12,6 +12,8 @@ from midealan.message import (
 )
 
 TEMP_NEG_VALUE = 127
+# Outdoor fan speed is transmitted as RPM / 10.
+FAN_SPEED_FACTOR = 10
 
 
 class C3SilentLevel(IntEnum):
@@ -410,7 +412,12 @@ class C3UnitParaBody(MessageBody):
         super().__init__(body)
         self.comp_run_freq = body[data_offset]
         self.unit_mode_run = body[data_offset + 1]
-        self.fan_speed = body[data_offset + 3] * 10
+        # Outdoor fan speed, transmitted as RPM / 10 in a single byte.
+        # It lives at data_offset + 2, directly after unit_mode_run; the
+        # previous data_offset + 3 read a neighbouring byte that is small and
+        # nearly constant while the unit runs, so fan_speed was reported as a
+        # fixed low value (typically 20) regardless of the real fan command.
+        self.fan_speed = body[data_offset + 2] * FAN_SPEED_FACTOR
         self.fg_capacity_need = body[data_offset + 5]
         self.temp_t3 = body[data_offset + 6]
         self.temp_t4 = body[data_offset + 7]

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -278,7 +278,8 @@ class TestMessageC3Response:
         body[0] = ListTypes.X10
         body[1] = 7
         body[2] = 3
-        body[4] = 4
+        body[3] = 4  # fan_speed / 10
+        body[4] = 2  # not fan_speed, must not leak into it
         body[6] = 11
         body[7] = 12
         body[8] = 13
@@ -503,7 +504,8 @@ class TestMessageC3Response:
         body[0] = ListTypes.X10
         body[1] = 50  # comp_run_freq
         body[2] = 2  # unit_mode_run
-        body[4] = 8  # fan_speed / 10
+        body[3] = 8  # fan_speed / 10
+        body[4] = 2  # not fan_speed, must not leak into it
         body[6] = 9  # fg_capacity_need
         body[8] = 30  # temp_t4
         body[10] = 40  # temp_tw_in
@@ -541,3 +543,97 @@ class TestMessageC3Response:
         assert response.total_electricity0 == 10
         assert hasattr(response, "instant_power0")
         assert response.instant_power0 == 500
+
+
+class TestC3UnitParaFanSpeed:
+    """Regression tests for the X10 (UNITPARA) outdoor fan speed offset.
+
+    The frames below are taken from LAN captures of a Hyundai HYHC-V30W/D2RN8
+    monobloc heat pump (OEM-equivalent Midea MHC-V30W/D2RN8, device type 0xC3,
+    protocol version 3, Wi-Fi module 171H120F). Only the first four X10 data
+    bytes are pinned, because those are the ones the capture confirms:
+
+    * data[0] - compressor running frequency in Hz
+    * data[1] - unit running mode (2 = cooling)
+    * data[2] - outdoor fan speed in RPM / 10
+    * data[3] - a different, near-constant quantity that the pre-fix parser
+      mistakenly reported as the fan speed
+
+    The remaining data bytes are left at zero; this test intentionally asserts
+    only on the fields the captures verify.
+    """
+
+    HEADER = bytearray(
+        [
+            0xAA,
+            0x00,
+            0xC3,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x03,  # protocol version 3
+            MessageType.query,
+        ],
+    )
+
+    @staticmethod
+    def _build_response(data_head: bytes) -> MessageC3Response:
+        """Build an X10 query response whose payload starts with data_head."""
+        body = bytearray(88)  # body type + 86 data bytes + CRC
+        body[0] = ListTypes.X10
+        body[1 : 1 + len(data_head)] = data_head
+        return MessageC3Response(
+            bytes(TestC3UnitParaFanSpeed.HEADER + body),
+        )
+
+    @pytest.mark.parametrize(
+        ("data_head", "comp_run_freq", "fan_speed"),
+        [
+            # Cooling at 57 Hz, fan command 0x40 -> 640 RPM (Super Silent).
+            (b"\x39\x02\x40\x02", 57, 640),
+            # Cooling at 35 Hz, fan command 0x3f -> 630 RPM (Super Silent).
+            (b"\x23\x02\x3f\x02", 35, 630),
+            # Compressor thermo-off: the outdoor fan keeps running for a short
+            # post-run at 0x4a -> 740 RPM while the compressor is already at 0.
+            (b"\x00\x02\x4a\x02", 0, 740),
+            # Post-run finished: fan command 0 and the fans physically stopped.
+            (b"\x00\x02\x00\x02", 0, 0),
+        ],
+        ids=["cooling_57hz", "cooling_35hz", "thermo_off_fan_post_run", "fan_stopped"],
+    )
+    def test_fan_speed_is_read_after_unit_mode_run(
+        self,
+        data_head: bytes,
+        comp_run_freq: int,
+        fan_speed: int,
+    ) -> None:
+        """Test fan speed comes from the byte right after the running mode."""
+        response = self._build_response(data_head)
+
+        assert response.body_type == ListTypes.X10
+        assert hasattr(response, "comp_run_freq")
+        assert hasattr(response, "unit_mode_run")
+        assert hasattr(response, "fan_speed")
+        assert response.comp_run_freq == comp_run_freq
+        assert response.unit_mode_run == C3DeviceMode.COOL
+        assert response.unit_mode_run == 2
+        assert response.fan_speed == fan_speed
+
+    def test_fan_speed_is_independent_of_compressor_state(self) -> None:
+        """Test a stopped compressor does not force the fan speed to zero."""
+        running = self._build_response(b"\x39\x02\x40\x02")
+        post_run = self._build_response(b"\x00\x02\x4a\x02")
+        stopped = self._build_response(b"\x00\x02\x00\x02")
+        assert hasattr(running, "comp_run_freq")
+        assert hasattr(post_run, "comp_run_freq")
+        assert hasattr(post_run, "fan_speed")
+        assert hasattr(stopped, "comp_run_freq")
+        assert hasattr(stopped, "fan_speed")
+
+        assert running.comp_run_freq > 0
+        assert post_run.comp_run_freq == 0
+        assert post_run.fan_speed > 0
+        assert stopped.comp_run_freq == 0
+        assert stopped.fan_speed == 0


### PR DESCRIPTION
## Summary

The C3 X10 (`UNITPARA`) response body read the outdoor fan speed from
`body[data_offset + 3]`. That byte is not the fan command. On a real unit it is
small and nearly constant while the compressor runs, so `fan_speed` was reported
as a fixed low value, typically `20`, during all active operation, including
while the outdoor fans were physically spinning at several hundred RPM.

The outdoor fan speed is at `body[data_offset + 2]`, directly after
`unit_mode_run`, and is transmitted as RPM / 10.

```diff
 self.comp_run_freq = body[data_offset]
 self.unit_mode_run = body[data_offset + 1]
-self.fan_speed = body[data_offset + 3] * 10
+self.fan_speed = body[data_offset + 2] * FAN_SPEED_FACTOR
```

Scope is deliberately minimal: the attribute keeps its name, its `int` type and
the existing `× 10` scaling, no other offset is touched, no other device family
is affected, and no new attribute is introduced. C3 has no protocol-version
branching for X10 (`MessageC3Response` dispatches `ListTypes.X10` unconditionally
and `MessageQueryUnitPara` is version-independent), so a single layout applies.

## Evidence

**Real-device observation.** LAN captures from a Hyundai HYHC-V30W/D2RN8
monobloc heat pump (OEM-equivalent Midea MHC-V30W/D2RN8, device type `0xC3`,
protocol version 3, Wi-Fi module `171H120F`), running with Home Assistant
2026.8.x:

| X10 data bytes | compressor | mode | byte at `+2` | fan behaviour observed |
| --- | --- | --- | --- | --- |
| `39 02 40 ...` | 57 Hz | cooling | `0x40` -> 640 RPM | fans running normally |
| `23 02 3f ...` | 35 Hz | cooling | `0x3f` -> 630 RPM | fans running normally |
| `00 02 4a ...` | 0 Hz | n/a | `0x4a` -> 740 RPM | short fan post-run after compressor stop |
| `00 02 00 ...` | 0 Hz | n/a | `0x00` -> 0 RPM | fans independently verified stopped |

The byte at `+2` was `0x3F`/`0x40` across dozens of samples during stable Super
Silent operation while the compressor frequency varied over roughly 27 to 61 Hz,
i.e. it tracks the fan command rather than the compressor. It stayed non-zero for
the fan post-run that follows a compressor thermo-off and dropped to `0x00`
about 30 s later, at the moment the physical fans stopped. Because of that
post-run, `fan_speed` must stay independent of compressor state. This change
does not derive it from `comp_run_freq`, and a regression test pins that.

**Protocol documentation.** Confirmed against Midea's own C3 lua for this exact
Wi-Fi module, [`T_0000_C3_171H120F_2023062601.lua`](https://github.com/wuwentao/midea-lua/blob/08d62f090c0ae3772f91a73feecc2c20e59dff85/lua/T_0000_C3_171H120F_2023062601.lua#L4269).
In the `MSG_TYPE_QUERY_UNITPARA` block (lua is 1-indexed, so `_bodyBytes[N]` is
`body[data_offset + N - 1]`):

```lua
binToModel(streams, "compRunFreq", _bodyBytes[1], nil)   -- body[data_offset]
binToModel(streams, "unitModeRun", _bodyBytes[2], nil)   -- body[data_offset + 1]
binToModel(streams, "fanSpeed",    _bodyBytes[3] * 10)   -- body[data_offset + 2]
binToModel(streams, "machVersion", _bodyBytes[4], nil)   -- body[data_offset + 3]
```

This also explains the reported symptom: the byte previously read is
`machVersion`, which is `2` on the test unit, so `fan_speed` was pinned at `20`.

**Structural / protocol evidence.** `x 10` on a single byte is the library's
existing convention for a fan speed expressed in RPM; compare
`midealan/devices/ac/message.py`, where `indoor_fan_speed` /
`target_indoor_fan_speed` are `raw × XC1_FAN_SPEED_FACTOR` and are surfaced in
`REVOLUTIONS_PER_MINUTE`. The corrected byte yields plausible outdoor-fan RPM
(0, 630 to 740); the previous byte yielded a constant 20 "RPM".

**Not claimed here.** The meaning of the byte at `data_offset + 3` (the one the
old code read) is not established by these captures, so this change leaves it
unread rather than renaming or re-purposing it. Nothing else in the X10 layout
is re-interpreted.

## Tests

New `TestC3UnitParaFanSpeed` builds X10 query responses from the captured
leading bytes and asserts on the three fields the captures confirm:

- compressor 57 Hz / cooling / 640 RPM
- compressor 35 Hz / cooling / 630 RPM
- compressor 0 Hz with a 740 RPM fan post-run
- compressor 0 Hz with fan 0 RPM
- `unit_mode_run == 2` (cooling) on every cooling frame
- fan speed reported independently of compressor state

Each frame also sets the byte at `data_offset + 3` to a non-zero decoy so the
tests fail with the old offset. Running the new tests against the unpatched
parser reproduces the reported bug exactly (`fan_speed == 20`).

The two existing synthetic X10 tests moved their fan byte from `body[4]` to
`body[3]` and gained the same decoy; their assertions are unchanged.

`pytest ./tests/` (1669 passed), `ruff check`, `ruff format --check`,
`mypy midealan` and `pylint --rcfile=pylintrc midealan` are all clean.

## Relation to #46

wuwentao/midea-lan#46 contains the same `+2` correction (credited there to a
wired-HMI correlation, which independently corroborates these captures), but it
is bundled with ~700 lines of additional C3 work, ships no tests, and in its
current state does not import: `midealan/devices/c3/message.py` still imports
from `midealocal.*`, and `midealan/devices/c3/__init__.py` contains 398
markdown-escaped `\_` sequences that are a `SyntaxError`. It also wraps
`fan_speed` in a `C3FanSpeed` enum whose members (`0/10/20/30/40`) were derived
from the *old* offset, so with the corrected offset a stopped fan decodes to the
string `'off'` while a running fan decodes to an `int`, verified by running that
branch against the frames above.

This PR is intentionally the isolated, testable fan-speed correction so it can
land independently of that larger effort.
