### PR TITLE
feat(c3): parse the MSG_TYPE_UP_UNITPARA notify

### DIFF
--- a/midealan/devices/c3/message.py
+++ b/midealan/devices/c3/message.py
@@ -493,6 +493,83 @@ class C3UnitParaBody(MessageBody):
         )
 
 
+class C3UnitParaUpBody(MessageBody):
+    """C3 UnitPara notify (MSG_TYPE_UP_UNITPARA) message body.
+
+    The unit pushes this unsolicited between polls. It carries the same
+    quantities as the X10 query response but in its own, shorter layout, so
+    the attribute names deliberately match C3UnitParaBody: whichever message
+    arrives last refreshes the same device attributes.
+
+    Layout from the official C3 lua for the 171H120F module,
+    MSG_TYPE_UP_UNITPARA block. The lua is 1-indexed, so _bodyBytes[N] is
+    body[data_offset + N - 1].
+
+    Only the fields C3UnitParaBody already exposes are decoded here. The lua
+    block continues with a long Sys* energy-analysis section that reuses the
+    same byte ranges for several different names, so it is not parsed.
+    """
+
+    def __init__(self, body: bytearray, data_offset: int = 0) -> None:
+        """Initialize C3 UnitPara notify message body."""
+        super().__init__(body)
+        self.comp_run_freq = body[data_offset]
+        self.fan_speed = body[data_offset + 1] * FAN_SPEED_FACTOR
+        self.temp_t3 = body[data_offset + 2]
+        self.temp_t4 = body[data_offset + 3]
+        self.temp_tp = body[data_offset + 4]
+        self.temp_tw_in = body[data_offset + 5]
+        self.temp_tw_out = body[data_offset + 6]
+        self.odu_comp_current = body[data_offset + 7]
+        self.odu_voltage = body[data_offset + 8] * 256 + body[data_offset + 9]
+        self.temp_t1 = body[data_offset + 10]
+        self.temp_tw2 = body[data_offset + 11]
+        self.temp_t2 = body[data_offset + 12]
+        self.temp_t2b = body[data_offset + 13]
+        self.temp_t5 = body[data_offset + 14]
+        self.temp_ta = body[data_offset + 15]
+        self.pressure_high = body[data_offset + 16] * 256 + body[data_offset + 17]
+        self.pressure_low = body[data_offset + 18] * 256 + body[data_offset + 19]
+        self.temp_th = body[data_offset + 20]
+        self.odu_target_fre = body[data_offset + 21]
+        self.temp_tf = body[data_offset + 22]
+        self.idu_t1s1 = body[data_offset + 23]
+        self.idu_t1s2 = body[data_offset + 24]
+        self.water_flower = body[data_offset + 25] * 256 + body[data_offset + 26]
+        self.current_unit_capacity = (
+            body[data_offset + 27] * 256 + body[data_offset + 28]
+        )
+        self.water_pressure = body[data_offset + 29] * 256 + body[data_offset + 30]
+        self.room_rel_hum = body[data_offset + 31]
+        self.total_electricity0 = (
+            (body[data_offset + 32] << 24)
+            + (body[data_offset + 33] << 16)
+            + (body[data_offset + 34] << 8)
+            + (body[data_offset + 35])
+        )
+        self.total_thermal0 = (
+            (body[data_offset + 36] << 24)
+            + (body[data_offset + 37] << 16)
+            + (body[data_offset + 38] << 8)
+            + (body[data_offset + 39])
+        )
+        # NOTE: _bodyBytes[41..48] are given two conflicting meanings by the
+        # lua (heatElecTotConsum0 / heatTotCapacity0 overlap SysHeatDay*), and
+        # on a real unit heatElecTotConsum0 reads 0 here while the X10 query
+        # reports 2249 at the same moment. Not decoded.
+        self.instant_power0 = (body[data_offset + 48] << 8) + (body[data_offset + 49])
+        self.instant_renew_power0 = (body[data_offset + 50] << 8) + (
+            body[data_offset + 51]
+        )
+        self.total_renew_power0 = (
+            (body[data_offset + 52] << 24)
+            + (body[data_offset + 53] << 16)
+            + (body[data_offset + 54] << 8)
+            + (body[data_offset + 55])
+        )
+        self.unit_mode_run = body[data_offset + 59]
+
+
 class MessageC3Response(MessageResponse):
     """C3 message response."""
 
@@ -511,6 +588,10 @@ class MessageC3Response(MessageResponse):
             self.set_body(C3EnergyBody(super().body, data_offset=1))
         elif self.message_type == MessageType.query and self.body_type == ListTypes.X05:
             self.set_body(C3SilenceBody(super().body, data_offset=1))
+        elif (
+            self.message_type == MessageType.notify1 and self.body_type == ListTypes.X05
+        ):
+            self.set_body(C3UnitParaUpBody(super().body, data_offset=1))
         elif self.body_type == ListTypes.X07:
             self.set_body(C3ECOBody(super().body, data_offset=1))
         elif self.body_type == ListTypes.X09:

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -637,3 +637,85 @@ class TestC3UnitParaFanSpeed:
         assert post_run.fan_speed > 0
         assert stopped.comp_run_freq == 0
         assert stopped.fan_speed == 0
+
+
+class TestC3UnitParaNotify:
+    """The MSG_TYPE_UP_UNITPARA notify body (message type 0x04, body 0x05).
+
+    The frame below is a real capture from a Hyundai HYHC-V30W/D2RN8
+    (OEM-equivalent Midea MHC-V30W/D2RN8, protocol 3, module 171H120F). The
+    unit pushes this message unsolicited between polls; 41 of them appeared
+    alongside 782 X10 query responses in the same session.
+
+    Every value asserted here was cross-checked against the X10 query response
+    captured immediately before it, and agreed to within sampling drift.
+    """
+
+    HEADER = bytearray(
+        [0xAA, 0x00, 0xC3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, MessageType.notify1],
+    )
+
+    BODY = bytes.fromhex(
+        "05213f24264d0d0b0400e10b1909081919041000640b2237ffff0000000000000000"
+        "002fa000000000000000000000000001010000000000000b94630200000000000000"
+        "00000000000000000000000000000000000000000000000000000000000000000000"
+        "00000000000000000000000000000000000000000000000000000000000000000000"
+        "00000000000000000000000000000000000000000000000000000000000000000000"
+        "00000000000000000000000000000000000000000000000000000000000000000000"
+        "00000000000000000000000000000000000000000000000000000000000000000000"
+        "00",
+    )
+
+    def test_notify_unit_para_is_parsed(self) -> None:
+        """Test the notify body decodes into the shared runtime attributes."""
+        response = MessageC3Response(bytes(self.HEADER + self.BODY + bytes([0x00])))
+
+        assert response.body_type == ListTypes.X05
+        assert hasattr(response, "unit_mode_run")
+        assert hasattr(response, "comp_run_freq")
+        assert hasattr(response, "fan_speed")
+        assert hasattr(response, "temp_t3")
+        assert hasattr(response, "temp_t4")
+        assert hasattr(response, "temp_tp")
+        assert hasattr(response, "temp_tw_in")
+        assert hasattr(response, "temp_tw_out")
+        assert hasattr(response, "odu_comp_current")
+        assert hasattr(response, "odu_voltage")
+        assert hasattr(response, "temp_t1")
+        assert hasattr(response, "temp_t2")
+        assert hasattr(response, "temp_t2b")
+        assert hasattr(response, "pressure_high")
+        assert hasattr(response, "pressure_low")
+        assert hasattr(response, "odu_target_fre")
+        assert hasattr(response, "temp_tf")
+        assert hasattr(response, "total_electricity0")
+        assert response.comp_run_freq == 33
+        assert response.fan_speed == 630
+        assert response.unit_mode_run == C3DeviceMode.COOL
+        assert response.temp_t3 == 36
+        assert response.temp_t4 == 38
+        assert response.temp_tp == 77
+        assert response.temp_tw_in == 13
+        assert response.temp_tw_out == 11
+        assert response.odu_comp_current == 4
+        assert response.odu_voltage == 225
+        assert response.temp_t1 == 11
+        assert response.temp_t2 == 9
+        assert response.temp_t2b == 8
+        assert response.pressure_high == 1040
+        assert response.pressure_low == 100
+        assert response.odu_target_fre == 34
+        assert response.temp_tf == 55
+        assert response.total_electricity0 == 12192
+
+    def test_query_x05_is_still_the_silence_body(self) -> None:
+        """Test a query 0x05 still parses as silence, not as unit parameters."""
+        header = bytearray(self.HEADER)
+        header[-1] = MessageType.query
+        body = bytearray.fromhex("050b170016320e001100")
+        response = MessageC3Response(bytes(header + body + bytes([0x00])))
+
+        assert response.body_type == ListTypes.X05
+        assert hasattr(response, "silent_mode")
+        assert response.silent_mode is True
+        assert not hasattr(response, "comp_run_freq")


### PR DESCRIPTION
As offered in
https://github.com/wuwentao/midea-lan/pull/51#issuecomment-5412762240, and
following the second lua link in
https://github.com/wuwentao/midea-lan/pull/51#issuecomment-5412504443.
Independent of #52 and #54.

## Summary

The unit pushes unit-parameter reports unsolicited, as message type `0x04`
(notify) with body type `0x05`. `MessageC3Response` has no branch for that
pair, so every one is dropped and runtime telemetry only refreshes on the next
poll.

This adds `C3UnitParaUpBody` for the `MSG_TYPE_UP_UNITPARA` layout in the
[C3 lua for the 171H120F module](https://github.com/wuwentao/midea-lua/blob/08d62f090c0ae3772f91a73feecc2c20e59dff85/lua/T_0000_C3_171H120F_2023062601.lua#L4512).
It carries the same quantities as the X10 query response in a different,
shorter order, so the attribute names match `C3UnitParaBody` and whichever
message arrives last refreshes the same device attributes.

The `query` + `0x05` silence branch is untouched and still takes precedence for
message type `0x03`. A test pins that, so silence cannot regress into being
parsed as unit parameters.

## Device verification

Captured from a Hyundai HYHC-V30W/D2RN8 (OEM-equivalent Midea
MHC-V30W/D2RN8, protocol 3, module 171H120F): **41 of these notifies arrived
alongside 782 X10 query responses** in one session, body length 239 bytes.

Pairing each notify with the X10 response captured immediately before it, every
decoded field agrees within sampling drift. Sample of the cross-check, showing
values seen on both sides:

```
field              notify (UP layout)     X10 query              agreement
comp_run_freq      [0, 27, 31, 33, 35]    [0, 27, 31, 32, 33]    41/41 within 2
fan_speed          [0, 630, 640]          [0, 630, 640]          identical value set
temp_t3            [25, 34, 35, 36, 39]   [25, 34, 36, 38, 40]   41/41 within 2
temp_t4            [37, 38]               [37, 38]               41/41 within 2
temp_tw_in         [12, 13, 14, 16, 17]   [12, 13, 14, 16, 17]   41/41 exact
temp_tw2           [25]                   [25]                   41/41 exact
temp_t2b           [7, 8, 9, 10, 12]      [7, 8, 9, 10, 12]      41/41 within 2
odu_voltage        [225, 226]             [225, 226]             41/41 within 2
pressure_low       [100]                  [100]                  41/41 exact
total_electricity0 [12192..12198]         [12192..12198]         41/41 exact
unit_mode_run      [2]                    [2]                    41/41 exact
```

The regression test uses one of those captured frames verbatim.

## Deliberately not decoded

**`_bodyBytes[41..48]`.** The lua gives this range two conflicting meanings:
`heatElecTotConsum0` and `heatTotCapacity0` cover `[41..44]` and `[45..48]`,
while `SysHeatDayCapacity`, `SysHeatDayRenewPower`, `SysHeatDayElecConsum` and
`SysHeatDayCOPEER` cover the same bytes in pairs. On the device
`heatElecTotConsum0` reads `0` here while the X10 query reports `2249` at the
same moment, so the range is left alone.

**The `Sys*` energy-analysis tail.** Roughly a hundred further fields, several
of which also reuse byte ranges under different names in the lua
(`SysTotalRenewPower` repeats `SysTotalHeatCapacity`, `SysTotalCOPEER` overlaps
`SysTotalHeatElecConsum`). None have a counterpart in `C3UnitParaBody`, and
exposing them would be guessing, so they are out of scope here.

## Evidence

**Protocol documentation.** The lua block linked above.

**Real-device observation.** The 41 captured notifies described above, matched
against the paired query responses.

**Speculative.** Nothing in this PR. Any field that the lua and the device
disagreed on, or that the lua defines twice, is excluded rather than guessed.

## Tests

`TestC3UnitParaNotify` decodes a real captured frame and asserts 20 fields,
plus a guard that `query` + `0x05` still parses as the silence body and does
not gain unit-parameter attributes. The first test fails without the new body
class.

`pytest ./tests/` (1671 passed), `ruff check`, `ruff format --check`,
`mypy midealan` and `pylint --rcfile=pylintrc midealan` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for decoding unsolicited unit-parameter notifications, including fan speed, temperatures, pressures, electrical totals, power values, and operating mode.

- **Bug Fixes**
  - Improved message handling so notification and query responses with the same message type are interpreted correctly.

- **Tests**
  - Added coverage for unit-parameter notifications and confirmed existing query message behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->