### PR TITLE
feat(c3): expose outdoor-unit runtime telemetry as device attributes

### DIFF
--- a/midealan/devices/c3/__init__.py
+++ b/midealan/devices/c3/__init__.py
@@ -68,6 +68,9 @@ class DeviceAttributes(StrEnum):
     outdoor_temperature = "outdoor_temperature"
     temp_tw_in = "temp_tw_in"
     temp_tw_out = "temp_tw_out"
+    comp_run_freq = "comp_run_freq"
+    unit_mode_run = "unit_mode_run"
+    fan_speed = "fan_speed"
     instant_power0 = "instant_power0"
     silent_mode = "silent_mode"
     silent_level = "silent_level"
@@ -138,6 +141,9 @@ class MideaC3Device(MideaDevice):
                 DeviceAttributes.outdoor_temperature: None,
                 DeviceAttributes.temp_tw_in: None,
                 DeviceAttributes.temp_tw_out: None,
+                DeviceAttributes.comp_run_freq: None,
+                DeviceAttributes.unit_mode_run: None,
+                DeviceAttributes.fan_speed: None,
                 DeviceAttributes.instant_power0: None,
                 DeviceAttributes.error_code: 0,
             },

--- a/tests/devices/c3/device_c3_test.py
+++ b/tests/devices/c3/device_c3_test.py
@@ -336,3 +336,23 @@ class TestMideaC3Device:
         """Test invalid customize format."""
         self.device.set_customize("{")
         self.device.set_customize('{"temperature_step":"10"}')
+
+    def test_process_message_unit_para_exposes_odu_runtime(self) -> None:
+        """Test X10 outdoor-unit runtime values reach the device attributes."""
+        # Real-device X10 (UNITPARA) frame: compressor 0x39 = 57 Hz, mode
+        # 0x02 = cooling, outdoor fan 0x40 = 640 RPM.
+        header = bytearray(
+            [0xAA, 0x00, 0xC3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x03],
+        )
+        body = bytearray(88)  # body type + 86 data bytes + CRC
+        body[0] = 0x10
+        body[1:5] = b"\x39\x02\x40\x02"
+
+        new_status = self.device.process_message(bytes(header + body))
+
+        assert new_status[DeviceAttributes.comp_run_freq.value] == 57
+        assert new_status[DeviceAttributes.unit_mode_run.value] == C3DeviceMode.COOL
+        assert new_status[DeviceAttributes.fan_speed.value] == 640
+        assert self.device.attributes[DeviceAttributes.comp_run_freq] == 57
+        assert self.device.attributes[DeviceAttributes.unit_mode_run] == 2
+        assert self.device.attributes[DeviceAttributes.fan_speed] == 640


### PR DESCRIPTION
Follow-up to #51.

## Summary

`comp_run_freq`, `unit_mode_run` and `fan_speed` are decoded from the X10
(`UNITPARA`) response, but none of them are listed in C3's `DeviceAttributes`.
`process_message` only copies attributes it finds in `self._attributes`, so all
three are parsed and then dropped. Today they are visible only in the
`_LOGGER.debug` dump of the response, which means a user has to turn on DEBUG
logging to see whether their compressor or outdoor fan is running.

This adds the three to `DeviceAttributes` with `None` defaults, matching how
`temp_tw_in`, `temp_tw_out` and `instant_power0` are already exposed. Six lines,
no parser changes, no renames.

## Scope

Deliberately limited to the three X10 data bytes that are confirmed by both the
lua protocol and real-device captures, and that #51 established the layout for:

| attribute | lua field | byte |
|---|---|---|
| `comp_run_freq` | `compRunFreq` | `_bodyBytes[1]` |
| `unit_mode_run` | `unitModeRun` | `_bodyBytes[2]` |
| `fan_speed` | `fanSpeed` | `_bodyBytes[3]` |

`C3UnitParaBody` decodes many more fields, and I have not added those here.
Exposing the rest is a larger question about which values are trustworthy enough
to surface by default, and it overlaps #46, so it seemed better kept separate.

## Tests

New `test_process_message_unit_para_exposes_odu_runtime` feeds a captured X10
frame through `MideaC3Device.process_message` and asserts the values reach both
the returned status dict and `device.attributes`, so the whole path is covered
rather than just the parser. It fails without this change.

`pytest ./tests/` (1670 passed), `ruff check`, `ruff format --check`,
`mypy midealan` and `pylint --rcfile=pylintrc midealan` are clean.

## Note for the integration side

On its own this only makes the values reachable through the library API. Showing
them in Home Assistant still needs matching entity definitions in
`midea_ac_lan`, which I am happy to send separately once this is released.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for reporting compressor frequency, operating mode, and outdoor fan speed for C3 devices.
  - These values are now available in device status information and stored device attributes.

- **Bug Fixes**
  - Improved handling of C3 device parameter data from real-device status frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->