### PR TITLE
fix(c3): shift 32-bit energy counters by 24, not 32

### DIFF
--- a/midealan/devices/c3/message.py
+++ b/midealan/devices/c3/message.py
@@ -330,16 +330,18 @@ class C3EnergyBody(MessageBody):
         self.status_tbh = (status_byte & 0x08) > 0
         # bit4
         self.status_ibh = (status_byte & 0x10) > 0
+        # 32 bit big-endian counters: the lua multiplies the top byte by
+        # 16777216 (<< 24), not 4294967296.
         # total_energy_consumption
         self.total_energy_consumption = (
-            (body[data_offset + 1] << 32)
+            (body[data_offset + 1] << 24)
             + (body[data_offset + 2] << 16)
             + (body[data_offset + 3] << 8)
             + (body[data_offset + 4])
         )
         # total_produced_energy
         self.total_produced_energy = (
-            (body[data_offset + 5] << 32)
+            (body[data_offset + 5] << 24)
             + (body[data_offset + 6] << 16)
             + (body[data_offset + 7] << 8)
             + (body[data_offset + 8])
@@ -461,25 +463,25 @@ class C3UnitParaBody(MessageBody):
         self.room_rel_hum = body[data_offset + 63]
         self.pwm_pump_out = body[data_offset + 63]
         self.total_electricity0 = (
-            (body[data_offset + 66] << 32)
+            (body[data_offset + 66] << 24)
             + (body[data_offset + 67] << 16)
             + (body[data_offset + 68] << 8)
             + (body[data_offset + 69])
         )
         self.total_thermal0 = (
-            (body[data_offset + 70] << 32)
+            (body[data_offset + 70] << 24)
             + (body[data_offset + 71] << 16)
             + (body[data_offset + 72] << 8)
             + (body[data_offset + 73])
         )
         self.heat_elec_total_consum0 = (
-            (body[data_offset + 74] << 32)
+            (body[data_offset + 74] << 24)
             + (body[data_offset + 75] << 16)
             + (body[data_offset + 76] << 8)
             + (body[data_offset + 77])
         )
         self.heat_elec_total_capacity0 = (
-            (body[data_offset + 78] << 32)
+            (body[data_offset + 78] << 24)
             + (body[data_offset + 79] << 16)
             + (body[data_offset + 80] << 8)
             + (body[data_offset + 81])

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -389,9 +389,9 @@ class TestMessageC3Response:
         assert hasattr(response, "status_heating")
         assert response.status_heating is True
         assert hasattr(response, "total_energy_consumption")
-        assert response.total_energy_consumption == 214750114754
+        assert response.total_energy_consumption == 840610754
         assert hasattr(response, "total_produced_energy")
-        assert response.total_produced_energy == 90195765805
+        assert response.total_produced_energy == 353774125
         assert hasattr(response, "outdoor_temperature")
         assert response.outdoor_temperature == 30
         assert hasattr(response, "zone1_temp_set")
@@ -637,3 +637,69 @@ class TestC3UnitParaFanSpeed:
         assert post_run.fan_speed > 0
         assert stopped.comp_run_freq == 0
         assert stopped.fan_speed == 0
+
+
+class TestC3Energy32BitCounters:
+    """The 32 bit energy counters against the official C3 lua protocol.
+
+    Reference: `T_0000_C3_171H120F_2023062601.lua`. Every one of these counters
+    is built as `_bodyBytes[n] * 16777216 + _bodyBytes[n+1] * 65536 +
+    _bodyBytes[n+2] * 256 + _bodyBytes[n+3]`, so the most significant byte is
+    shifted by 24, not 32. The bug only shows once a counter passes 2 ** 24,
+    which is why the existing fixtures never caught it.
+    """
+
+    HEADER = bytearray([0xAA, 0x00, 0xC3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00])
+
+    def _response(self, msg_type: int, values: dict[int, int]) -> MessageC3Response:
+        """Build a C3 response with the given body bytes set."""
+        header = bytearray(self.HEADER)
+        header[-1] = msg_type
+        body = bytearray(96)
+        body[0] = ListTypes.X04 if msg_type == MessageType.notify1 else ListTypes.X10
+        for index, value in values.items():
+            body[index] = value
+        return MessageC3Response(bytes(header + body))
+
+    def test_notify_energy_counters_are_32_bit(self) -> None:
+        """Test the notify1 0x04 totals use a 24 bit shift on the top byte."""
+        response = self._response(
+            MessageType.notify1,
+            {2: 0x01, 3: 0x02, 4: 0x03, 5: 0x04, 6: 0x0A, 7: 0x0B, 8: 0x0C, 9: 0x0D},
+        )
+        assert hasattr(response, "total_energy_consumption")
+        assert hasattr(response, "total_produced_energy")
+        assert response.total_energy_consumption == 0x01020304
+        assert response.total_produced_energy == 0x0A0B0C0D
+
+    def test_unit_para_energy_counters_are_32_bit(self) -> None:
+        """Test the X10 totals use a 24 bit shift on the top byte."""
+        response = self._response(
+            MessageType.query,
+            {
+                67: 0x01,
+                68: 0x02,
+                69: 0x03,
+                70: 0x04,
+                71: 0x05,
+                72: 0x06,
+                73: 0x07,
+                74: 0x08,
+                75: 0x09,
+                76: 0x0A,
+                77: 0x0B,
+                78: 0x0C,
+                79: 0x0D,
+                80: 0x0E,
+                81: 0x0F,
+                82: 0x10,
+            },
+        )
+        assert hasattr(response, "total_electricity0")
+        assert hasattr(response, "total_thermal0")
+        assert hasattr(response, "heat_elec_total_consum0")
+        assert hasattr(response, "heat_elec_total_capacity0")
+        assert response.total_electricity0 == 0x01020304
+        assert response.total_thermal0 == 0x05060708
+        assert response.heat_elec_total_consum0 == 0x090A0B0C
+        assert response.heat_elec_total_capacity0 == 0x0D0E0F10

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -703,8 +703,8 @@ class TestC3Energy32BitCounters:
         assert response.total_thermal0 == 0x05060708
         assert response.heat_elec_total_consum0 == 0x090A0B0C
         assert response.heat_elec_total_capacity0 == 0x0D0E0F10
-        
-        
+
+
 class TestC3UnitParaNotify:
     """The MSG_TYPE_UP_UNITPARA notify body (message type 0x04, body 0x05).
 


### PR DESCRIPTION
Another one found by comparing against the C3 lua for the 171H120F module,
[`T_0000_C3_171H120F_2023062601.lua`](https://github.com/wuwentao/midea-lua/blob/08d62f090c0ae3772f91a73feecc2c20e59dff85/lua/T_0000_C3_171H120F_2023062601.lua).
Independent of #52; either can merge first.

## Summary

All six 32 bit counters in the C3 parser shift their most significant byte by
32 instead of 24:

```python
(body[data_offset + 1] << 32)   # multiplies by 4294967296
+ (body[data_offset + 2] << 16)
+ (body[data_offset + 3] << 8)
+ (body[data_offset + 4])
```

The lua builds every one of them the same way, and the top byte is always
`* 16777216`, which is `<< 24`:

```lua
binToModel(streams, "totalelectricity0",
           _bodyBytes[2] * 16777216 + _bodyBytes[3] * 65536 +
               _bodyBytes[4] * 256 + _bodyBytes[5], nil)
```

Affected fields:

| body | attribute |
|---|---|
| `C3EnergyBody` | `total_energy_consumption`, `total_produced_energy` |
| `C3UnitParaBody` | `total_electricity0`, `total_thermal0`, `heat_elec_total_consum0`, `heat_elec_total_capacity0` |

The byte offsets were already right, so this only bites once a counter passes
`2 ** 24`. Past that point the top byte lands 256 times too high and the value
jumps. `total_energy_consumption` and `total_produced_energy` are exposed as
device attributes, so this one is user visible.

## A note on the existing fixture

`test_message_notify1_x04_response` was asserting the buggy results:

```python
assert response.total_energy_consumption == 214750114754
assert response.total_produced_energy == 90195765805
```

Its own fixture feeds four bytes into each counter, so neither value can exceed
`0xFFFFFFFF`. Both are far past that, which is what the bug produces. Corrected
to `840610754` (`0x321AB3C2`) and `353774125` (`21,22,42,45` big-endian), which
are the values of the bytes that test already sets. The fixture comments in that
test already label them `BYTE 2` through `BYTE 5`, matching the lua, so only the
shift was ever wrong.

## Evidence

**Protocol documentation.** The lua linked above, in both the
`MSG_TYPE_UP_POWER4` and `MSG_TYPE_QUERY_UNITPARA` blocks.

**Not claimed here.** No real-device confirmation. My own counters have not
passed `2 ** 24`, so I cannot demonstrate the difference on hardware; the claim
is that the parser now matches the published protocol and that the previous
expectations were arithmetically impossible for a four byte field.

## Tests

`TestC3Energy32BitCounters` covers both bodies with a top byte set, so the
shift is actually exercised. Both fail against the current parser.

`pytest ./tests/` (1671 passed), `ruff check`, `ruff format --check`,
`mypy midealan` and `pylint --rcfile=pylintrc midealan` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for decoding unsolicited C3 unit-parameter notifications, including operational, temperature, pressure, energy, and power readings.
  * Continued support for correctly interpreting silence responses to unit-parameter queries.
* **Bug Fixes**
  * Corrected decoding of C3 energy and unit-parameter counters, including large 32-bit values with significant high-order bytes.
* **Tests**
  * Added regression coverage for energy notifications, unit-parameter notifications, and query responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->