### PR TITLE
fix(c3): align four X10 UnitPara offsets with the official lua protocol

### DIFF
--- a/midealan/devices/c3/message.py
+++ b/midealan/devices/c3/message.py
@@ -420,7 +420,8 @@ class C3UnitParaBody(MessageBody):
         # nearly constant while the unit runs, so fan_speed was reported as a
         # fixed low value (typically 20) regardless of the real fan command.
         self.fan_speed = body[data_offset + 2] * FAN_SPEED_FACTOR
-        self.fg_capacity_need = body[data_offset + 5]
+        # lua _bodyBytes[5]; data_offset + 5 is the disabled `tempset` byte.
+        self.fg_capacity_need = body[data_offset + 4]
         self.temp_t3 = body[data_offset + 6]
         self.temp_t4 = body[data_offset + 7]
         self.temp_tp = body[data_offset + 8]
@@ -456,12 +457,21 @@ class C3UnitParaBody(MessageBody):
         self.idu_t1s2 = body[data_offset + 53]
         self.water_flower = body[data_offset + 54] * 256 + body[data_offset + 55]
         self.odu_plan_vol_lmt = body[data_offset + 56]
-        self.current_unit_capacity = body[data_offset + 57]
+        # lua _bodyBytes[58] * 256 + _bodyBytes[59]; the low byte was dropped.
+        self.current_unit_capacity = (
+            body[data_offset + 57] * 256 + body[data_offset + 58]
+        )
         self.sphera_ahs_voltage = body[data_offset + 59]
         self.temp_t4a_ver = body[data_offset + 60]
         self.water_pressure = body[data_offset + 61] * 256 + body[data_offset + 62]
         self.room_rel_hum = body[data_offset + 63]
-        self.pwm_pump_out = body[data_offset + 63]
+        # lua _bodyBytes[65]; data_offset + 63 duplicated room_rel_hum.
+        # On a 171H120F this byte reads 0 while the MSG_TYPE_UP_UNITPARA
+        # notify reports pwmPumpOut = 99, so this firmware appears not to
+        # populate it in the query response. _bodyBytes[66], which happens
+        # to hold a constant 99, is marked reserved by the lua and is not
+        # used here.
+        self.pwm_pump_out = body[data_offset + 64]
         self.total_electricity0 = (
             (body[data_offset + 66] << 24)
             + (body[data_offset + 67] << 16)
@@ -490,8 +500,15 @@ class C3UnitParaBody(MessageBody):
         self.instant_renew_power0 = (body[data_offset + 84] << 8) + (
             body[data_offset + 85]
         )
-        self.total_renew_power0 = (body[data_offset + 84] << 8) + (
-            body[data_offset + 85]
+        # lua _bodyBytes[87..90] as a 32 bit value; data_offset + 84,85
+        # duplicated instant_renew_power0. Read defensively: the lua frame runs
+        # to _bodyBytes[191] but this parser previously stopped at
+        # data_offset + 85, so shorter bodies must not raise.
+        self.total_renew_power0 = (
+            (self.read_byte(body, data_offset + 86) << 24)
+            + (self.read_byte(body, data_offset + 87) << 16)
+            + (self.read_byte(body, data_offset + 88) << 8)
+            + self.read_byte(body, data_offset + 89)
         )
 
 

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -506,7 +506,8 @@ class TestMessageC3Response:
         body[2] = 2  # unit_mode_run
         body[3] = 8  # fan_speed / 10
         body[4] = 2  # not fan_speed, must not leak into it
-        body[6] = 9  # fg_capacity_need
+        body[5] = 9  # fg_capacity_need
+        body[6] = 3  # tempset, disabled in the lua; must not leak into it
         body[8] = 30  # temp_t4
         body[10] = 40  # temp_tw_in
         body[11] = 35  # temp_tw_out
@@ -785,3 +786,62 @@ class TestC3UnitParaNotify:
         assert hasattr(response, "silent_mode")
         assert response.silent_mode is True
         assert not hasattr(response, "comp_run_freq")
+
+
+class TestC3UnitParaLuaOffsets:
+    """Offsets in the X10 body checked against the official C3 lua protocol.
+
+    Reference: `T_0000_C3_171H120F_2023062601.lua`, `MSG_TYPE_QUERY_UNITPARA`.
+    The lua is 1-indexed, so `_bodyBytes[N]` is `body[data_offset + N - 1]`.
+    Each case places a distinct decoy on the byte the parser used to read, so
+    a regression cannot pass by picking up the neighbouring value.
+    """
+
+    HEADER = bytearray(
+        [0xAA, 0x00, 0xC3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, MessageType.query],
+    )
+
+    @staticmethod
+    def _build_response(values: dict[int, int]) -> MessageC3Response:
+        """Build an X10 query response with the given body bytes set."""
+        body = bytearray(96)
+        body[0] = ListTypes.X10
+        for index, value in values.items():
+            body[index] = value
+        return MessageC3Response(bytes(TestC3UnitParaLuaOffsets.HEADER + body))
+
+    def test_fg_capacity_need_lua_byte_5(self) -> None:
+        """Test fg_capacity_need is lua _bodyBytes[5], not the tempset byte."""
+        response = self._build_response({5: 9, 6: 3})
+        assert hasattr(response, "fg_capacity_need")
+        assert response.fg_capacity_need == 9
+
+    def test_current_unit_capacity_is_16_bit(self) -> None:
+        """Test current_unit_capacity is lua _bodyBytes[58] * 256 + [59]."""
+        response = self._build_response({58: 2, 59: 44})
+        assert hasattr(response, "current_unit_capacity")
+        assert response.current_unit_capacity == 556
+
+    def test_pwm_pump_out_lua_byte_65(self) -> None:
+        """Test pwm_pump_out is lua _bodyBytes[65], decoded independently."""
+        response = self._build_response({64: 46, 65: 80, 66: 99})
+        assert hasattr(response, "room_rel_hum")
+        assert hasattr(response, "pwm_pump_out")
+        assert response.room_rel_hum == 46
+        assert response.pwm_pump_out == 80
+
+    def test_total_renew_power0_is_32_bit(self) -> None:
+        """Test total_renew_power0 is lua _bodyBytes[87..90], not [85..86]."""
+        response = self._build_response({85: 1, 86: 244, 89: 1, 90: 2})
+        assert hasattr(response, "instant_renew_power0")
+        assert hasattr(response, "total_renew_power0")
+        assert response.instant_renew_power0 == 500
+        assert response.total_renew_power0 == 258
+
+    def test_short_body_does_not_raise(self) -> None:
+        """Test a body that stops at the old maximum still parses."""
+        body = bytearray(88)  # body type + 86 data bytes + CRC
+        body[0] = ListTypes.X10
+        response = MessageC3Response(bytes(self.HEADER + body))
+        assert hasattr(response, "total_renew_power0")
+        assert response.total_renew_power0 == 0


### PR DESCRIPTION
Follow-up to #51, as invited in
https://github.com/wuwentao/midea-lan/pull/51#issuecomment-5412892195.
Rebased onto `main` after #53, #54 and #55 merged, and squashed to a single
commit. The test file needed a manual resolve, since #54 and #55 appended their
own test classes to the same place; both were kept.

## Summary

I diffed the whole `C3UnitParaBody` against Midea's C3 lua for the 171H120F
module, [`T_0000_C3_171H120F_2023062601.lua`](https://github.com/wuwentao/midea-lua/blob/08d62f090c0ae3772f91a73feecc2c20e59dff85/lua/T_0000_C3_171H120F_2023062601.lua#L4269),
`MSG_TYPE_QUERY_UNITPARA` block. The lua is 1-indexed, so `_bodyBytes[N]` is
`body[data_offset + N - 1]`.

Every field in that block already matched, except four:

| attribute | was | lua says | effect of the bug |
|---|---|---|---|
| `fg_capacity_need` | `data_offset + 5` | `_bodyBytes[5]` = `data_offset + 4` | read the `tempset` byte, which the lua leaves commented out |
| `current_unit_capacity` | `data_offset + 57`, 1 byte | `_bodyBytes[58,59]` = u16 at `data_offset + 57,58` | low byte dropped |
| `pwm_pump_out` | `data_offset + 63` | `_bodyBytes[65]` = `data_offset + 64` | duplicated `room_rel_hum` |
| `total_renew_power0` | `data_offset + 84,85` | `_bodyBytes[87..90]` = u32 at `data_offset + 86..89` | duplicated `instant_renew_power0` |

Two further fields differ from the lua only in spelling (`water_flower` vs
`waterFlow`, `heat_elec_total_capacity0` vs `heatTotCapacity0`); their offsets
are correct, and renaming them would be a breaking change, so they are left
alone.

## Body length

`total_renew_power0` is the only one of the four that reads past the parser's
previous maximum of `data_offset + 85`. The lua frame runs to `_bodyBytes[191]`,
so the bytes exist in a full response, but rather than assume every firmware
sends a full-length body this uses the existing `MessageBody.read_byte` helper
and defaults to `0` on a short body. A regression test covers exactly that case
with an 86-data-byte body.

## Evidence

**Protocol documentation.** All four corrections come from the lua linked above,
and each one is cited inline in both the parser and the tests.

**Not claimed here.** No real-device confirmation of the corrected values yet.
Unlike the fan speed in #51, I have no captures that pin these four fields to
observed physical behaviour; the claim is only that the parser now matches the
published protocol. Happy to gather logs from my C3 (Hyundai HYHC-V30W/D2RN8,
OEM-equivalent Midea MHC-V30W/D2RN8, protocol 3, module 171H120F) if you would
like any of them confirmed against the device before merging.

## Tests

`TestC3UnitParaLuaOffsets` covers each of the four, with a distinct decoy value
placed on the byte the parser used to read so a regression cannot pass by
picking up the neighbouring value, plus the short-body case. All four fail
against the current parser and pass after the change.

`pytest ./tests/` (1674 passed), `ruff check`, `ruff format --check`,
`mypy midealan` and `pylint --rcfile=pylintrc midealan` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected PWM pump output readings using the proper response data.
  * Improved outdoor fan-speed and unit-capacity decoding.
  * Corrected 16-bit capacity and 32-bit renewable-power readings.
  * Improved handling of short device responses.
  * Added support for unsolicited unit-parameter notifications.

* **Tests**
  * Added regression coverage for documented offsets, compressor states, response formats, energy counters, capacity values, and unit-parameter notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->