### PR TITLE
fix(ac): decode C0 temperatures for model 220F4047

### DIFF
--- a/midealan/devices/ac/__init__.py
+++ b/midealan/devices/ac/__init__.py
@@ -12,6 +12,8 @@ from midealan.device import MideaDevice, MideaDeviceInitKwargs
 from midealan.message import ListTypes
 
 from .message import (
+    C0_DEFAULT_INVALID_OUTDOOR_TEMPERATURE_VALUES,
+    C0_DEFAULT_TEMPERATURE_OFFSET,
     CapabilitiesAdditionalQuery,
     CapabilitiesQuery,
     GroupOneQuery,
@@ -132,6 +134,7 @@ BB_FRESH_AIR_DEFAULT_SPEED = 60
 # The BB exhaust preset map has no "medium" (60) entry; use the first
 # advertised non-silent exhaust mode when a power-on command has no prior speed.
 BB_FRESH_AIR_EXHAUST_DEFAULT_SPEED = 80
+MODEL_220F4047_C0_OUTDOOR_TEMPERATURE_PLACEHOLDER = 0x20
 
 
 @dataclass(frozen=True)
@@ -141,13 +144,23 @@ class ACModelCapabilities:
     attributes: frozenset[DeviceAttributes] = frozenset()
     uses_bb_protocol: bool = False
     has_bb_fresh_air: bool = False
+    c0_indoor_temperature_offset: int = C0_DEFAULT_TEMPERATURE_OFFSET
+    c0_invalid_outdoor_temperature_values: frozenset[int] = (
+        C0_DEFAULT_INVALID_OUTDOOR_TEMPERATURE_VALUES
+    )
 
 
 DEFAULT_AC_MODEL_CAPABILITIES = ACModelCapabilities()
-# These BB fields use model-specific offsets and command payloads observed on
-# exact model/subtype pairs. Keep unrelated devices hidden from attributes and
-# commands whose bytes may have a different meaning on other firmware.
+# These fields use model-specific offsets, sentinels, or command payloads observed
+# on exact model/subtype pairs. Keep unrelated devices on the generic decoder and
+# hidden from commands whose bytes may have a different meaning on other firmware.
 AC_MODEL_CAPABILITIES = {
+    ("220F4047", 8): ACModelCapabilities(
+        c0_indoor_temperature_offset=0,
+        c0_invalid_outdoor_temperature_values=frozenset(
+            {MODEL_220F4047_C0_OUTDOOR_TEMPERATURE_PLACEHOLDER},
+        ),
+    ),
     ("23096633", 1): ACModelCapabilities(
         attributes=frozenset(
             {
@@ -408,8 +421,14 @@ class MideaACDevice(MideaDevice):
         """Midea AC device process message."""
         message = MessageACResponse(
             bytearray(msg),
-            self._power_analysis_method,
-            self._uses_new_protocol_temperature,
+            power_analysis_method=self._power_analysis_method,
+            new_protocol_temperature=self._uses_new_protocol_temperature,
+            c0_indoor_temperature_offset=(
+                self._model_capabilities.c0_indoor_temperature_offset
+            ),
+            c0_invalid_outdoor_temperature_values=(
+                self._model_capabilities.c0_invalid_outdoor_temperature_values
+            ),
         )
         _LOGGER.debug("[%s] Received: %s", self.device_id, message)
         new_status = {}

--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -49,6 +49,8 @@ POWER_SAVING_VALUE = 0x08
 SCREEN_DISPLAY_BYTE_CHECK = 0x07
 SUB_PROTOCOL_BODY_TEMP_CHECK = 0x80
 TEMP_DECIMAL_MIN_BODY_LENGTH = 20
+C0_DEFAULT_TEMPERATURE_OFFSET = 50
+C0_DEFAULT_INVALID_OUTDOOR_TEMPERATURE_VALUES: frozenset[int] = frozenset()
 TIMER_MIN_SUBPROTOCOL_LENGTH = 27
 XBB_SN8_BYTE_FLAG = 0x31
 XC1_SUBBODY_TYPE_40 = 0x40
@@ -1036,11 +1038,15 @@ class XMessageBody(MessageBody):
     """AC A1/C0 message body - common functions."""
 
     @staticmethod
-    def parse_temperature(integer: int, decimal: int) -> float | None:
+    def parse_temperature(
+        integer: int,
+        decimal: int,
+        offset: int = C0_DEFAULT_TEMPERATURE_OFFSET,
+    ) -> float | None:
         """Decode special signed integer with BCD decimal temperature format."""
         if integer == MAX_BYTE_VALUE:
             return None
-        temp_integer = (integer - 50) / 2
+        temp_integer = (integer - offset) / 2
         if decimal == 0:
             return temp_integer
         if temp_integer < 0:
@@ -1275,7 +1281,14 @@ class CapabilityBody(NewProtocolMessageBody):
 class StateBody(XMessageBody):
     """AC C0 message body."""
 
-    def __init__(self, body: bytearray) -> None:
+    def __init__(
+        self,
+        body: bytearray,
+        indoor_temperature_offset: int = C0_DEFAULT_TEMPERATURE_OFFSET,
+        invalid_outdoor_temperature_values: frozenset[
+            int
+        ] = C0_DEFAULT_INVALID_OUTDOOR_TEMPERATURE_VALUES,
+    ) -> None:
         """Initialize AC C0 message body."""
         super().__init__(body)
         self.power = (body[1] & 0x1) > 0  # powerValue
@@ -1302,8 +1315,17 @@ class StateBody(XMessageBody):
         self.temp_fahrenheit = (body[10] & 0x04) > 0
         self.sleep_mode = (body[10] & 0x01) > 0
         decimal = body[15] if len(body) > TEMP_DECIMAL_MIN_BODY_LENGTH else 0
-        self.indoor_temperature = self.parse_temperature(body[11], decimal & 0x0F)
-        self.outdoor_temperature = self.parse_temperature(body[12], decimal >> 4)
+        self.indoor_temperature = self.parse_temperature(
+            body[11],
+            decimal & 0x0F,
+            indoor_temperature_offset,
+        )
+        outdoor_temperature = body[12]
+        self.outdoor_temperature = (
+            None
+            if outdoor_temperature in invalid_outdoor_temperature_values
+            else self.parse_temperature(outdoor_temperature, decimal >> 4)
+        )
         self.kick_quilt = (body[10] & 0x04) >> 2  # kickQuilt
         self.prevent_cold = (body[10] & 0x20) >> 5  # preventCold
         self.full_dust = ((body[13] & 0x20) >> 5) > 0  # dust_full_time
@@ -1590,6 +1612,10 @@ class MessageACResponse(MessageResponse):
         message: bytearray,
         power_analysis_method: int = 3,
         new_protocol_temperature: bool = False,
+        c0_indoor_temperature_offset: int = C0_DEFAULT_TEMPERATURE_OFFSET,
+        c0_invalid_outdoor_temperature_values: frozenset[
+            int
+        ] = C0_DEFAULT_INVALID_OUTDOOR_TEMPERATURE_VALUES,
     ) -> None:
         """Initialize AC message response."""
         super().__init__(message)
@@ -1633,7 +1659,13 @@ class MessageACResponse(MessageResponse):
             self.message_type in [MessageType.query, MessageType.set]
             and self.body_type == ListTypes.C0
         ):
-            self.set_body(StateBody(super().body))
+            self.set_body(
+                StateBody(
+                    super().body,
+                    c0_indoor_temperature_offset,
+                    c0_invalid_outdoor_temperature_values,
+                ),
+            )
         # messageBytes[0] 0xC1
         elif self.message_type == MessageType.query and self.body_type == ListTypes.C1:
             self.set_body(GroupBody(super().body, power_analysis_method))

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -30,6 +30,12 @@ from midealan.devices.ac.message import (
 )
 from midealan.message import ListTypes, MessageBase
 
+# C0 body from the public capture in
+# https://github.com/wuwentao/midea_ac_lan/issues/998
+MODEL_220F4047_C0_BODY = bytes.fromhex(
+    "c00150667f7f0000000c002e200b0003000000000000000058020000f0ff533d",
+)
+
 
 class TestMideaACDevice:
     """Test Midea AC Device."""
@@ -393,6 +399,44 @@ class TestMideaACDevice:
                 True,
             )
             build_send.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("decimal", "expected_temperature"),
+        [(0x03, 23.3), (0x08, 23.8)],
+    )
+    def test_220f4047_c0_temperature_uses_model_specific_encoding(
+        self,
+        decimal: int,
+        expected_temperature: float,
+    ) -> None:
+        """Decode the C0 temperatures reported by model 220F4047 subtype 8."""
+        device = self._make_device("220F4047", 8)
+        body = bytearray(MODEL_220F4047_C0_BODY)
+        body[15] = decimal
+
+        status = device.process_message(self._response(body))
+
+        assert status[DeviceAttributes.indoor_temperature.value] == expected_temperature
+        assert status[DeviceAttributes.outdoor_temperature.value] is None
+
+    @pytest.mark.parametrize(
+        ("model", "subtype"),
+        [("220F4047", 1), ("other", 8)],
+    )
+    def test_220f4047_c0_temperature_encoding_is_exactly_gated(
+        self,
+        model: str,
+        subtype: int,
+    ) -> None:
+        """Keep the standard C0 decoder for every other model/subtype pair."""
+        device = self._make_device(model, subtype)
+
+        status = device.process_message(
+            self._response(bytearray(MODEL_220F4047_C0_BODY)),
+        )
+
+        assert status[DeviceAttributes.indoor_temperature.value] == -2.3
+        assert status[DeviceAttributes.outdoor_temperature.value] == -9.0
 
     def test_actual_frequency_only_model_gating(self) -> None:
         """Test the naturally detected BB model exposes only actual frequency."""


### PR DESCRIPTION
## Summary

- Add exact model/subtype C0 temperature decoding options for 220F4047 subtype 8.
- Decode its indoor temperature byte without the standard 50-point offset.
- Treat raw outdoor value 0x20 as an invalid placeholder only for this device pair.
- Preserve the generic C0 decoder for every other model and subtype.

## Evidence

The public C0 capture in wuwentao/midea_ac_lan#998 contains indoor byte 0x2e. The generic decoder produces -2.3 C, while the model-specific encoding produces 23.3 C. The regression also covers the reported 0.8 decimal sample, producing 23.8 C.

## Validation

- AC message and device tests: 149 passed.
- Full test suite: 1855 passed.
- All prek hooks, including ruff, mypy, pylint, codespell, and private-key detection: passed.
- Source distribution and wheel build: passed.
- The built wheel decoded the captured packet as 23.3 C with outdoor temperature unavailable.

## Scope

This does not change target-temperature decoding, control commands, or capability queries. Real-device installation and control validation remain pending.

Addresses wuwentao/midea_ac_lan#998.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temperature readings for a verified air conditioner model and subtype using its specific C0 response format.
  * Correctly handles decimal indoor temperatures and unavailable outdoor temperature placeholders.
  * Prevents temperature corrections when response data is incomplete.
* **Tests**
  * Added coverage for model-specific decoding, standard decoding compatibility, placeholder handling, decimal values, and short responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->