### PR TITLE
feat(c3): expose outdoor-unit telemetry as device attributes

### DIFF
--- a/midealan/devices/c3/__init__.py
+++ b/midealan/devices/c3/__init__.py
@@ -71,6 +71,20 @@ class DeviceAttributes(StrEnum):
     comp_run_freq = "comp_run_freq"
     unit_mode_run = "unit_mode_run"
     fan_speed = "fan_speed"
+    temp_t1 = "temp_t1"
+    temp_t2 = "temp_t2"
+    temp_t2b = "temp_t2b"
+    temp_t3 = "temp_t3"
+    temp_tp = "temp_tp"
+    temp_th = "temp_th"
+    temp_tf = "temp_tf"
+    pressure_high = "pressure_high"
+    pressure_low = "pressure_low"
+    odu_voltage = "odu_voltage"
+    odu_comp_current = "odu_comp_current"
+    odu_target_fre = "odu_target_fre"
+    exv_current = "exv_current"
+    fg_capacity_need = "fg_capacity_need"
     instant_power0 = "instant_power0"
     silent_mode = "silent_mode"
     silent_level = "silent_level"
@@ -144,6 +158,20 @@ class MideaC3Device(MideaDevice):
                 DeviceAttributes.comp_run_freq: None,
                 DeviceAttributes.unit_mode_run: None,
                 DeviceAttributes.fan_speed: None,
+                DeviceAttributes.temp_t1: None,
+                DeviceAttributes.temp_t2: None,
+                DeviceAttributes.temp_t2b: None,
+                DeviceAttributes.temp_t3: None,
+                DeviceAttributes.temp_tp: None,
+                DeviceAttributes.temp_th: None,
+                DeviceAttributes.temp_tf: None,
+                DeviceAttributes.pressure_high: None,
+                DeviceAttributes.pressure_low: None,
+                DeviceAttributes.odu_voltage: None,
+                DeviceAttributes.odu_comp_current: None,
+                DeviceAttributes.odu_target_fre: None,
+                DeviceAttributes.exv_current: None,
+                DeviceAttributes.fg_capacity_need: None,
                 DeviceAttributes.instant_power0: None,
                 DeviceAttributes.error_code: 0,
             },

--- a/midealan/devices/c3/message.py
+++ b/midealan/devices/c3/message.py
@@ -431,7 +431,9 @@ class C3UnitParaBody(MessageBody):
         self.hydbox_subtype = body[data_offset + 12]
         self.fg_usb_info_connect = body[data_offset + 13]
         # self.usb_index_max  body[data_offset + 14]
-        # self.odu_comp_current  body[data_offset + 16]
+        # lua _bodyBytes[17], compressor current in A. Already decoded by
+        # C3UnitParaUpBody; enabled here so the polled response carries it too.
+        self.odu_comp_current = body[data_offset + 16]
         self.odu_voltage = body[data_offset + 17] * 256 + body[data_offset + 18]
         self.exv_current = body[data_offset + 19] * 256 + body[data_offset + 20]
         self.odu_model = body[data_offset + 21]

--- a/tests/devices/c3/device_c3_test.py
+++ b/tests/devices/c3/device_c3_test.py
@@ -356,3 +356,50 @@ class TestMideaC3Device:
         assert self.device.attributes[DeviceAttributes.comp_run_freq] == 57
         assert self.device.attributes[DeviceAttributes.unit_mode_run] == 2
         assert self.device.attributes[DeviceAttributes.fan_speed] == 640
+
+    def test_process_message_unit_para_exposes_odu_telemetry(self) -> None:
+        """Test the X10 telemetry values reach the device attributes.
+
+        Real capture from a Hyundai HYHC-V30W/D2RN8 (OEM-equivalent Midea
+        MHC-V30W/D2RN8, protocol 3, module 171H120F). The unit serial in the
+        tail of the frame has been replaced with zeroes; no parsed field is
+        affected.
+        """
+        header = bytearray(
+            [0xAA, 0x00, 0xC3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x03],
+        )
+        body = bytes.fromhex(
+            "1021023f0205002426500d0b7f070000000300e200881e0100000000040081482048"
+            "0b190a0919197f7f64042400640f03220c3536ffff00000000000000000000006300"
+            "002fa000000000000008c90000000000e600000000000000000015172d2d2d2d2d2d"
+            "2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d"
+            "2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d30303030303030303030"
+            "303030303030303030303030303030303030303030300000000000000000",
+        )
+
+        new_status = self.device.process_message(bytes(header + body + bytes(1)))
+
+        expected = {
+            "comp_run_freq": 33,
+            "unit_mode_run": 2,
+            "fan_speed": 630,
+            "fg_capacity_need": 5,
+            "temp_t3": 36,
+            "temp_tp": 80,
+            "temp_tw_in": 13,
+            "temp_tw_out": 11,
+            "odu_comp_current": 3,
+            "odu_voltage": 226,
+            "exv_current": 136,
+            "temp_t1": 11,
+            "temp_t2": 10,
+            "temp_t2b": 9,
+            "pressure_high": 1060,
+            "pressure_low": 100,
+            "temp_th": 15,
+            "odu_target_fre": 34,
+            "temp_tf": 54,
+        }
+        for name, value in expected.items():
+            assert new_status[name] == value, name
+            assert self.device.attributes[DeviceAttributes[name]] == value, name

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -852,9 +852,10 @@ class TestC3UnitParaOutdoorTelemetryOffsets:
 
     Each case sets the field's byte(s) and puts a different decoy on each
     neighbouring byte, so a regression that shifts an offset by one cannot
-    pass. These lock the parser's current byte positions; the mapping from
-    byte to physical quantity and its unit still needs a real-device
-    capture to confirm.
+    pass. Offsets match `T_0000_C3_171H120F_2023062601.lua`
+    (`MSG_TYPE_QUERY_UNITPARA`) and were cross-checked against a real-device
+    capture; the unit for the two pressures is still unconfirmed, as the lua
+    applies no scaling and names none.
     """
 
     HEADER = bytearray(

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -845,3 +845,56 @@ class TestC3UnitParaLuaOffsets:
         response = MessageC3Response(bytes(self.HEADER + body))
         assert hasattr(response, "total_renew_power0")
         assert response.total_renew_power0 == 0
+
+
+class TestC3UnitParaOutdoorTelemetryOffsets:
+    """Pin the X10 body offsets for the outdoor-unit telemetry fields.
+
+    Each case sets the field's byte(s) and puts a different decoy on each
+    neighbouring byte, so a regression that shifts an offset by one cannot
+    pass. These lock the parser's current byte positions; the mapping from
+    byte to physical quantity and its unit still needs a real-device
+    capture to confirm.
+    """
+
+    HEADER = bytearray(
+        [0xAA, 0x00, 0xC3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, MessageType.query],
+    )
+
+    @staticmethod
+    def _build_response(values: dict[int, int]) -> MessageC3Response:
+        """Build an X10 query response with the given body bytes set."""
+        body = bytearray(96)
+        body[0] = ListTypes.X10
+        for index, value in values.items():
+            body[index] = value
+        return MessageC3Response(
+            bytes(TestC3UnitParaOutdoorTelemetryOffsets.HEADER + body),
+        )
+
+    @pytest.mark.parametrize(
+        ("attribute", "values", "expected"),
+        [
+            ("temp_t3", {6: 99, 7: 33, 8: 88}, 33),
+            ("temp_tp", {8: 88, 9: 41, 10: 77}, 41),
+            ("odu_comp_current", {16: 99, 17: 12, 18: 88}, 12),
+            ("exv_current", {19: 99, 20: 1, 21: 200, 22: 88}, 456),
+            ("temp_t1", {33: 99, 34: 21, 35: 88}, 21),
+            ("temp_t2", {35: 99, 36: 7, 37: 88}, 7),
+            ("temp_t2b", {36: 99, 37: 9, 38: 88}, 9),
+            ("pressure_low", {44: 99, 45: 2, 46: 10, 47: 88}, 522),
+            ("temp_th", {46: 99, 47: 25, 48: 88}, 25),
+            ("odu_target_fre", {48: 99, 49: 60, 50: 88}, 60),
+            ("temp_tf", {51: 99, 52: 44, 53: 88}, 44),
+        ],
+    )
+    def test_field_is_read_from_its_offset(
+        self,
+        attribute: str,
+        values: dict[int, int],
+        expected: int,
+    ) -> None:
+        """Test each telemetry field decodes from the expected body offset."""
+        response = self._build_response(values)
+        assert hasattr(response, attribute)
+        assert getattr(response, attribute) == expected


### PR DESCRIPTION
Follow-up to #53, which exposed `comp_run_freq`, `unit_mode_run` and
`fan_speed`. This adds the rest of the outdoor-unit runtime telemetry.

## Relationship to #46

**This overlaps #46, and I want to be upfront about it rather than quietly file
alongside it.** @vasicekmilan90-eng did the original exploration of C3
telemetry there, and the outdoor fan offset in #51 came out of the same work.
#46 exposes 86 attributes; this exposes 14, chosen only where I have device
measurements showing the value actually moves.

I am not trying to pre-empt that PR. If #46 lands first, this becomes
redundant and I will close it. If the maintainer would rather see the broader
version, say so and I will close it now. My reason for proposing the narrow
slice is that #46 currently does not import and is conflicted with `main`
after #51 through #55, and I did not want the useful part blocked behind
resolving all of that.

## Summary

`C3UnitParaBody` decodes around 45 values, but only a handful appear in
`DeviceAttributes`. `process_message` copies just the attributes it finds
there, so everything else is parsed and then dropped, visible only to someone
running the integration at DEBUG level.

Newly exposed:

`temp_t1`, `temp_t2`, `temp_t2b`, `temp_t3`, `temp_tp`, `temp_th`, `temp_tf`,
`pressure_high`, `pressure_low`, `odu_voltage`, `odu_comp_current`,
`odu_target_fre`, `exv_current`, `fg_capacity_need`.

One parser line changed: `odu_comp_current` was decoded only by
`C3UnitParaUpBody` (#55), while `C3UnitParaBody` carried it as a comment. It is
now enabled at `data_offset + 16`, which is lua `_bodyBytes[17]`, exactly where
that comment already said it was.

## Selection criteria

Everything here **varies** on a real 171H120F across a full compressor cycle,
measured over 782 X10 frames:

| attribute | observed range |
|---|---|
| `temp_tp` | 43..80 |
| `pressure_high` | 990..1870 |
| `exv_current` | 104..480 |
| `odu_target_fre` | 0..62 |
| `fg_capacity_need` | 0..18 |
| `odu_comp_current` | 1..8 |
| `temp_t3` | 24..46 |
| `temp_th` | 8..37 |
| `temp_tf` | 40..59 |
| `temp_t1` / `temp_t2` / `temp_t2b` | 9..19 / 7..26 / 7..23 |
| `odu_voltage` | 224..226 |

`pressure_low` reads a constant 100 on that unit and is included only because
it is the documented pair of `pressure_high`; a unit with the sensor fitted
should populate it.

**Deliberately excluded**, because they read one constant value on that unit
and there is no evidence they carry anything: `temp_t5`, `temp_ta` and
`temp_tw2` (all 25), `water_flower`, `water_pressure` and
`current_unit_capacity` (all 0), `hydrobox_capacity` (100). `temp_t4` is left
out because `outdoor_temperature` already carries it and two entities for one
sensor would be worse than none.

This is the opposite approach to exposing everything the parser touches. If
someone with a differently equipped unit shows one of the excluded fields
moving, adding it later is a one-line change.

## Evidence

**Protocol documentation.** All offsets are unchanged from the parser, which
was aligned to the C3 lua for this module in #51, #52 and #54.

**Real-device observation.** The ranges above, from 782 frames captured across
a compressor cycle on a Hyundai HYHC-V30W/D2RN8 (OEM-equivalent Midea
MHC-V30W/D2RN8, protocol 3, module 171H120F).

**Speculative.** Nothing. Fields without evidence are excluded rather than
guessed.

## Tests

`test_process_message_unit_para_exposes_odu_telemetry` drives a real captured
frame through `MideaC3Device.process_message` and asserts 19 values land in
both the returned status dict and `device.attributes`, so the whole path is
covered rather than the parser alone.

The unit serial number sits in ASCII in the tail of that frame and has been
replaced with zeroes. No parsed field is affected.

`pytest ./tests/` (1680 passed), `ruff check`, `ruff format --check`,
`mypy midealan` and `pylint --rcfile=pylintrc midealan` are clean.

## Note on the Home Assistant side

This only makes the values reachable through the library API. Sensors in
`midea_ac_lan` are a separate change, which I will send there once this is in a
release. wuwentao/midea_ac_lan#1011 covers overlapping ground there, by the
same author, and the same offer applies: if that one lands first I will not
duplicate it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed outdoor-unit diagnostic telemetry, including temperatures, pressures, voltage, compressor current, frequency, expansion-valve current, and fan capacity.
  * Improved decoding of compressor current readings.

* **Bug Fixes**
  * Corrected outdoor-unit telemetry parsing to ensure readings are extracted accurately.

* **Tests**
  * Added regression coverage for outdoor-unit telemetry, including temperature, pressure, electrical, frequency, and expansion-valve values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->