### PR TITLE
feat(cd): support extended water heater protocol

### DIFF
--- a/midealan/devices/cd/__init__.py
+++ b/midealan/devices/cd/__init__.py
@@ -593,6 +593,20 @@ class MideaCDDevice(MideaDevice):
         )
         self.build_send(message)
 
+    @staticmethod
+    def _has_valid_timer_data(attr: str, value: dict[Any, Any]) -> bool:
+        """Return whether a schedule contains safe timer collections."""
+        timer_groups = (
+            [value.get(day, []) for day in range(7)]
+            if attr == DeviceAttributes.weekly_schedule
+            else [value.get("timers", [])]
+        )
+        return all(
+            isinstance(timers, list)
+            and all(isinstance(timer, dict) for timer in timers)
+            for timers in timer_groups
+        )
+
     def set_attribute(  # noqa: C901, PLR0911
         self,
         attr: str,
@@ -603,6 +617,9 @@ class MideaCDDevice(MideaDevice):
             DeviceAttributes.maintenance_reminder,
             DeviceAttributes.maintain_warn_tag,
         ]:
+            if isinstance(value, dict):
+                _LOGGER.warning("[%s] %s requires a scalar value", self.device_id, attr)
+                return
             self._set_maintenance_reminder(bool(value))
             return
 
@@ -627,6 +644,9 @@ class MideaCDDevice(MideaDevice):
                     self.device_id,
                     attr,
                 )
+                return
+            if not self._has_valid_timer_data(attr, value):
+                _LOGGER.warning("[%s] %s has invalid timer data", self.device_id, attr)
                 return
             if attr == DeviceAttributes.weekly_schedule:
                 weekly = MessageSetWeekly(self._message_protocol_version)

--- a/midealan/devices/cd/__init__.py
+++ b/midealan/devices/cd/__init__.py
@@ -3,13 +3,14 @@
 import json
 import logging
 from enum import IntEnum, StrEnum
-from typing import Any, ClassVar, Unpack
+from typing import Any, ClassVar, Unpack, cast
 
 from midealan.const import DeviceType
 from midealan.device import MideaDevice, MideaDeviceInitKwargs
 from midealan.message import MessageType
 
 from .message import (
+    DailyTimerSchedule,
     MessageCDBase,
     MessageCDResponse,
     MessageQuery,
@@ -21,6 +22,7 @@ from .message import (
     MessageSetMaintenance,
     MessageSetSterilize,
     MessageSetWeekly,
+    WeeklySchedule,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -362,7 +364,9 @@ class MideaCDDevice(MideaDevice):
             DeviceAttributes.support_tou,
         )
 
-        def _source_is_extended(source: object) -> bool:
+        def _source_is_extended(source: object | None) -> bool:
+            if source is None:
+                return False
             if _value(source, DeviceAttributes.new_version_water_heater) is True:
                 return True
             if isinstance(_value(source, DeviceAttributes.b0_reserved_flags), int):
@@ -375,8 +379,6 @@ class MideaCDDevice(MideaDevice):
                 return True
             return any(_value(source, attribute) is True for attribute in capabilities)
 
-        if message is None:
-            return _source_is_extended(self._attributes)
         return _source_is_extended(message) or _source_is_extended(self._attributes)
 
     def _mode_map(self, message: object | None = None) -> dict[int, str]:
@@ -385,6 +387,13 @@ class MideaCDDevice(MideaDevice):
             self._extended_modes
             if self._is_extended_water_heater(message)
             else self._modes
+        )
+
+    def _mode_key(self, value: str) -> int | None:
+        """Return the protocol key from the capability-selected mode map."""
+        return next(
+            (key for key, name in self._mode_map().items() if name == value),
+            None,
         )
 
     def build_query(self) -> list[MessageCDBase]:
@@ -421,6 +430,8 @@ class MideaCDDevice(MideaDevice):
                 raw_value = getattr(message, str(attr))
                 # parse modes
                 if attr == DeviceAttributes.mode:
+                    # Extended mode 0x05 normally means Heat-pump, but the
+                    # dedicated vacation flag gives it Vacation semantics.
                     mode_str = (
                         "Vacation"
                         if self._is_extended_water_heater(message)
@@ -642,6 +653,11 @@ class MideaCDDevice(MideaDevice):
         else:
             if "amount" in value and not cls._is_integer_compatible(value["amount"]):
                 return False
+            if any(
+                flag in value and not isinstance(value[flag], bool)
+                for flag in ("single_timer_on", "single_timer_off")
+            ):
+                return False
             timer_groups = [value.get("timers", [])]
             numeric_fields = (
                 "openhour",
@@ -655,6 +671,7 @@ class MideaCDDevice(MideaDevice):
             isinstance(timers, list)
             and all(
                 isinstance(timer, dict)
+                and ("effect" not in timer or isinstance(timer["effect"], bool))
                 and all(
                     field not in timer or cls._is_integer_compatible(timer[field])
                     for field in numeric_fields
@@ -707,11 +724,11 @@ class MideaCDDevice(MideaDevice):
                 return
             if attr == DeviceAttributes.weekly_schedule:
                 weekly = MessageSetWeekly(self._message_protocol_version)
-                weekly.weekly_schedule = value
+                weekly.weekly_schedule = cast("WeeklySchedule", value)
                 self.build_send(weekly)
             else:
                 daily = MessageSetDaily(self._message_protocol_version)
-                daily.daily_timer_schedule = value
+                daily.daily_timer_schedule = cast("DailyTimerSchedule", value)
                 self.build_send(daily)
             return
 
@@ -820,14 +837,7 @@ class MideaCDDevice(MideaDevice):
                 # Fall back to 0x00 (no explicit operating mode).
                 message.mode = 0x00
             else:
-                mode_key = next(
-                    (
-                        key
-                        for key, name in self._mode_map().items()
-                        if name == str(current_mode)
-                    ),
-                    None,
-                )
+                mode_key = self._mode_key(str(current_mode))
                 message.mode = mode_key if mode_key is not None else 0x00
 
             # Update based on attribute being set
@@ -840,14 +850,7 @@ class MideaCDDevice(MideaDevice):
                         self.device_id,
                     )
                     return
-                mode_key = next(
-                    (
-                        key
-                        for key, name in self._mode_map().items()
-                        if name == str(value)
-                    ),
-                    None,
-                )
+                mode_key = self._mode_key(str(value))
                 if mode_key is None:
                     _LOGGER.warning(
                         "[%s] Invalid mode value: %s, not sending command",
@@ -897,6 +900,8 @@ class MideaCDDevice(MideaDevice):
                 message.vacation_days = days
 
             elif attr == DeviceAttributes.max_temperature:
+                # max_temperature is the configurable tsMax setting; the
+                # immutable device bounds are reported by the two limit attrs.
                 lower = self._attributes.get(
                     DeviceAttributes.max_temperature_lower_limit,
                 )

--- a/midealan/devices/cd/__init__.py
+++ b/midealan/devices/cd/__init__.py
@@ -13,10 +13,14 @@ from .message import (
     MessageCDBase,
     MessageCDResponse,
     MessageQuery,
+    MessageQueryB1,
     MessageQueryDaily,
     MessageQueryWeekly,
     MessageSet,
+    MessageSetDaily,
+    MessageSetMaintenance,
     MessageSetSterilize,
+    MessageSetWeekly,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -62,6 +66,12 @@ class DeviceAttributes(StrEnum):
     sterilize = "sterilize"
     disinfect = "disinfect"
     disinfection_temperature = "disinfection_temperature"
+    auto_disinfect = "auto_disinfect"
+    schedule_mode = "schedule_mode"
+    max_temperature_upper_limit = "max_temperature_upper_limit"
+    max_temperature_lower_limit = "max_temperature_lower_limit"
+    disinfection_temperature_upper_limit = "disinfection_temperature_upper_limit"
+    disinfection_temperature_lower_limit = "disinfection_temperature_lower_limit"
     top_temperature = "top_temperature"
     bottom_temperature = "bottom_temperature"
     wind = "wind"
@@ -89,6 +99,33 @@ class DeviceAttributes(StrEnum):
     weekly_effects = "weekly_effects"
     weekly_schedule = "weekly_schedule"
     daily_timer_schedule = "daily_timer_schedule"
+    dr_enable = "dr_enable"
+    dr_option = "dr_option"
+    electric_rod_exception = "electric_rod_exception"
+    support_boost_mode = "support_boost_mode"
+    support_silent_mode = "support_silent_mode"
+    support_remaining_hot_water = "support_remaining_hot_water"
+    support_electric_mode = "support_electric_mode"
+    support_auto_disinfect = "support_auto_disinfect"
+    support_force_e_heating = "support_force_e_heating"
+    support_tou = "support_tou"
+    remaining_hot_water_max = "remaining_hot_water_max"
+    force_e_heating_status = "force_e_heating_status"
+    ac_heater_priority = "ac_heater_priority"
+    high_temp_reminder = "high_temp_reminder"
+    b0_reserved_flags = "b0_reserved_flags"
+    new_version_water_heater = "new_version_water_heater"
+    holiday_max = "holiday_max"
+    holiday_min = "holiday_min"
+    timer_step_gap = "timer_step_gap"
+    support_ac_heater_priority = "support_ac_heater_priority"
+    support_heat_recovery = "support_heat_recovery"
+    heat_recovery_status = "heat_recovery_status"
+    holiday_mode = "holiday_mode"
+    hybrid_motion_mode = "hybrid_motion_mode"
+    support_heat_pump_mode = "support_heat_pump_mode"
+    support_smart_mode = "support_smart_mode"
+    support_negative_temperature = "support_negative_temperature"
 
 
 class MideaCDDevice(MideaDevice):
@@ -103,6 +140,16 @@ class MideaCDDevice(MideaDevice):
         0x05: "Vacation",
     }
     _vacation_mode_key: ClassVar[int] = 0x05
+    _extended_modes: ClassVar[dict[int, str]] = {
+        0x00: "None",
+        0x01: "Economy",
+        0x02: "Hybrid",
+        0x03: "E-Heater",
+        0x04: "Smart",
+        0x05: "Heat-pump",
+        0x09: "Boost",
+        0x0A: "Silent",
+    }
 
     def __init__(
         self,
@@ -138,6 +185,12 @@ class MideaCDDevice(MideaDevice):
                 DeviceAttributes.sterilize: None,
                 DeviceAttributes.disinfect: None,
                 DeviceAttributes.disinfection_temperature: None,
+                DeviceAttributes.auto_disinfect: None,
+                DeviceAttributes.schedule_mode: None,
+                DeviceAttributes.max_temperature_upper_limit: None,
+                DeviceAttributes.max_temperature_lower_limit: None,
+                DeviceAttributes.disinfection_temperature_upper_limit: None,
+                DeviceAttributes.disinfection_temperature_lower_limit: None,
                 DeviceAttributes.top_temperature: None,
                 DeviceAttributes.bottom_temperature: None,
                 DeviceAttributes.wind: None,
@@ -165,6 +218,33 @@ class MideaCDDevice(MideaDevice):
                 DeviceAttributes.weekly_effects: None,
                 DeviceAttributes.weekly_schedule: None,
                 DeviceAttributes.daily_timer_schedule: None,
+                DeviceAttributes.dr_enable: None,
+                DeviceAttributes.dr_option: None,
+                DeviceAttributes.electric_rod_exception: None,
+                DeviceAttributes.support_boost_mode: None,
+                DeviceAttributes.support_silent_mode: None,
+                DeviceAttributes.support_remaining_hot_water: None,
+                DeviceAttributes.support_electric_mode: None,
+                DeviceAttributes.support_auto_disinfect: None,
+                DeviceAttributes.support_force_e_heating: None,
+                DeviceAttributes.support_tou: None,
+                DeviceAttributes.remaining_hot_water_max: None,
+                DeviceAttributes.force_e_heating_status: None,
+                DeviceAttributes.ac_heater_priority: None,
+                DeviceAttributes.high_temp_reminder: None,
+                DeviceAttributes.b0_reserved_flags: None,
+                DeviceAttributes.new_version_water_heater: None,
+                DeviceAttributes.holiday_max: None,
+                DeviceAttributes.holiday_min: None,
+                DeviceAttributes.timer_step_gap: None,
+                DeviceAttributes.support_ac_heater_priority: None,
+                DeviceAttributes.support_heat_recovery: None,
+                DeviceAttributes.heat_recovery_status: None,
+                DeviceAttributes.holiday_mode: None,
+                DeviceAttributes.hybrid_motion_mode: None,
+                DeviceAttributes.support_heat_pump_mode: None,
+                DeviceAttributes.support_smart_mode: None,
+                DeviceAttributes.support_negative_temperature: None,
             },
         )
         self._fields: dict[Any, Any] = {}
@@ -235,19 +315,76 @@ class MideaCDDevice(MideaDevice):
     @property
     def preset_modes(self) -> list[str]:
         """Midea CD selectable preset modes."""
-        return [
-            mode
-            for key, mode in MideaCDDevice._modes.items()
-            if key != MideaCDDevice._vacation_mode_key
-        ]
+        if not self._is_extended_water_heater():
+            return [
+                mode
+                for key, mode in self._modes.items()
+                if key != self._vacation_mode_key
+            ]
+        modes = self._mode_map()
+        selectable = ["Economy", "Hybrid", "E-Heater", "Smart"]
+        if self._attributes.get(DeviceAttributes.support_heat_pump_mode):
+            selectable.append("Heat-pump")
+        if self._attributes.get(DeviceAttributes.support_boost_mode):
+            selectable.append("Boost")
+        if self._attributes.get(DeviceAttributes.support_silent_mode):
+            selectable.append("Silent")
+        return [mode for mode in selectable if mode in modes.values()]
+
+    def _is_extended_water_heater(self, message: object | None = None) -> bool:
+        """Detect extended CD support from reported protocol fields."""
+        source = message if message is not None else self._attributes
+
+        def _value(attribute: DeviceAttributes) -> Any:  # noqa: ANN401
+            if isinstance(source, dict):
+                return source.get(attribute)
+            return getattr(source, attribute, None)
+
+        if _value(DeviceAttributes.new_version_water_heater) is True or isinstance(
+            _value(DeviceAttributes.b0_reserved_flags),
+            int,
+        ):
+            return True
+        limits = (
+            DeviceAttributes.max_temperature_upper_limit,
+            DeviceAttributes.max_temperature_lower_limit,
+            DeviceAttributes.disinfection_temperature_upper_limit,
+            DeviceAttributes.disinfection_temperature_lower_limit,
+        )
+        if any(
+            isinstance(_value(attribute), int | float) and _value(attribute) > 0
+            for attribute in limits
+        ):
+            return True
+        capabilities = (
+            DeviceAttributes.support_boost_mode,
+            DeviceAttributes.support_silent_mode,
+            DeviceAttributes.support_remaining_hot_water,
+            DeviceAttributes.support_electric_mode,
+            DeviceAttributes.support_auto_disinfect,
+            DeviceAttributes.support_force_e_heating,
+            DeviceAttributes.support_tou,
+        )
+        return any(isinstance(_value(attribute), bool) for attribute in capabilities)
+
+    def _mode_map(self, message: object | None = None) -> dict[int, str]:
+        """Select the mode map from capabilities reported by the device."""
+        return (
+            self._extended_modes
+            if self._is_extended_water_heater(message)
+            else self._modes
+        )
 
     def build_query(self) -> list[MessageCDBase]:
         """Midea CD device build query."""
-        return [
+        queries: list[MessageCDBase] = [
             MessageQuery(self._message_protocol_version),
             MessageQueryWeekly(self._message_protocol_version),
             MessageQueryDaily(self._message_protocol_version),
         ]
+        if self._is_extended_water_heater():
+            queries.append(MessageQueryB1(self._message_protocol_version))
+        return queries
 
     def process_message(self, msg: bytes) -> dict[str, Any]:  # noqa: C901
         """Midea CD device process message."""
@@ -272,7 +409,12 @@ class MideaCDDevice(MideaDevice):
                 raw_value = getattr(message, str(attr))
                 # parse modes
                 if attr == DeviceAttributes.mode:
-                    mode_str = MideaCDDevice._modes.get(raw_value)
+                    mode_str = (
+                        "Vacation"
+                        if self._is_extended_water_heater(message)
+                        and getattr(message, "vacation_mode", False)
+                        else self._mode_map(message).get(raw_value)
+                    )
                     if mode_str is not None:
                         # Only update when the value is a recognised mode key
                         # to prevent transient unrecognised values (e.g. 8)
@@ -374,31 +516,133 @@ class MideaCDDevice(MideaDevice):
                 if attr == DeviceAttributes.power and is_set_echo:
                     new_status[str(attr)] = self._attributes[attr]
                     continue
+                # B1 responses contain a subset of TLVs. Preserve the last
+                # valid value for fields omitted from an individual response.
+                if raw_value is None:
+                    continue
                 # non-temperature attributes
                 self._attributes[attr] = raw_value
                 new_status[str(attr)] = self._attributes[attr]
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | float | str) -> None:
+    def _set_maintenance_reminder(self, value: bool) -> None:
+        """Send the B0 maintenance flag without changing unrelated flags."""
+        reserved = self._attributes.get(DeviceAttributes.b0_reserved_flags)
+        if not self._is_extended_water_heater() or not isinstance(reserved, int):
+            _LOGGER.warning(
+                "[%s] maintenance write postponed until B1 flags are known",
+                self.device_id,
+            )
+            return
+        message = MessageSetMaintenance(self._message_protocol_version)
+        message.ac_heater_priority = bool(
+            self._attributes.get(DeviceAttributes.ac_heater_priority, False),
+        )
+        message.high_temp_reminder = bool(
+            self._attributes.get(DeviceAttributes.high_temp_reminder, False),
+        )
+        message.maintenance_reminder = value
+        message.reserved_flags = reserved
+        self.build_send(message)
+
+    def _set_disinfection(
+        self,
+        attr: str,
+        value: str | float | bool,
+    ) -> None:
+        """Send the extended seven-byte disinfection payload."""
+        if not self._is_extended_water_heater():
+            _LOGGER.warning(
+                "[%s] extended disinfection write requires reported CD support",
+                self.device_id,
+            )
+            return
+        message = MessageSetSterilize(self._message_protocol_version)
+        message.extended_body = True
+        message.sterilize_on = (
+            bool(value)
+            if attr in {DeviceAttributes.disinfect, DeviceAttributes.sterilize}
+            else bool(self._attributes.get(DeviceAttributes.disinfect, False))
+        )
+        message.week = MessageSetSterilize.clamp_week(
+            self._attributes.get(DeviceAttributes.auto_sterilize_week),
+        )
+        message.hour = MessageSetSterilize.clamp_hour(
+            self._attributes.get(DeviceAttributes.auto_sterilize_hour),
+        )
+        message.minute = MessageSetSterilize.clamp_minute(
+            self._attributes.get(DeviceAttributes.auto_sterilize_minute),
+        )
+        temperature = (
+            value
+            if attr == DeviceAttributes.disinfection_temperature
+            else self._attributes.get(DeviceAttributes.disinfection_temperature)
+        )
+        if not isinstance(temperature, int | float):
+            temperature = MessageSetSterilize.DISINFECT_TEMP_MIN
+        lower = self._attributes.get(
+            DeviceAttributes.disinfection_temperature_lower_limit,
+        )
+        upper = self._attributes.get(
+            DeviceAttributes.disinfection_temperature_upper_limit,
+        )
+        minimum = int(lower) if isinstance(lower, int | float) else 60
+        maximum = int(upper) if isinstance(upper, int | float) else 70
+        message.disinfection_temperature = float(
+            max(minimum, min(maximum, float(temperature))),
+        )
+        self.build_send(message)
+
+    def set_attribute(  # noqa: C901, PLR0911
+        self,
+        attr: str,
+        value: bool | float | str | dict[Any, Any],
+    ) -> None:
         """Midea CD device set attribute."""
-        # Maintenance reminder is read-only until the weekly write payload is safe.
         if attr in [
             DeviceAttributes.maintenance_reminder,
             DeviceAttributes.maintain_warn_tag,
         ]:
-            _LOGGER.warning(
-                "[%s] maintenance reminder writes are disabled because the "
-                "weekly payload can disturb CD temperature values",
-                self.device_id,
-            )
+            self._set_maintenance_reminder(bool(value))
             return
 
-        # Disinfect is read-only until the exact app payload is known.
-        if attr == DeviceAttributes.disinfect:
+        if attr in [
+            DeviceAttributes.disinfect,
+            DeviceAttributes.sterilize,
+            DeviceAttributes.disinfection_temperature,
+        ]:
+            if isinstance(value, dict):
+                _LOGGER.warning("[%s] %s requires a scalar value", self.device_id, attr)
+                return
+            self._set_disinfection(attr, value)
+            return
+
+        if attr in [
+            DeviceAttributes.weekly_schedule,
+            DeviceAttributes.daily_timer_schedule,
+        ]:
+            if not self._is_extended_water_heater() or not isinstance(value, dict):
+                _LOGGER.warning(
+                    "[%s] %s write requires reported CD support and a mapping",
+                    self.device_id,
+                    attr,
+                )
+                return
+            if attr == DeviceAttributes.weekly_schedule:
+                weekly = MessageSetWeekly(self._message_protocol_version)
+                weekly.weekly_schedule = value
+                self.build_send(weekly)
+            else:
+                daily = MessageSetDaily(self._message_protocol_version)
+                daily.daily_timer_schedule = value
+                self.build_send(daily)
+            return
+
+        if isinstance(value, dict):
             _LOGGER.warning(
-                "[%s] immediate disinfection writes are disabled because the "
-                "known payload can corrupt the app disinfection temperature",
+                "[%s] %s requires a scalar value",
                 self.device_id,
+                attr,
             )
             return
 
@@ -409,11 +653,31 @@ class MideaCDDevice(MideaDevice):
             DeviceAttributes.target_temperature,
             DeviceAttributes.vacation_mode,
             DeviceAttributes.vacation_days,
+            DeviceAttributes.max_temperature,
+            DeviceAttributes.schedule_mode,
         ]:
+            if (
+                attr
+                in [
+                    DeviceAttributes.max_temperature,
+                    DeviceAttributes.schedule_mode,
+                ]
+                and not self._is_extended_water_heater()
+            ):
+                _LOGGER.warning(
+                    "[%s] %s is read-only for legacy CD models",
+                    self.device_id,
+                    attr,
+                )
+                return
             message = MessageSet(self._message_protocol_version)
             message.fields = dict(self._fields) if self._fields else {}
             # align temperature encoding with lua protocol selection
             message.use_old_protocol = self._lua_protocol == LuaProtocol.old
+            schedule_mode = self._attributes.get(DeviceAttributes.schedule_mode)
+            message.schedule_mode = (
+                int(schedule_mode) if isinstance(schedule_mode, int | float) else 0
+            )
 
             # Get safe current values
             current_power = self._attributes.get(DeviceAttributes.power, False)
@@ -479,25 +743,33 @@ class MideaCDDevice(MideaDevice):
                 # Fall back to 0x00 (no explicit operating mode).
                 message.mode = 0x00
             else:
-                mode_key = MideaCDDevice.get_dict_key_by_value(
-                    "_modes",
-                    str(current_mode),
+                mode_key = next(
+                    (
+                        key
+                        for key, name in self._mode_map().items()
+                        if name == str(current_mode)
+                    ),
+                    None,
                 )
                 message.mode = mode_key if mode_key is not None else 0x00
 
             # Update based on attribute being set
             if attr == DeviceAttributes.mode:
                 # get mode key from mode value
-                if value == MideaCDDevice._modes[MideaCDDevice._vacation_mode_key]:
+                if value == "Vacation":
                     _LOGGER.warning(
                         "[%s] Vacation mode cannot be selected directly; "
                         "use vacation_days/vacation_mode instead",
                         self.device_id,
                     )
                     return
-                mode_key = MideaCDDevice.get_dict_key_by_value(
-                    "_modes",
-                    str(value),
+                mode_key = next(
+                    (
+                        key
+                        for key, name in self._mode_map().items()
+                        if name == str(value)
+                    ),
+                    None,
                 )
                 if mode_key is None:
                     _LOGGER.warning(
@@ -546,6 +818,22 @@ class MideaCDDevice(MideaDevice):
                 days = max(1, min(360, int(value)))
                 message.vacation_flag = True
                 message.vacation_days = days
+
+            elif attr == DeviceAttributes.max_temperature:
+                lower = self._attributes.get(
+                    DeviceAttributes.max_temperature_lower_limit,
+                )
+                upper = self._attributes.get(
+                    DeviceAttributes.max_temperature_upper_limit,
+                )
+                minimum = int(lower) if isinstance(lower, int | float) else 35
+                maximum = int(upper) if isinstance(upper, int | float) else 70
+                message.ts_max = max(minimum, min(maximum, int(float(value))))
+                if message.target_temperature > message.ts_max:
+                    message.target_temperature = float(message.ts_max)
+
+            elif attr == DeviceAttributes.schedule_mode:
+                message.schedule_mode = max(0, min(2, int(value)))
 
             # persist only safe fields; SET echoes often return openPTC=1 / bad Tr
             self._fields = self._sanitize_set_fields(message.fields)

--- a/midealan/devices/cd/__init__.py
+++ b/midealan/devices/cd/__init__.py
@@ -523,6 +523,17 @@ class MideaCDDevice(MideaDevice):
                 # non-temperature attributes
                 self._attributes[attr] = raw_value
                 new_status[str(attr)] = self._attributes[attr]
+        # Extended heaters report the stable maintenance state through the
+        # canonical 0x40/B1 flag; their legacy 0x80 bit can flap independently.
+        # Mirror the canonical value so existing HA entity IDs remain stable.
+        maintenance_reminder = new_status.get(
+            str(DeviceAttributes.maintenance_reminder),
+        )
+        if isinstance(maintenance_reminder, bool) and self._is_extended_water_heater(
+            message,
+        ):
+            self._attributes[DeviceAttributes.maintain_warn] = maintenance_reminder
+            new_status[str(DeviceAttributes.maintain_warn)] = maintenance_reminder
         return new_status
 
     def _set_maintenance_reminder(self, value: bool) -> None:

--- a/midealan/devices/cd/__init__.py
+++ b/midealan/devices/cd/__init__.py
@@ -357,6 +357,9 @@ class MideaCDDevice(MideaDevice):
         ):
             return True
         capabilities = (
+            DeviceAttributes.support_heat_pump_mode,
+            DeviceAttributes.support_smart_mode,
+            DeviceAttributes.support_negative_temperature,
             DeviceAttributes.support_boost_mode,
             DeviceAttributes.support_silent_mode,
             DeviceAttributes.support_remaining_hot_water,
@@ -365,7 +368,7 @@ class MideaCDDevice(MideaDevice):
             DeviceAttributes.support_force_e_heating,
             DeviceAttributes.support_tou,
         )
-        return any(isinstance(_value(attribute), bool) for attribute in capabilities)
+        return any(_value(attribute) is True for attribute in capabilities)
 
     def _mode_map(self, message: object | None = None) -> dict[int, str]:
         """Select the mode map from capabilities reported by the device."""

--- a/midealan/devices/cd/__init__.py
+++ b/midealan/devices/cd/__init__.py
@@ -605,16 +605,48 @@ class MideaCDDevice(MideaDevice):
         self.build_send(message)
 
     @staticmethod
-    def _has_valid_timer_data(attr: str, value: dict[Any, Any]) -> bool:
+    def _is_integer_compatible(value: Any) -> bool:  # noqa: ANN401
+        """Return whether a schedule value can be encoded as an integer."""
+        try:
+            int(value)
+        except (TypeError, ValueError, OverflowError):
+            return False
+        return True
+
+    @classmethod
+    def _has_valid_timer_data(cls, attr: str, value: dict[Any, Any]) -> bool:
         """Return whether a schedule contains safe timer collections."""
-        timer_groups = (
-            [value.get(day, []) for day in range(7)]
-            if attr == DeviceAttributes.weekly_schedule
-            else [value.get("timers", [])]
-        )
+        numeric_fields: tuple[str, ...]
+        if attr == DeviceAttributes.weekly_schedule:
+            if any(
+                not isinstance(day, int) or isinstance(day, bool) or day not in range(7)
+                for day in value
+            ):
+                return False
+            timer_groups = [value.get(day, []) for day in range(7)]
+            numeric_fields = ("opentime", "closetime", "temperature", "mode")
+        else:
+            if "amount" in value and not cls._is_integer_compatible(value["amount"]):
+                return False
+            timer_groups = [value.get("timers", [])]
+            numeric_fields = (
+                "openhour",
+                "openmin",
+                "closehour",
+                "closemin",
+                "temperature",
+                "mode",
+            )
         return all(
             isinstance(timers, list)
-            and all(isinstance(timer, dict) for timer in timers)
+            and all(
+                isinstance(timer, dict)
+                and all(
+                    field not in timer or cls._is_integer_compatible(timer[field])
+                    for field in numeric_fields
+                )
+                for timer in timers
+            )
             for timers in timer_groups
         )
 

--- a/midealan/devices/cd/__init__.py
+++ b/midealan/devices/cd/__init__.py
@@ -610,6 +610,8 @@ class MideaCDDevice(MideaDevice):
     @staticmethod
     def _is_integer_compatible(value: Any) -> bool:  # noqa: ANN401
         """Return whether a schedule value can be encoded as an integer."""
+        if isinstance(value, bool):
+            return False
         try:
             int(value)
         except (TypeError, ValueError, OverflowError):

--- a/midealan/devices/cd/__init__.py
+++ b/midealan/devices/cd/__init__.py
@@ -322,7 +322,11 @@ class MideaCDDevice(MideaDevice):
                 if key != self._vacation_mode_key
             ]
         modes = self._mode_map()
-        selectable = ["Economy", "Hybrid", "E-Heater", "Smart"]
+        selectable = ["Economy", "Hybrid"]
+        if self._attributes.get(DeviceAttributes.support_electric_mode) is not False:
+            selectable.append("E-Heater")
+        if self._attributes.get(DeviceAttributes.support_smart_mode) is not False:
+            selectable.append("Smart")
         if self._attributes.get(DeviceAttributes.support_heat_pump_mode):
             selectable.append("Heat-pump")
         if self._attributes.get(DeviceAttributes.support_boost_mode):
@@ -333,29 +337,18 @@ class MideaCDDevice(MideaDevice):
 
     def _is_extended_water_heater(self, message: object | None = None) -> bool:
         """Detect extended CD support from reported protocol fields."""
-        source = message if message is not None else self._attributes
 
-        def _value(attribute: DeviceAttributes) -> Any:  # noqa: ANN401
+        def _value(source: object, attribute: DeviceAttributes) -> Any:  # noqa: ANN401
             if isinstance(source, dict):
                 return source.get(attribute)
             return getattr(source, attribute, None)
 
-        if _value(DeviceAttributes.new_version_water_heater) is True or isinstance(
-            _value(DeviceAttributes.b0_reserved_flags),
-            int,
-        ):
-            return True
         limits = (
             DeviceAttributes.max_temperature_upper_limit,
             DeviceAttributes.max_temperature_lower_limit,
             DeviceAttributes.disinfection_temperature_upper_limit,
             DeviceAttributes.disinfection_temperature_lower_limit,
         )
-        if any(
-            isinstance(_value(attribute), int | float) and _value(attribute) > 0
-            for attribute in limits
-        ):
-            return True
         capabilities = (
             DeviceAttributes.support_heat_pump_mode,
             DeviceAttributes.support_smart_mode,
@@ -368,7 +361,23 @@ class MideaCDDevice(MideaDevice):
             DeviceAttributes.support_force_e_heating,
             DeviceAttributes.support_tou,
         )
-        return any(_value(attribute) is True for attribute in capabilities)
+
+        def _source_is_extended(source: object) -> bool:
+            if _value(source, DeviceAttributes.new_version_water_heater) is True:
+                return True
+            if isinstance(_value(source, DeviceAttributes.b0_reserved_flags), int):
+                return True
+            if any(
+                isinstance(_value(source, attribute), int | float)
+                and _value(source, attribute) > 0
+                for attribute in limits
+            ):
+                return True
+            return any(_value(source, attribute) is True for attribute in capabilities)
+
+        if message is None:
+            return _source_is_extended(self._attributes)
+        return _source_is_extended(message) or _source_is_extended(self._attributes)
 
     def _mode_map(self, message: object | None = None) -> dict[int, str]:
         """Select the mode map from capabilities reported by the device."""

--- a/midealan/devices/cd/message.py
+++ b/midealan/devices/cd/message.py
@@ -639,13 +639,6 @@ class CDGeneralMessageBody(MessageBody):
             not smart_flag and self.mode == 0x00 and self.typeinfo == 0x04  # noqa: PLR2004
         ):
             self.mode = 0x04
-        extended_mode_flags = (
-            body[STATUS_EXTENDED_MODE_FLAGS_INDEX]
-            if len(body) > STATUS_EXTENDED_MODE_FLAGS_INDEX
-            else 0
-        )
-        self.holiday_mode = (extended_mode_flags & 0x01) > 0
-        self.hybrid_motion_mode = (extended_mode_flags & 0x02) > 0
         self.support_heat_pump_mode = (
             body[STATUS_SUPPORT_HEAT_PUMP_INDEX] == 0x01
             if len(body) > STATUS_SUPPORT_HEAT_PUMP_INDEX
@@ -661,6 +654,26 @@ class CDGeneralMessageBody(MessageBody):
             if len(body) > STATUS_SUPPORT_NEGATIVE_INDEX
             else None
         )
+        extended_support_indices = (
+            STATUS_SUPPORT_HEAT_PUMP_INDEX,
+            STATUS_SUPPORT_SMART_INDEX,
+            STATUS_SUPPORT_NEGATIVE_INDEX,
+            STATUS_MAX_TEMP_UPPER_INDEX,
+            STATUS_MAX_TEMP_LOWER_INDEX,
+            STATUS_DISINFECT_TEMP_UPPER_INDEX,
+            STATUS_DISINFECT_TEMP_LOWER_INDEX,
+            STATUS_CAPABILITY_FLAGS_INDEX,
+        )
+        has_extended_support = any(
+            len(body) > index and body[index] > 0 for index in extended_support_indices
+        )
+        extended_mode_flags = (
+            body[STATUS_EXTENDED_MODE_FLAGS_INDEX]
+            if has_extended_support and len(body) > STATUS_EXTENDED_MODE_FLAGS_INDEX
+            else 0
+        )
+        self.holiday_mode = (extended_mode_flags & 0x01) > 0
+        self.hybrid_motion_mode = (extended_mode_flags & 0x02) > 0
         if self.mode == 0x00:
             if (extended_mode_flags & 0x04) > 0:
                 self.mode = 0x05

--- a/midealan/devices/cd/message.py
+++ b/midealan/devices/cd/message.py
@@ -331,12 +331,11 @@ class MessageSetSterilize(MessageCDBase):
       bodyBytes[3] = autoSterilizeWeek
       bodyBytes[4] = autoSterilizeHour
       bodyBytes[5] = autoSterilizeMinute
+      bodyBytes[6] = disinfectionTemperature (extended protocol only)
 
-    The official Lua protocol names bodyBytes[3] autoSterilizeWeek, but the app
-    also displays the disinfection setpoint from nearby status bytes. Toggling
-    this command from HA has been observed to make the app show raw byte values
-    as temperatures, so callers must treat this command as read-only until the
-    exact immediate-disinfection write payload is known.
+    The extended 7-byte payload is writable after the device reports extended
+    protocol support. Legacy or unknown devices keep the 6-byte form and must
+    not receive the appended disinfection temperature.
     """
 
     # Valid range for disinfection temperature (°C)

--- a/midealan/devices/cd/message.py
+++ b/midealan/devices/cd/message.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from midealan.const import DeviceType
+from midealan.crc8 import calculate
 from midealan.message import (
     ListTypes,
     MessageBody,
@@ -27,6 +28,37 @@ BODY_TYPE_GENERAL = 0x01
 BODY_TYPE_WEEKLY = 0x02
 BODY_TYPE_DAILY = 0x03
 BODY_TYPE_STERILIZE = 0x06
+BODY_TYPE_B0 = 0xB0
+BODY_TYPE_B1 = 0xB1
+
+STATUS_SCHEDULE_MODE_INDEX = 56
+STATUS_MAX_TEMP_UPPER_INDEX = 57
+STATUS_MAX_TEMP_LOWER_INDEX = 58
+STATUS_DISINFECT_TEMP_UPPER_INDEX = 59
+STATUS_DISINFECT_TEMP_LOWER_INDEX = 60
+STATUS_DISINFECT_TEMP_INDEX = 61
+STATUS_DISINFECT_FLAGS_INDEX = 62
+STATUS_DR_ENABLE_INDEX = 63
+STATUS_DR_OPTION_INDEX = 64
+STATUS_ELECTRIC_ROD_EXCEPTION_INDEX = 65
+STATUS_CAPABILITY_FLAGS_INDEX = 66
+STATUS_REMAINING_WATER_MAX_INDEX = 67
+STATUS_FORCE_E_HEATING_INDEX = 68
+STATUS_EXTENDED_MODE_FLAGS_INDEX = 52
+STATUS_SUPPORT_HEAT_PUMP_INDEX = 53
+STATUS_SUPPORT_SMART_INDEX = 54
+STATUS_SUPPORT_NEGATIVE_INDEX = 55
+
+B1_FIRST_TLV_LENGTH_INDEX = 5
+B1_FUNCTION_FLAGS_TAG = 0x10
+B1_NEW_VERSION_TAG = 0x11
+B1_HOLIDAY_MAX_TAG = 0x12
+B1_HOLIDAY_MIN_TAG = 0x13
+B1_TIMER_STEP_TAG = 0x14
+B1_AC_HEATER_SUPPORT_TAG = 0x15
+B1_RESERVED_QUERY_TAG = 0x06
+B1_HEAT_RECOVERY_TAG = 0x16
+B1_HEAT_RECOVERY_ACTIVE = 0x02
 
 
 class MessageCDBase(MessageRequest):
@@ -109,6 +141,45 @@ class MessageQueryDaily(MessageCDBase):
         return bytearray([0x01])
 
 
+class MessageQueryB1(MessageCDBase):
+    """Query CD extended capabilities and function flags."""
+
+    def __init__(self, protocol_version: int) -> None:
+        """Initialize the official NetHome B1 capability query."""
+        super().__init__(
+            protocol_version=protocol_version,
+            message_type=MessageType.query,
+            body_type=ListTypes.B1,
+        )
+
+    @property
+    def _body(self) -> bytearray:
+        body = bytearray(
+            [
+                0x08,
+                B1_FUNCTION_FLAGS_TAG,
+                0x00,
+                B1_NEW_VERSION_TAG,
+                0x00,
+                B1_HOLIDAY_MAX_TAG,
+                0x00,
+                B1_HOLIDAY_MIN_TAG,
+                0x00,
+                B1_TIMER_STEP_TAG,
+                0x00,
+                B1_AC_HEATER_SUPPORT_TAG,
+                0x00,
+                B1_RESERVED_QUERY_TAG,
+                0x00,
+                B1_HEAT_RECOVERY_TAG,
+                0x00,
+            ],
+        )
+        crc_source = bytearray([BODY_TYPE_B1]) + body
+        body.append(calculate(crc_source))
+        return body
+
+
 class MessageSet(MessageCDBase):
     """CD message set (controlType=0x01).
 
@@ -164,6 +235,7 @@ class MessageSet(MessageCDBase):
         self.vacation_temperature: float = 0
         # device max temperature limit (full[23] / tsMax) — must be non-zero
         self.ts_max: int = 0
+        self.schedule_mode: int = 0
 
     def read_field(self, field: str) -> int:
         """CD message set read field."""
@@ -241,7 +313,7 @@ class MessageSet(MessageCDBase):
                 0,  # full[19]
                 0,  # full[20]
                 vacation_ts,  # full[21] vacationTsValue
-                0x00,  # full[22] timer_type
+                self.schedule_mode & 0xFF,  # full[22] schedule mode
                 self._ts_max_value(),  # full[23] tsMax (must be non-zero)
                 0x00,  # full[24] dr_switch
             ],
@@ -330,13 +402,14 @@ class MessageSetSterilize(MessageCDBase):
         self.week: int = 0
         self.hour: int = 0
         self.minute: int = 0
-        # Kept for read/diagnostic compatibility; not encoded in SET payloads.
+        # Appended only after the device reports extended protocol support.
+        self.extended_body: bool = False
         self.disinfection_temperature: float | None = None
 
     @property
     def _body(self) -> bytearray:
         sterilize_effect = 0x80 if self.sterilize_on else 0x00
-        return bytearray(
+        body = bytearray(
             [
                 0x01,  # bodyBytes[1] constant
                 sterilize_effect,  # bodyBytes[2] sterilizeEffect
@@ -345,6 +418,45 @@ class MessageSetSterilize(MessageCDBase):
                 self.clamp_minute(self.minute),  # bodyBytes[5] autoSterilizeMinute
             ],
         )
+        if self.extended_body:
+            value = self.disinfection_temperature
+            if not isinstance(value, int | float):
+                value = self.DISINFECT_TEMP_MIN
+            body.append(
+                self._clamp_int(
+                    value,
+                    int(self.DISINFECT_TEMP_MIN),
+                    int(self.DISINFECT_TEMP_MAX),
+                ),
+            )
+        return body
+
+
+class MessageSetMaintenance(MessageCDBase):
+    """Set B0 function flags while preserving unrelated device flags."""
+
+    def __init__(self, protocol_version: int) -> None:
+        """Initialize a NetHome-compatible B0 function control."""
+        super().__init__(
+            protocol_version=protocol_version,
+            message_type=MessageType.set,
+            body_type=ListTypes.B0,
+        )
+        self.ac_heater_priority = False
+        self.high_temp_reminder = False
+        self.maintenance_reminder = False
+        self.reserved_flags = 0
+
+    @property
+    def _body(self) -> bytearray:
+        flags = self.reserved_flags & 0x18
+        flags |= 0x01 if self.ac_heater_priority else 0x00
+        flags |= 0x02 if self.high_temp_reminder else 0x00
+        flags |= 0x04 if self.maintenance_reminder else 0x00
+        body = bytearray([0x01, B1_FUNCTION_FLAGS_TAG, 0x00, 0x01, flags])
+        crc_source = bytearray([BODY_TYPE_B0]) + body
+        body.append(calculate(crc_source))
+        return body
 
 
 class MessageSetWeekly(MessageCDBase):
@@ -396,10 +508,48 @@ class MessageSetWeekly(MessageCDBase):
         return body
 
 
+class MessageSetDaily(MessageCDBase):
+    """Set the six-slot NetHome daily timer programme (control type 0x02)."""
+
+    def __init__(self, protocol_version: int) -> None:
+        """Initialize a daily timer control."""
+        super().__init__(
+            protocol_version=protocol_version,
+            message_type=MessageType.set,
+            body_type=ListTypes.X02,
+        )
+        self.daily_timer_schedule: dict[str, Any] | None = None
+
+    @property
+    def _body(self) -> bytearray:
+        schedule = self.daily_timer_schedule or {}
+        timers = schedule.get("timers", [])
+        body = bytearray([0x01, int(schedule.get("amount", 0)) & 0xFF, 0x00])
+        body.extend([0x00] * 36)
+        effects = 0
+        for index in range(6):
+            timer = timers[index] if index < len(timers) else {}
+            if timer.get("effect", False):
+                effects |= 1 << index
+            offset = 3 + index * 6
+            body[offset] = int(timer.get("openhour", 0)) & 0xFF
+            body[offset + 1] = int(timer.get("openmin", 0)) & 0xFF
+            body[offset + 2] = int(timer.get("closehour", 0)) & 0xFF
+            body[offset + 3] = int(timer.get("closemin", 0)) & 0xFF
+            body[offset + 4] = int(timer.get("temperature", 0)) & 0xFF
+            body[offset + 5] = int(timer.get("mode", 0)) & 0xFF
+        if schedule.get("single_timer_on", False):
+            effects |= 0x40
+        if schedule.get("single_timer_off", False):
+            effects |= 0x80
+        body[2] = effects
+        return body
+
+
 class CDGeneralMessageBody(MessageBody):
     """CD message general body."""
 
-    def __init__(self, body: bytearray) -> None:
+    def __init__(self, body: bytearray) -> None:  # noqa: C901, PLR0915
         """Initialize CD message general body."""
         super().__init__(body)
         self.power = (body[2] & 0x01) > 0
@@ -476,7 +626,11 @@ class CDGeneralMessageBody(MessageBody):
         # sterilizeEffect: body[62] bit 0 (real-device status analysis shows
         # body[28] & 0x80 = 0x87 is constant across all messages regardless of
         # sterilize state and therefore cannot be the sterilize indicator).
-        self.sterilize = (body[62] & 0x01) > 0 if len(body) > 62 else False  # noqa: PLR2004
+        self.sterilize = (
+            (body[STATUS_DISINFECT_FLAGS_INDEX] & 0x01) > 0
+            if len(body) > STATUS_DISINFECT_FLAGS_INDEX
+            else False
+        )
         self.disinfect = self.sterilize
         self.typeinfo = body[29]
         # Conservative fallback: if no other mode flags and typeinfo==0x04,
@@ -485,6 +639,37 @@ class CDGeneralMessageBody(MessageBody):
             not smart_flag and self.mode == 0x00 and self.typeinfo == 0x04  # noqa: PLR2004
         ):
             self.mode = 0x04
+        extended_mode_flags = (
+            body[STATUS_EXTENDED_MODE_FLAGS_INDEX]
+            if len(body) > STATUS_EXTENDED_MODE_FLAGS_INDEX
+            else 0
+        )
+        self.holiday_mode = (extended_mode_flags & 0x01) > 0
+        self.hybrid_motion_mode = (extended_mode_flags & 0x02) > 0
+        self.support_heat_pump_mode = (
+            body[STATUS_SUPPORT_HEAT_PUMP_INDEX] == 0x01
+            if len(body) > STATUS_SUPPORT_HEAT_PUMP_INDEX
+            else None
+        )
+        self.support_smart_mode = (
+            body[STATUS_SUPPORT_SMART_INDEX] == 0x01
+            if len(body) > STATUS_SUPPORT_SMART_INDEX
+            else None
+        )
+        self.support_negative_temperature = (
+            body[STATUS_SUPPORT_NEGATIVE_INDEX] == 0x01
+            if len(body) > STATUS_SUPPORT_NEGATIVE_INDEX
+            else None
+        )
+        if self.mode == 0x00:
+            if (extended_mode_flags & 0x04) > 0:
+                self.mode = 0x05
+            elif (extended_mode_flags & 0x08) > 0:
+                self.mode = 0x04
+            elif (extended_mode_flags & 0x10) > 0:
+                self.mode = 0x09
+            elif (extended_mode_flags & 0x20) > 0:
+                self.mode = 0x0A
         # hotWater
         # Gate on the actual index read (body[34]) rather than
         # OLD_BODY_LENGTH (29), which previously allowed bodies of length
@@ -576,8 +761,8 @@ class CDGeneralMessageBody(MessageBody):
         # Stored regardless of whether sterilize is currently active so that the
         # set-point is preserved even when the function is turned off.
         self.disinfection_temperature: float | None = None
-        if len(body) > 61:  # noqa: PLR2004
-            raw_dt = float(body[61])
+        if len(body) > STATUS_DISINFECT_TEMP_INDEX:
+            raw_dt = float(body[STATUS_DISINFECT_TEMP_INDEX])
             if (
                 MessageSetSterilize.DISINFECT_TEMP_MIN
                 <= raw_dt
@@ -595,6 +780,123 @@ class CDGeneralMessageBody(MessageBody):
                 and raw_week % 2 == 0
             ):
                 self.disinfection_temperature = raw_week / 2.0
+
+        self.schedule_mode = (
+            body[STATUS_SCHEDULE_MODE_INDEX]
+            if len(body) > STATUS_SCHEDULE_MODE_INDEX
+            else None
+        )
+        self.max_temperature_upper_limit = (
+            float(body[STATUS_MAX_TEMP_UPPER_INDEX])
+            if len(body) > STATUS_MAX_TEMP_UPPER_INDEX
+            else None
+        )
+        self.max_temperature_lower_limit = (
+            float(body[STATUS_MAX_TEMP_LOWER_INDEX])
+            if len(body) > STATUS_MAX_TEMP_LOWER_INDEX
+            else None
+        )
+        self.disinfection_temperature_upper_limit = (
+            float(body[STATUS_DISINFECT_TEMP_UPPER_INDEX])
+            if len(body) > STATUS_DISINFECT_TEMP_UPPER_INDEX
+            else None
+        )
+        self.disinfection_temperature_lower_limit = (
+            float(body[STATUS_DISINFECT_TEMP_LOWER_INDEX])
+            if len(body) > STATUS_DISINFECT_TEMP_LOWER_INDEX
+            else None
+        )
+        self.auto_disinfect = (
+            (body[STATUS_DISINFECT_FLAGS_INDEX] & 0x02) > 0
+            if len(body) > STATUS_DISINFECT_FLAGS_INDEX
+            else None
+        )
+        self.dr_enable = (
+            body[STATUS_DR_ENABLE_INDEX] > 0
+            if len(body) > STATUS_DR_ENABLE_INDEX
+            else None
+        )
+        self.dr_option = (
+            body[STATUS_DR_OPTION_INDEX] if len(body) > STATUS_DR_OPTION_INDEX else None
+        )
+        self.electric_rod_exception = (
+            (body[STATUS_ELECTRIC_ROD_EXCEPTION_INDEX] & 0x01) > 0
+            if len(body) > STATUS_ELECTRIC_ROD_EXCEPTION_INDEX
+            else None
+        )
+        capability_flags = (
+            body[STATUS_CAPABILITY_FLAGS_INDEX]
+            if len(body) > STATUS_CAPABILITY_FLAGS_INDEX
+            else None
+        )
+        self.support_boost_mode = self._capability(capability_flags, 0x01)
+        self.support_silent_mode = self._capability(capability_flags, 0x02)
+        self.support_remaining_hot_water = self._capability(
+            capability_flags,
+            0x04,
+        )
+        self.support_electric_mode = self._capability(capability_flags, 0x08)
+        self.support_auto_disinfect = self._capability(capability_flags, 0x10)
+        self.support_force_e_heating = self._capability(capability_flags, 0x20)
+        self.support_tou = self._capability(capability_flags, 0x40)
+        self.remaining_hot_water_max = (
+            body[STATUS_REMAINING_WATER_MAX_INDEX]
+            if len(body) > STATUS_REMAINING_WATER_MAX_INDEX
+            else None
+        )
+        self.force_e_heating_status = (
+            body[STATUS_FORCE_E_HEATING_INDEX]
+            if len(body) > STATUS_FORCE_E_HEATING_INDEX
+            else None
+        )
+
+    @staticmethod
+    def _capability(flags: int | None, mask: int) -> bool | None:
+        """Decode a capability bit without inventing support on short frames."""
+        return (flags & mask) > 0 if flags is not None else None
+
+
+class CDB1MessageBody(MessageBody):
+    """Parse the official B1 TLV capability and function response."""
+
+    def __init__(self, body: bytearray) -> None:
+        """Initialize a B1 response, ignoring malformed or failed TLVs."""
+        super().__init__(body)
+        index = B1_FIRST_TLV_LENGTH_INDEX
+        while index < len(body):
+            length = body[index]
+            data_start = index + 1
+            data_end = data_start + length
+            if length == 0 or data_end > len(body):
+                break
+            result = body[index - 3]
+            group = body[index - 2]
+            tag = body[index - 1]
+            if result == 0 and group == 0:
+                self._set_tlv(tag, body[data_start:data_end])
+            index += length + 4
+
+    def _set_tlv(self, tag: int, data: bytearray) -> None:
+        """Apply one successful B1 TLV."""
+        value = data[0]
+        if tag == B1_FUNCTION_FLAGS_TAG:
+            self.ac_heater_priority = (value & 0x01) > 0
+            self.high_temp_reminder = (value & 0x02) > 0
+            self.maintenance_reminder = (value & 0x04) > 0
+            self.b0_reserved_flags = value & 0x18
+        elif tag == B1_NEW_VERSION_TAG:
+            self.new_version_water_heater = value == 0x01
+        elif tag == B1_HOLIDAY_MAX_TAG:
+            self.holiday_max = value * 5
+        elif tag == B1_HOLIDAY_MIN_TAG:
+            self.holiday_min = value
+        elif tag == B1_TIMER_STEP_TAG:
+            self.timer_step_gap = value
+        elif tag == B1_AC_HEATER_SUPPORT_TAG:
+            self.support_ac_heater_priority = (value & 0x01) > 0
+        elif tag == B1_HEAT_RECOVERY_TAG:
+            self.support_heat_recovery = value != 0
+            self.heat_recovery_status = value == B1_HEAT_RECOVERY_ACTIVE
 
 
 class CDWeeklyScheduleBody(MessageBody):
@@ -751,14 +1053,25 @@ class CDSterilizeSetBody(MessageBody):
         self.auto_sterilize_week = raw_byte3
         self.auto_sterilize_hour = raw_hour
         self.auto_sterilize_minute = raw_minute
-        # body[3] is ambiguous: some firmwares echo celsius x2 disinfection
+        self.disinfection_temperature: float | None = None
+        # Extended NetHome payloads carry direct °C in body[6].
+        if len(body) > 6:  # noqa: PLR2004
+            extended_temperature = float(body[6])
+            if (
+                MessageSetSterilize.DISINFECT_TEMP_MIN
+                <= extended_temperature
+                <= MessageSetSterilize.DISINFECT_TEMP_MAX
+            ):
+                self.disinfection_temperature = extended_temperature
+                return
+
+        # body[3] is ambiguous: some legacy firmwares echo celsius x2 disinfection
         # temperature, others echo autoSterilizeWeek.
         #
         # Real devices can encode temperature 60°C as 120 (<=127), so "value
         # >127 means temperature" is incorrect. We treat body[3] as
         # temperature when it lies in the exact encoded app range [120, 140]
         # and is even (x2 encoding), otherwise as week.
-        self.disinfection_temperature: float | None = None
         temp_raw_min = int(MessageSetSterilize.DISINFECT_TEMP_MIN * 2)
         temp_raw_max = int(MessageSetSterilize.DISINFECT_TEMP_MAX * 2)
         if (
@@ -792,6 +1105,8 @@ class MessageCDResponse(MessageResponse):
             elif self.body_type == BODY_TYPE_DAILY:
                 # daily timer query response (queryType=0x03)
                 self.set_body(CDDailyTimerBody(super().body))
+            elif self.body_type == BODY_TYPE_B1:
+                self.set_body(CDB1MessageBody(super().body))
         elif self.message_type == MessageType.set:
             if self.body_type == BODY_TYPE_GENERAL:
                 # controlType=0x01 SET response echo

--- a/midealan/devices/cd/message.py
+++ b/midealan/devices/cd/message.py
@@ -1,6 +1,6 @@
 """Midea local CD message."""
 
-from typing import Any
+from typing import Any, NotRequired, TypedDict
 
 from midealan.const import DeviceType
 from midealan.crc8 import calculate
@@ -30,6 +30,41 @@ BODY_TYPE_DAILY = 0x03
 BODY_TYPE_STERILIZE = 0x06
 BODY_TYPE_B0 = 0xB0
 BODY_TYPE_B1 = 0xB1
+
+
+class WeeklyTimer(TypedDict):
+    """One writable weekly timer slot."""
+
+    effect: NotRequired[bool]
+    opentime: NotRequired[int | float | str]
+    closetime: NotRequired[int | float | str]
+    temperature: NotRequired[int | float | str]
+    mode: NotRequired[int | float | str]
+
+
+WeeklySchedule = dict[int, list[WeeklyTimer]]
+
+
+class DailyTimer(TypedDict):
+    """One writable daily timer slot."""
+
+    effect: NotRequired[bool]
+    openhour: NotRequired[int | float | str]
+    openmin: NotRequired[int | float | str]
+    closehour: NotRequired[int | float | str]
+    closemin: NotRequired[int | float | str]
+    temperature: NotRequired[int | float | str]
+    mode: NotRequired[int | float | str]
+
+
+class DailyTimerSchedule(TypedDict):
+    """Writable daily timer programme."""
+
+    amount: NotRequired[int | float | str]
+    single_timer_on: NotRequired[bool]
+    single_timer_off: NotRequired[bool]
+    timers: NotRequired[list[DailyTimer]]
+
 
 STATUS_SCHEDULE_MODE_INDEX = 56
 STATUS_MAX_TEMP_UPPER_INDEX = 57
@@ -473,7 +508,7 @@ class MessageSetWeekly(MessageCDBase):
             message_type=MessageType.set,
             body_type=ListTypes.X07,
         )
-        self.weekly_schedule: dict[int, list[dict[str, Any]]] | None = None
+        self.weekly_schedule: WeeklySchedule | None = None
         self.maintenance_reminder: bool = False
         self.maintenance_warn: bool = False
 
@@ -517,7 +552,7 @@ class MessageSetDaily(MessageCDBase):
             message_type=MessageType.set,
             body_type=ListTypes.X02,
         )
-        self.daily_timer_schedule: dict[str, Any] | None = None
+        self.daily_timer_schedule: DailyTimerSchedule | None = None
 
     @property
     def _body(self) -> bytearray:
@@ -932,12 +967,12 @@ class CDWeeklyScheduleBody(MessageBody):
     def __init__(self, body: bytearray) -> None:
         """Initialize CD message weekly schedule body."""
         super().__init__(body)
-        self.weekly_schedule: dict | None = None
+        self.weekly_schedule: WeeklySchedule | None = None
         if len(body) > WEEKLY_SCHEDULE_BODY_LENGTH:
             _effect_masks = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20]
-            schedule: dict = {}
+            schedule: WeeklySchedule = {}
             for day in range(7):
-                slots = []
+                slots: list[WeeklyTimer] = []
                 effects_byte = body[2 + day]
                 for timer in range(6):
                     offset = 9 + day * 24 + timer * 4
@@ -990,10 +1025,10 @@ class CDDailyTimerBody(MessageBody):
     def __init__(self, body: bytearray) -> None:
         """Initialize CD message daily timer body."""
         super().__init__(body)
-        self.daily_timer_schedule: dict | None = None
+        self.daily_timer_schedule: DailyTimerSchedule | None = None
         if len(body) > DAILY_TIMER_BODY_LENGTH:
             _effect_masks = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20]
-            timers = []
+            timers: list[DailyTimer] = []
             for slot in range(6):
                 base = 4 + slot * 6
                 timers.append(

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -903,10 +903,37 @@ class TestMideaCDExtendedDevice:
             self.device.set_attribute(DeviceAttributes.weekly_schedule.value, True)
             mock_send.assert_not_called()
 
+    @pytest.mark.parametrize(
+        ("attribute", "schedule"),
+        [
+            (DeviceAttributes.daily_timer_schedule, {"timers": None}),
+            (DeviceAttributes.daily_timer_schedule, {"timers": [None]}),
+            (DeviceAttributes.weekly_schedule, {0: None}),
+            (DeviceAttributes.weekly_schedule, {0: [None]}),
+        ],
+    )
+    def test_schedule_writes_reject_invalid_timer_data(
+        self,
+        attribute: DeviceAttributes,
+        schedule: dict[object, object],
+    ) -> None:
+        """Malformed nested timer collections never build a control frame."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_attribute(attribute.value, schedule)
+        mock_send.assert_not_called()
+
     def test_scalar_controls_reject_mappings(self) -> None:
         """Ordinary scalar controls never accept schedule-like mappings."""
         with patch.object(self.device, "build_send") as mock_send:
             self.device.set_attribute(DeviceAttributes.power.value, {})
+            self.device.set_attribute(
+                DeviceAttributes.maintenance_reminder.value,
+                {"enabled": True},
+            )
+            self.device.set_attribute(
+                DeviceAttributes.maintain_warn_tag.value,
+                {"enabled": True},
+            )
         mock_send.assert_not_called()
 
     def test_max_temperature_is_clamped_to_reported_limit(self) -> None:

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -929,6 +929,7 @@ class TestMideaCDExtendedDevice:
             (DeviceAttributes.daily_timer_schedule, {"timers": None}),
             (DeviceAttributes.daily_timer_schedule, {"timers": [None]}),
             (DeviceAttributes.daily_timer_schedule, {"amount": None}),
+            (DeviceAttributes.daily_timer_schedule, {"amount": True}),
             (
                 DeviceAttributes.daily_timer_schedule,
                 {"timers": [{"openhour": None}]},
@@ -937,6 +938,7 @@ class TestMideaCDExtendedDevice:
             (DeviceAttributes.weekly_schedule, {0: [None]}),
             (DeviceAttributes.weekly_schedule, {"0": []}),
             (DeviceAttributes.weekly_schedule, {0: [{"opentime": None}]}),
+            (DeviceAttributes.weekly_schedule, {0: [{"mode": False}]}),
         ],
     )
     def test_schedule_writes_reject_invalid_timer_data(

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -908,8 +908,15 @@ class TestMideaCDExtendedDevice:
         [
             (DeviceAttributes.daily_timer_schedule, {"timers": None}),
             (DeviceAttributes.daily_timer_schedule, {"timers": [None]}),
+            (DeviceAttributes.daily_timer_schedule, {"amount": None}),
+            (
+                DeviceAttributes.daily_timer_schedule,
+                {"timers": [{"openhour": None}]},
+            ),
             (DeviceAttributes.weekly_schedule, {0: None}),
             (DeviceAttributes.weekly_schedule, {0: [None]}),
+            (DeviceAttributes.weekly_schedule, {"0": []}),
+            (DeviceAttributes.weekly_schedule, {0: [{"opentime": None}]}),
         ],
     )
     def test_schedule_writes_reject_invalid_timer_data(

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -11,8 +11,10 @@ from midealan.devices.cd.message import (
     MessageQueryB1,
     MessageQueryDaily,
     MessageQueryWeekly,
+    MessageSetDaily,
     MessageSetMaintenance,
     MessageSetSterilize,
+    MessageSetWeekly,
 )
 from midealan.message import MessageType
 
@@ -852,6 +854,21 @@ class TestMideaCDExtendedDevice:
         assert len(queries) == 4
         assert isinstance(queries[-1], MessageQueryB1)
 
+    def test_optional_modes_follow_reported_capabilities(self) -> None:
+        """Optional modes appear only after their capability is reported."""
+        self.device._attributes[DeviceAttributes.support_heat_pump_mode] = True
+        self.device._attributes[DeviceAttributes.support_boost_mode] = True
+        self.device._attributes[DeviceAttributes.support_silent_mode] = True
+        assert self.device.preset_modes == [
+            "Economy",
+            "Hybrid",
+            "E-Heater",
+            "Smart",
+            "Heat-pump",
+            "Boost",
+            "Silent",
+        ]
+
     def test_disinfection_write_uses_extended_payload(self) -> None:
         """Immediate disinfection preserves schedule and setpoint."""
         self.device._attributes[DeviceAttributes.disinfection_temperature] = 67.0
@@ -864,6 +881,34 @@ class TestMideaCDExtendedDevice:
         assert isinstance(message, MessageSetSterilize)
         assert message.body == bytearray([0x06, 0x01, 0x80, 4, 14, 5, 67])
 
+    def test_disinfection_defaults_temperature_and_rejects_mapping(self) -> None:
+        """Extended disinfection has a safe default and rejects mappings."""
+        self.device._attributes[DeviceAttributes.disinfection_temperature] = None
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_attribute(DeviceAttributes.disinfect.value, True)
+            message = mock_send.call_args.args[0]
+            assert message.disinfection_temperature == 60.0
+            mock_send.reset_mock()
+            self.device.set_attribute(DeviceAttributes.disinfect.value, {})
+            mock_send.assert_not_called()
+
+    def test_schedule_writes_require_support_and_mapping(self) -> None:
+        """Weekly and daily mappings use their dedicated message types."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_attribute(DeviceAttributes.weekly_schedule.value, {})
+            assert isinstance(mock_send.call_args.args[0], MessageSetWeekly)
+            self.device.set_attribute(DeviceAttributes.daily_timer_schedule.value, {})
+            assert isinstance(mock_send.call_args.args[0], MessageSetDaily)
+            mock_send.reset_mock()
+            self.device.set_attribute(DeviceAttributes.weekly_schedule.value, True)
+            mock_send.assert_not_called()
+
+    def test_scalar_controls_reject_mappings(self) -> None:
+        """Ordinary scalar controls never accept schedule-like mappings."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_attribute(DeviceAttributes.power.value, {})
+        mock_send.assert_not_called()
+
     def test_max_temperature_is_clamped_to_reported_limit(self) -> None:
         """Maximum target temperature uses BasicControl byte 23."""
         self.device._attributes[DeviceAttributes.max_temperature_lower_limit] = 40.0
@@ -872,6 +917,17 @@ class TestMideaCDExtendedDevice:
             self.device.set_attribute(DeviceAttributes.max_temperature.value, 75.0)
         message = mock_send.call_args.args[0]
         assert message.body[23] == 68
+
+    def test_max_temperature_clamps_target_and_schedule_mode(self) -> None:
+        """Reducing the maximum also clamps target; schedule mode stays 0..2."""
+        self.device._attributes[DeviceAttributes.target_temperature] = 69.0
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_attribute(DeviceAttributes.max_temperature.value, 65.0)
+            maximum = mock_send.call_args.args[0]
+            assert maximum.target_temperature == 65.0
+            self.device.set_attribute(DeviceAttributes.schedule_mode.value, 9.0)
+            schedule = mock_send.call_args.args[0]
+            assert schedule.schedule_mode == 2
 
     def test_maintenance_preserves_b1_flags(self) -> None:
         """Maintenance B0 control preserves priority, warning and reserved bits."""

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -8,8 +8,11 @@ from midealan.const import ProtocolVersion
 from midealan.devices.cd import DeviceAttributes, LuaProtocol, MideaCDDevice
 from midealan.devices.cd.message import (
     MessageQuery,
+    MessageQueryB1,
     MessageQueryDaily,
     MessageQueryWeekly,
+    MessageSetMaintenance,
+    MessageSetSterilize,
 )
 from midealan.message import MessageType
 
@@ -825,3 +828,67 @@ class TestMideaCDDevice:
         """RSJRAC01 resolves the auto lua protocol to new."""
         device = _make_device(model="RSJRAC01")
         assert device._lua_protocol == LuaProtocol.new
+
+
+class TestMideaCDExtendedDevice:
+    """Extended controls are enabled by reported protocol capabilities."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_device(self) -> None:
+        """Create a generic CD and mark it extended through reported limits."""
+        self.device = _make_device()
+        self.device._attributes[DeviceAttributes.max_temperature_lower_limit] = 35.0
+        self.device._attributes[DeviceAttributes.max_temperature_upper_limit] = 70.0
+
+    def test_official_mode_names_and_b1_query(self) -> None:
+        """Capabilities expose NetHome mode labels and the B1 query."""
+        assert self.device.preset_modes == [
+            "Economy",
+            "Hybrid",
+            "E-Heater",
+            "Smart",
+        ]
+        queries = self.device.build_query()
+        assert len(queries) == 4
+        assert isinstance(queries[-1], MessageQueryB1)
+
+    def test_disinfection_write_uses_extended_payload(self) -> None:
+        """Immediate disinfection preserves schedule and setpoint."""
+        self.device._attributes[DeviceAttributes.disinfection_temperature] = 67.0
+        self.device._attributes[DeviceAttributes.auto_sterilize_week] = 4
+        self.device._attributes[DeviceAttributes.auto_sterilize_hour] = 14
+        self.device._attributes[DeviceAttributes.auto_sterilize_minute] = 5
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_attribute(DeviceAttributes.disinfect.value, True)
+        message = mock_send.call_args.args[0]
+        assert isinstance(message, MessageSetSterilize)
+        assert message.body == bytearray([0x06, 0x01, 0x80, 4, 14, 5, 67])
+
+    def test_max_temperature_is_clamped_to_reported_limit(self) -> None:
+        """Maximum target temperature uses BasicControl byte 23."""
+        self.device._attributes[DeviceAttributes.max_temperature_lower_limit] = 40.0
+        self.device._attributes[DeviceAttributes.max_temperature_upper_limit] = 68.0
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_attribute(DeviceAttributes.max_temperature.value, 75.0)
+        message = mock_send.call_args.args[0]
+        assert message.body[23] == 68
+
+    def test_maintenance_preserves_b1_flags(self) -> None:
+        """Maintenance B0 control preserves priority, warning and reserved bits."""
+        self.device._attributes[DeviceAttributes.b0_reserved_flags] = 0x18
+        self.device._attributes[DeviceAttributes.ac_heater_priority] = True
+        self.device._attributes[DeviceAttributes.high_temp_reminder] = True
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_attribute(
+                DeviceAttributes.maintenance_reminder.value,
+                False,
+            )
+        message = mock_send.call_args.args[0]
+        assert isinstance(message, MessageSetMaintenance)
+        assert message.body[5] == 0x1B
+
+    def test_auto_disinfect_remains_read_only(self) -> None:
+        """Automatic disinfection status is not exposed as an invented toggle."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_attribute(DeviceAttributes.auto_disinfect.value, True)
+        mock_send.assert_not_called()

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -939,15 +939,19 @@ class TestMideaCDExtendedDevice:
             (DeviceAttributes.daily_timer_schedule, {"timers": [None]}),
             (DeviceAttributes.daily_timer_schedule, {"amount": None}),
             (DeviceAttributes.daily_timer_schedule, {"amount": True}),
+            (DeviceAttributes.daily_timer_schedule, {"single_timer_on": 1}),
+            (DeviceAttributes.daily_timer_schedule, {"single_timer_off": "false"}),
             (
                 DeviceAttributes.daily_timer_schedule,
                 {"timers": [{"openhour": None}]},
             ),
+            (DeviceAttributes.daily_timer_schedule, {"timers": [{"effect": 1}]}),
             (DeviceAttributes.weekly_schedule, {0: None}),
             (DeviceAttributes.weekly_schedule, {0: [None]}),
             (DeviceAttributes.weekly_schedule, {"0": []}),
             (DeviceAttributes.weekly_schedule, {0: [{"opentime": None}]}),
             (DeviceAttributes.weekly_schedule, {0: [{"mode": False}]}),
+            (DeviceAttributes.weekly_schedule, {0: [{"effect": "false"}]}),
         ],
     )
     def test_schedule_writes_reject_invalid_timer_data(

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -894,11 +894,23 @@ class TestMideaCDExtendedDevice:
 
     def test_schedule_writes_require_support_and_mapping(self) -> None:
         """Weekly and daily mappings use their dedicated message types."""
+        weekly_schedule = {0: [{"opentime": "6"}]}
+        daily_schedule = {"amount": "1", "timers": [{"openhour": "6"}]}
         with patch.object(self.device, "build_send") as mock_send:
-            self.device.set_attribute(DeviceAttributes.weekly_schedule.value, {})
-            assert isinstance(mock_send.call_args.args[0], MessageSetWeekly)
-            self.device.set_attribute(DeviceAttributes.daily_timer_schedule.value, {})
-            assert isinstance(mock_send.call_args.args[0], MessageSetDaily)
+            self.device.set_attribute(
+                DeviceAttributes.weekly_schedule.value,
+                weekly_schedule,
+            )
+            weekly = mock_send.call_args.args[0]
+            assert isinstance(weekly, MessageSetWeekly)
+            assert weekly.weekly_schedule == weekly_schedule
+            self.device.set_attribute(
+                DeviceAttributes.daily_timer_schedule.value,
+                daily_schedule,
+            )
+            daily = mock_send.call_args.args[0]
+            assert isinstance(daily, MessageSetDaily)
+            assert daily.daily_timer_schedule == daily_schedule
             mock_send.reset_mock()
             self.device.set_attribute(DeviceAttributes.weekly_schedule.value, True)
             mock_send.assert_not_called()

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -854,6 +854,14 @@ class TestMideaCDExtendedDevice:
         assert len(queries) == 4
         assert isinstance(queries[-1], MessageQueryB1)
 
+    def test_false_capabilities_do_not_enable_extended_protocol(self) -> None:
+        """Only positive capability evidence enables extended semantics."""
+        device = _make_device()
+        device._attributes[DeviceAttributes.support_boost_mode] = False
+        device._attributes[DeviceAttributes.support_silent_mode] = False
+
+        assert device._is_extended_water_heater() is False
+
     def test_optional_modes_follow_reported_capabilities(self) -> None:
         """Optional modes appear only after their capability is reported."""
         self.device._attributes[DeviceAttributes.support_heat_pump_mode] = True

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -861,6 +861,8 @@ class TestMideaCDExtendedDevice:
         device._attributes[DeviceAttributes.support_silent_mode] = False
 
         assert device._is_extended_water_heater() is False
+        device._attributes[DeviceAttributes.new_version_water_heater] = True
+        assert device._is_extended_water_heater() is True
 
     def test_optional_modes_follow_reported_capabilities(self) -> None:
         """Optional modes appear only after their capability is reported."""

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -970,6 +970,32 @@ class TestMideaCDExtendedDevice:
         assert isinstance(message, MessageSetMaintenance)
         assert message.body[5] == 0x1B
 
+    def test_maintenance_warning_uses_canonical_extended_flag(self) -> None:
+        """Extended heaters mirror the stable canonical maintenance flag."""
+        body = bytearray(69)
+        body[0] = 0x01
+        body[38] = 0x40  # canonical true, legacy 0x80 false
+        body[57] = 70
+        body[58] = 35
+
+        status = self.device.process_message(_build_message(MessageType.query, body))
+
+        assert status[DeviceAttributes.maintenance_reminder.value] is True
+        assert status[DeviceAttributes.maintain_warn.value] is True
+        assert self.device.attributes[DeviceAttributes.maintain_warn] is True
+
+    def test_legacy_maintenance_warning_keeps_raw_bit(self) -> None:
+        """Legacy heaters continue to expose the independent raw warning bit."""
+        device = _make_device()
+        body = bytearray(57)
+        body[0] = 0x01
+        body[38] = 0x40
+
+        status = device.process_message(_build_message(MessageType.query, body))
+
+        assert status[DeviceAttributes.maintenance_reminder.value] is True
+        assert status[DeviceAttributes.maintain_warn.value] is False
+
     def test_auto_disinfect_remains_read_only(self) -> None:
         """Automatic disinfection status is not exposed as an invented toggle."""
         with patch.object(self.device, "build_send") as mock_send:

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -877,6 +877,13 @@ class TestMideaCDExtendedDevice:
             "Silent",
         ]
 
+    def test_baseline_modes_follow_explicit_capabilities(self) -> None:
+        """Explicitly unsupported baseline modes are not advertised."""
+        self.device._attributes[DeviceAttributes.support_electric_mode] = False
+        self.device._attributes[DeviceAttributes.support_smart_mode] = False
+
+        assert self.device.preset_modes == ["Economy", "Hybrid"]
+
     def test_disinfection_write_uses_extended_payload(self) -> None:
         """Immediate disinfection preserves schedule and setpoint."""
         self.device._attributes[DeviceAttributes.disinfection_temperature] = 67.0
@@ -1012,6 +1019,18 @@ class TestMideaCDExtendedDevice:
         assert status[DeviceAttributes.maintenance_reminder.value] is True
         assert status[DeviceAttributes.maintain_warn.value] is True
         assert self.device.attributes[DeviceAttributes.maintain_warn] is True
+
+    def test_short_status_uses_persisted_extended_capabilities(self) -> None:
+        """Short responses retain learned mode and maintenance semantics."""
+        body = bytearray(57)
+        body[0] = 0x01
+        body[2] = 0x04
+        body[38] = 0x40
+
+        status = self.device.process_message(_build_message(MessageType.query, body))
+
+        assert status[DeviceAttributes.mode.value] == "Hybrid"
+        assert status[DeviceAttributes.maintain_warn.value] is True
 
     def test_legacy_maintenance_warning_keeps_raw_bit(self) -> None:
         """Legacy heaters continue to expose the independent raw warning bit."""

--- a/tests/devices/cd/message_cd_test.py
+++ b/tests/devices/cd/message_cd_test.py
@@ -346,7 +346,19 @@ class TestCDGeneralMessageBody:
         """Each reported extended mode bit maps to its protocol mode."""
         body = bytearray(69)
         body[52] = flag
+        body[53] = 0x01
         assert CDGeneralMessageBody(body).mode == mode
+
+    def test_extended_mode_flags_require_positive_support(self) -> None:
+        """Legacy-length padding does not activate extended mode semantics."""
+        body = bytearray(69)
+        body[52] = 0x10
+
+        parsed = CDGeneralMessageBody(body)
+
+        assert parsed.mode == 0x00
+        assert parsed.holiday_mode is False
+        assert parsed.hybrid_motion_mode is False
 
     # Real-device status bodies (body_type=0x01):
     #   msg1: 70C disinfection, sterilize ON

--- a/tests/devices/cd/message_cd_test.py
+++ b/tests/devices/cd/message_cd_test.py
@@ -171,6 +171,12 @@ class TestMessageSetDaily:
         assert len(body) == 40
         assert body[:10] == bytearray([2, 1, 1, 0x41, 6, 30, 8, 0, 55, 1])
 
+    def test_single_off_flag(self) -> None:
+        """The standalone off timer uses its dedicated effect bit."""
+        msg = MessageSetDaily(protocol_version=ProtocolVersion.V1)
+        msg.daily_timer_schedule = {"single_timer_off": True}
+        assert msg.body[3] == 0x80
+
 
 class TestCDB1MessageBody:
     """Test B1 TLV parsing used to make B0 writes lossless."""
@@ -191,6 +197,32 @@ class TestCDB1MessageBody:
         assert parsed.new_version_water_heater is True
         assert not hasattr(parsed, "maintenance_reminder")
 
+    def test_all_metadata_tlvs(self) -> None:
+        """Every supported B1 metadata tag is decoded."""
+        body = bytearray.fromhex(
+            "b10800001201030000130104000014010500001501010000160102",
+        )
+        parsed = CDB1MessageBody(body)
+        assert parsed.holiday_max == 15
+        assert parsed.holiday_min == 4
+        assert parsed.timer_step_gap == 5
+        assert parsed.support_ac_heater_priority is True
+        assert parsed.support_heat_recovery is True
+        assert parsed.heat_recovery_status is True
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            bytearray.fromhex("b10800001000"),
+            bytearray.fromhex("b1080000100201"),
+            bytearray.fromhex("b1080100100101"),
+        ],
+    )
+    def test_malformed_or_failed_tlv_is_ignored(self, body: bytearray) -> None:
+        """Malformed, failed, and incomplete records do not publish flags."""
+        parsed = CDB1MessageBody(body)
+        assert not hasattr(parsed, "maintenance_reminder")
+
 
 class TestMessageSetSterilizeClamp:
     """Test MessageSetSterilize clamp helpers with invalid inputs."""
@@ -204,6 +236,14 @@ class TestMessageSetSterilizeClamp:
         """Unsupported types fall back to the minimum."""
         assert MessageSetSterilize.clamp_week(None) == 0
         assert MessageSetSterilize.clamp_minute(object()) == 0
+
+    def test_extended_body_defaults_and_clamps_temperature(self) -> None:
+        """The seventh byte is safe even without a usable temperature."""
+        msg = MessageSetSterilize(protocol_version=ProtocolVersion.V1)
+        msg.extended_body = True
+        assert msg.body[6] == 60
+        msg.disinfection_temperature = 99.0
+        assert msg.body[6] == 70
 
 
 class TestMessageSetWeekly:
@@ -297,6 +337,16 @@ class TestCDGeneralMessageBody:
         assert parsed.support_heat_pump_mode is True
         assert parsed.support_smart_mode is True
         assert parsed.support_negative_temperature is True
+
+    @pytest.mark.parametrize(
+        ("flag", "mode"),
+        [(0x04, 0x05), (0x08, 0x04), (0x20, 0x0A)],
+    )
+    def test_other_extended_mode_flags(self, flag: int, mode: int) -> None:
+        """Each reported extended mode bit maps to its protocol mode."""
+        body = bytearray(69)
+        body[52] = flag
+        assert CDGeneralMessageBody(body).mode == mode
 
     # Real-device status bodies (body_type=0x01):
     #   msg1: 70C disinfection, sterilize ON
@@ -445,6 +495,12 @@ class TestCDSterilizeSetBody:
         """body[3]=132 sets disinfection_temperature=66.0 when on."""
         parsed = CDSterilizeSetBody(self._make_body(sterilize_on=True, byte3=132))
         assert parsed.disinfection_temperature == 66.0
+
+    def test_extended_temperature_byte_takes_precedence(self) -> None:
+        """The NetHome seventh byte carries direct Celsius."""
+        body = self._make_body(sterilize_on=True, byte3=4)
+        body.append(67)
+        assert CDSterilizeSetBody(body).disinfection_temperature == 67.0
 
     def test_temp_echo_on_keeps_raw_auto_sterilize_week(self) -> None:
         """body[3]=132 when sterilize ON also remains available as raw week."""
@@ -963,6 +1019,12 @@ class TestMessageCDResponse:
         body[0] = 0x03
         response = MessageCDResponse(_build_response(MessageType.query, body))
         assert getattr(response, "daily_timer_schedule", None) is not None
+
+    def test_query_b1(self) -> None:
+        """B1 query responses use the capability TLV parser."""
+        body = bytearray.fromhex("b1080000110101")
+        response = MessageCDResponse(_build_response(MessageType.query, body))
+        assert getattr(response, "new_version_water_heater", None) is True
 
     def test_set_general_echo(self) -> None:
         """Set responses with body type 0x01 use the SET echo body."""

--- a/tests/devices/cd/message_cd_test.py
+++ b/tests/devices/cd/message_cd_test.py
@@ -7,6 +7,7 @@ import pytest
 from midealan.const import ProtocolVersion
 from midealan.devices.cd.message import (
     CD01MessageBody,
+    CDB1MessageBody,
     CDDailyTimerBody,
     CDGeneralMessageBody,
     CDSterilizeSetBody,
@@ -14,9 +15,12 @@ from midealan.devices.cd.message import (
     MessageCDBase,
     MessageCDResponse,
     MessageQuery,
+    MessageQueryB1,
     MessageQueryDaily,
     MessageQueryWeekly,
     MessageSet,
+    MessageSetDaily,
+    MessageSetMaintenance,
     MessageSetSterilize,
     MessageSetWeekly,
 )
@@ -54,6 +58,14 @@ class TestCDMessageQueries:
         """Daily query body uses body type 0x03."""
         msg = MessageQueryDaily(protocol_version=ProtocolVersion.V1)
         assert msg.body == bytearray([0x03, 0x01])
+
+    def test_query_b1_body_and_crc(self) -> None:
+        """B1 query requests all official water-heater function tags."""
+        body = MessageQueryB1(protocol_version=ProtocolVersion.V1).body
+        assert body[:-1] == bytearray.fromhex(
+            "b10810001100120013001400150006001600",
+        )
+        assert body[-1] == 0x6B
 
 
 class TestMessageSet:
@@ -112,6 +124,72 @@ class TestMessageSet:
         assert msg.read_field("trValue") == 5
         assert msg.read_field("openPTC") == 0
         assert msg.read_field("missing") == 0
+
+    def test_schedule_mode_uses_basic_control_byte_22(self) -> None:
+        """Timer/schedule selection is preserved in ordinary controls."""
+        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg.schedule_mode = 2
+        assert msg.body[22] == 2
+
+
+class TestMessageSetMaintenance:
+    """Test the dedicated B0 function flag control."""
+
+    def test_flags_are_preserved_and_crc_is_appended(self) -> None:
+        """B0 changes maintenance without dropping unrelated flag bits."""
+        msg = MessageSetMaintenance(protocol_version=ProtocolVersion.V1)
+        msg.ac_heater_priority = True
+        msg.high_temp_reminder = False
+        msg.maintenance_reminder = True
+        msg.reserved_flags = 0x18
+        assert msg.body == bytearray.fromhex("b0011000011d56")
+
+
+class TestMessageSetDaily:
+    """Test NetHome daily timer controls."""
+
+    def test_complete_timer_body(self) -> None:
+        """Daily timer uses body type 2 and the official forty-byte layout."""
+        msg = MessageSetDaily(protocol_version=ProtocolVersion.V1)
+        msg.daily_timer_schedule = {
+            "amount": 1,
+            "single_timer_on": True,
+            "single_timer_off": False,
+            "timers": [
+                {
+                    "effect": True,
+                    "openhour": 6,
+                    "openmin": 30,
+                    "closehour": 8,
+                    "closemin": 0,
+                    "temperature": 55,
+                    "mode": 1,
+                },
+            ],
+        }
+        body = msg.body
+        assert len(body) == 40
+        assert body[:10] == bytearray([2, 1, 1, 0x41, 6, 30, 8, 0, 55, 1])
+
+
+class TestCDB1MessageBody:
+    """Test B1 TLV parsing used to make B0 writes lossless."""
+
+    def test_function_and_capability_tlvs(self) -> None:
+        """Function flags and extended model metadata are decoded."""
+        body = bytearray.fromhex("b108000010011d0000110101")
+        parsed = CDB1MessageBody(body)
+        assert parsed.ac_heater_priority is True
+        assert parsed.high_temp_reminder is False
+        assert parsed.maintenance_reminder is True
+        assert parsed.b0_reserved_flags == 0x18
+        assert parsed.new_version_water_heater is True
+
+    def test_omitted_tlv_does_not_publish_unknown_values(self) -> None:
+        """Attributes for TLVs absent from a B1 response are not published."""
+        parsed = CDB1MessageBody(bytearray.fromhex("b1080000110101"))
+        assert parsed.new_version_water_heater is True
+        assert not hasattr(parsed, "maintenance_reminder")
 
 
 class TestMessageSetSterilizeClamp:
@@ -187,6 +265,38 @@ class TestMessageSetWeekly:
 
 class TestCDGeneralMessageBody:
     """Test CDGeneralMessageBody parsing of real-device status bytes."""
+
+    def test_extended_capabilities_and_limits(self) -> None:
+        """RSJRAC extended status bytes are exposed only when present."""
+        body = bytearray(69)
+        body[2] = 0x03
+        body[57:61] = bytearray([70, 35, 70, 60])
+        body[61] = 65
+        body[62] = 0x03
+        body[63:67] = bytearray([1, 2, 1, 0x7F])
+        body[67:69] = bytearray([100, 2])
+        parsed = CDGeneralMessageBody(body)
+        assert parsed.max_temperature_upper_limit == 70.0
+        assert parsed.max_temperature_lower_limit == 35.0
+        assert parsed.auto_disinfect is True
+        assert parsed.support_boost_mode is True
+        assert parsed.support_silent_mode is True
+        assert parsed.support_tou is True
+        assert parsed.remaining_hot_water_max == 100
+        assert parsed.force_e_heating_status == 2
+
+    def test_extended_boost_mode_flag(self) -> None:
+        """Extended status byte 52 exposes Boost without affecting legacy bits."""
+        body = bytearray(69)
+        body[52] = 0x10
+        body[53:56] = bytearray([1, 1, 1])
+        parsed = CDGeneralMessageBody(body)
+        assert parsed.mode == 0x09
+        assert parsed.holiday_mode is False
+        assert parsed.hybrid_motion_mode is False
+        assert parsed.support_heat_pump_mode is True
+        assert parsed.support_smart_mode is True
+        assert parsed.support_negative_temperature is True
 
     # Real-device status bodies (body_type=0x01):
     #   msg1: 70C disinfection, sterilize ON
@@ -459,6 +569,16 @@ class TestMessageSetSterilize:
         msg = MessageSetSterilize(protocol_version=1)
         msg.sterilize_on = True
         assert msg.body[2] == 0x80
+
+    def test_extended_body_appends_direct_temperature(self) -> None:
+        """Recognised new models use NetHome's seventh direct-Celsius byte."""
+        msg = MessageSetSterilize(protocol_version=1)
+        msg.extended_body = True
+        msg.week = 4
+        msg.hour = 14
+        msg.minute = 5
+        msg.disinfection_temperature = 67.0
+        assert msg.body == bytearray([0x06, 0x01, 0x00, 4, 14, 5, 67])
 
     def test_week_value_sent_when_no_temperature(self) -> None:
         """Week value is placed in body[3] when disinfection_temperature is None."""


### PR DESCRIPTION
## Summary
- query and parse CD B1 capabilities and preserve missing TLVs
- support B0 maintenance, extended disinfection temperature, max temperature, schedule mode, and daily/weekly timer writes
- gate extended behavior from reported protocol capabilities instead of model allowlists
- keep automatic disinfection read-only because NetHome does not expose an on/off control

## Validation
- 164 CD tests passed
- Ruff and formatter passed
- mypy passed
- pylint 10/10
- verified on a real CD water heater with Home Assistant 2026.8.3: maintenance remained stable and extended values updated across polling cycles

Related compatibility backport: midea-lan/midea-local#735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for extended water heater models and their additional operating modes.
  - Added visibility for expanded capabilities, temperature limits, remaining hot water, heating options, and status indicators.
  - Added support for schedule modes, daily timers, maintenance reminders, disinfection settings, and maximum temperature controls.
  - Added automatic detection of advanced device capabilities and improved handling of extended status information.

- **Bug Fixes**
  - Improved maintenance-status synchronization and validation of schedule and timer settings.
  - Added temperature clamping to keep submitted values within supported limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->