### PR TITLE
feat(ac): run B5 capability queries once and publish results to HA

### DIFF
--- a/midealan/device.py
+++ b/midealan/device.py
@@ -443,11 +443,21 @@ class MideaDevice(threading.Thread):
         status stage has been appended yet, and whether this call appended
         anything (the unchecked pass loops on it until every stage is queued).
         """
-        new_init = [
-            cmd
-            for cmd in self.build_init_query()
-            if cmd.__class__.__name__ not in queued
-        ]
+        # The init/capability probes depend on the message protocol version the
+        # appliance reply reports. Offer them only once a parsed reply has
+        # cleared _appliance_query; if the appliance query timed out, raised, or
+        # is still pending, _message_protocol_version is unresolved (0), so skip
+        # straight to build_query() rather than probe with a stale version and
+        # risk blacklisting a capability query for the whole connection.
+        new_init = (
+            [
+                cmd
+                for cmd in self.build_init_query()
+                if cmd.__class__.__name__ not in queued
+            ]
+            if not self._appliance_query
+            else []
+        )
         if new_init:
             for cmd in new_init:
                 queued.add(cmd.__class__.__name__)

--- a/midealan/device.py
+++ b/midealan/device.py
@@ -394,6 +394,26 @@ class MideaDevice(threading.Thread):
         msg = PacketBuilder(self._device_id, data).finalize()
         self.send_message(msg, query=query)
 
+    def _splice_followup_init_queries(
+        self,
+        cmds: list,
+        index: int,
+        queued_init: set[str],
+    ) -> None:
+        """Insert init queries armed by the reply just processed.
+
+        Called from refresh_status()'s checked pass after a reply. Each newly
+        armed init query is inserted at ``index`` (the read cursor) so it is the
+        next command sent and validated in the same pass. ``queued_init`` records
+        every init query already queued this refresh, so a probe left armed after
+        a timeout is not inserted again and thus never re-sent.
+        """
+        for follow_up in self.build_init_query():
+            name = follow_up.__class__.__name__
+            if name not in queued_init and name not in self._unsupported_protocol:
+                cmds.insert(index, follow_up)
+                queued_init.add(name)
+
     def refresh_status(self, check_protocol: bool = False) -> None:
         """Refresh device status."""
         real_cmds: list = self.build_query()
@@ -406,6 +426,11 @@ class MideaDevice(threading.Thread):
         if self._appliance_query:
             cmds = [MessageQueryAppliance(self.device_type), *cmds]
         error_count = 0
+        # Init-query classes already queued this refresh. A reply can arm a
+        # follow-up init query (e.g. the AC additional-capability probe), which
+        # is spliced into this same pass below; the set stops it being queued
+        # more than once, so a probe left armed after a timeout is not re-sent.
+        queued_init = {cmd.__class__.__name__ for cmd in init_cmds}
         _LOGGER.debug(
             "[%s] refresh_status with cmds: %s, check_protocol %s, "
             "device %s, type %s, model %s, subtype %s, device_protocol: %s, "
@@ -421,7 +446,12 @@ class MideaDevice(threading.Thread):
             self._message_protocol_version,
             self._unsupported_protocol,
         )
-        for cmd in cmds:
+        # Index-based so a follow-up init query armed while processing a reply
+        # can be inserted and validated within this same checked pass.
+        index = 0
+        while index < len(cmds):
+            cmd = cmds[index]
+            index += 1
             if cmd.__class__.__name__ not in self._unsupported_protocol:
                 # set socket QUERY_TIMEOUT for query msg
                 # build_send exception should be catch by connect/run
@@ -450,6 +480,16 @@ class MideaDevice(threading.Thread):
                                 raise ResponseException  # noqa: TRY301
                         # recovery SOCKET_TIMEOUT after recv msg
                         self._socket.settimeout(SOCKET_TIMEOUT)
+                        # A reply may arm a follow-up init query (e.g. the AC
+                        # additional-capability probe, armed only once the basic
+                        # frame advertises it). Splice any newly-armed probe in
+                        # at the read cursor so it is the next command sent and
+                        # validated within this checked pass.
+                        self._splice_followup_init_queries(
+                            cmds,
+                            index,
+                            queued_init,
+                        )
                     # only catch TimoutError for check_protocol
                     # unexpected exception in recv/settimeout, catch by main loop
                     except TimeoutError:

--- a/midealan/device.py
+++ b/midealan/device.py
@@ -398,8 +398,13 @@ class MideaDevice(threading.Thread):
         """Refresh device status."""
         real_cmds: list = self.build_query()
         cmds = real_cmds
+        # One-time init queries (e.g. AC B5 capability probes) run before the
+        # recurring status queries so later queries can react to their result.
+        init_cmds = self.build_init_query()
+        if init_cmds:
+            cmds = [*init_cmds, *cmds]
         if self._appliance_query:
-            cmds = [MessageQueryAppliance(self.device_type), *real_cmds]
+            cmds = [MessageQueryAppliance(self.device_type), *cmds]
         error_count = 0
         _LOGGER.debug(
             "[%s] refresh_status with cmds: %s, check_protocol %s, "
@@ -608,6 +613,27 @@ class MideaDevice(threading.Thread):
         """Build query."""
         raise NotImplementedError
 
+    def build_init_query(self) -> list:
+        """Build one-time queries to run once at connect time.
+
+        These are prepended ahead of build_query() during refresh_status(), so
+        their replies are processed before the recurring status queries. A
+        device only needs to send these once (e.g. capability probes whose reply
+        never changes); the subclass clears its own arming flags when the reply
+        is parsed, and any query that times out is recorded in
+        _unsupported_protocol and skipped from then on. The base class has none.
+        """
+        return []
+
+    def reset_init_query(self) -> None:
+        """Re-arm the one-time init queries after the socket is closed.
+
+        Called from close_socket() alongside the appliance-query re-arm so a
+        reconnected device re-probes from scratch instead of reusing stale
+        results. Subclasses that override build_init_query() reset their arming
+        flags here. The base class has no init queries, so this is a no-op.
+        """
+
     def process_message(self, msg: bytes) -> dict[str, Any]:
         """Process message."""
         raise NotImplementedError
@@ -700,6 +726,9 @@ class MideaDevice(threading.Thread):
                 # pre_process_message and was never set back, so a reconnected device
                 # would skip protocol detection and re-probe with build_query() alone.
                 self._appliance_query = True
+                # Re-arm one-time init queries (e.g. AC B5 capability probes) so a
+                # reconnected device re-probes instead of reusing stale results.
+                self.reset_init_query()
                 self._buffer = b""
         if sock is not None:
             try:

--- a/midealan/device.py
+++ b/midealan/device.py
@@ -394,45 +394,122 @@ class MideaDevice(threading.Thread):
         msg = PacketBuilder(self._device_id, data).finalize()
         self.send_message(msg, query=query)
 
-    def _splice_followup_init_queries(
+    def _await_query_reply(self) -> None:
+        """Block until the current query is answered (checked pass only).
+
+        Loops over socket reads until parse_message reports SUCCESS, then
+        restores SOCKET_TIMEOUT. A PADDING result keeps reading; any other
+        result raises ResponseException. A missing socket or a closed peer
+        raises to the connect/main loop. TimeoutError from recv propagates to
+        the caller, which records the query as unsupported.
+        """
+        while True:
+            if not self._socket:
+                _LOGGER.debug("[%s] device socket is none", self._device_id)
+                # raise exception to connect/main loop
+                raise SocketException
+            msg = self._socket.recv(512)
+            if len(msg) == 0:
+                raise ConnectionResetError("Connection closed by peer.")
+            result = self.parse_message(msg)
+            # Prevent infinite loop
+            if result == MessageResult.SUCCESS:
+                break
+            if result == MessageResult.PADDING:
+                continue
+            raise ResponseException
+        # recovery SOCKET_TIMEOUT after recv msg
+        self._socket.settimeout(SOCKET_TIMEOUT)
+
+    def _advance_query_stage(
         self,
         cmds: list,
-        index: int,
-        queued_init: set[str],
-    ) -> None:
-        """Insert init queries armed by the reply just processed.
+        queued: set[str],
+        real_cmds: list,
+        status_appended: bool,
+    ) -> tuple[list, bool, bool]:
+        """Append the next due query stage to ``cmds`` in dependency order.
 
-        Called from refresh_status()'s checked pass after a reply. Each newly
-        armed init query is inserted at ``index`` (the read cursor) so it is the
-        next command sent and validated in the same pass. ``queued_init`` records
-        every init query already queued this refresh, so a probe left armed after
-        a timeout is not inserted again and thus never re-sent.
+        Queries are built lazily, one stage at a time, so each stage sees the
+        state resolved by the previous stage's reply: the one-time init queries
+        (e.g. the AC B5 capability probes, which need the protocol version the
+        appliance reply reports) run first, offered until they are exhausted,
+        then the recurring status queries (which may need the decoded
+        capabilities). Commands already queued this refresh are filtered out, so
+        a probe left armed after a timeout -- still reported by build_init_query
+        but recorded in _unsupported_protocol -- is not queued a second time.
+
+        Returns the status-query list (for the all-failed check), whether the
+        status stage has been appended yet, and whether this call appended
+        anything (the unchecked pass loops on it until every stage is queued).
         """
-        for follow_up in self.build_init_query():
-            name = follow_up.__class__.__name__
-            if name not in queued_init and name not in self._unsupported_protocol:
-                cmds.insert(index, follow_up)
-                queued_init.add(name)
+        new_init = [
+            cmd
+            for cmd in self.build_init_query()
+            if cmd.__class__.__name__ not in queued
+        ]
+        if new_init:
+            for cmd in new_init:
+                queued.add(cmd.__class__.__name__)
+                cmds.append(cmd)
+            return real_cmds, status_appended, True
+        if not status_appended:
+            real_cmds = self.build_query()
+            for cmd in real_cmds:
+                queued.add(cmd.__class__.__name__)
+                cmds.append(cmd)
+            return real_cmds, True, True
+        return real_cmds, status_appended, False
 
     def refresh_status(self, check_protocol: bool = False) -> None:
-        """Refresh device status."""
-        real_cmds: list = self.build_query()
-        cmds = real_cmds
-        # One-time init queries (e.g. AC B5 capability probes) run before the
-        # recurring status queries so later queries can react to their result.
-        init_cmds = self.build_init_query()
-        if init_cmds:
-            cmds = [*init_cmds, *cmds]
-        if self._appliance_query:
-            cmds = [MessageQueryAppliance(self.device_type), *cmds]
+        """Refresh device status.
+
+        Queries are built and sent in dependency order so each stage's reply
+        can inform the next: the appliance query first (it reports the message
+        protocol version); once answered, the one-time init/capability probes
+        are built (they need that version) and sent; once those are answered,
+        the recurring status queries are built (they may need the decoded
+        capabilities) and sent. In the checked pass each stage's reply is
+        awaited before the next stage is built, via _advance_query_stage(). In
+        the unchecked periodic refresh no reply is awaited inline -- the run
+        loop parses them -- so any still-armed stage is built and sent back to
+        back.
+        """
+        cmds: list = []
+        real_cmds: list = []
+        status_appended = False
         error_count = 0
-        # Init-query classes already queued this refresh. A reply can arm a
-        # follow-up init query (e.g. the AC additional-capability probe), which
-        # is spliced into this same pass below; the set stops it being queued
-        # more than once, so a probe left armed after a timeout is not re-sent.
-        queued_init = {cmd.__class__.__name__ for cmd in init_cmds}
+        # Names already queued this refresh, so a stage command left armed after
+        # a timeout (recorded in _unsupported_protocol) is not queued again.
+        queued: set[str] = set()
+        # Stage 1: the appliance query. When its reply will be awaited (checked
+        # pass), later stages are appended only after it, so they see the
+        # protocol version it reports. Otherwise they are seeded below.
+        if self._appliance_query:
+            cmds.append(MessageQueryAppliance(self.device_type))
+            queued.add("MessageQueryAppliance")
+        if check_protocol:
+            # Nothing to await first (appliance query already done): seed the
+            # next stage now; its reply then drives the remaining stages.
+            if not cmds:
+                real_cmds, status_appended, _ = self._advance_query_stage(
+                    cmds,
+                    queued,
+                    real_cmds,
+                    status_appended,
+                )
+        else:
+            # No inline replies: build every still-armed stage up front.
+            advanced = True
+            while advanced:
+                real_cmds, status_appended, advanced = self._advance_query_stage(
+                    cmds,
+                    queued,
+                    real_cmds,
+                    status_appended,
+                )
         _LOGGER.debug(
-            "[%s] refresh_status with cmds: %s, check_protocol %s, "
+            "[%s] refresh_status seed cmds: %s, check_protocol %s, "
             "device %s, type %s, model %s, subtype %s, device_protocol: %s, "
             "message_protocol %s, unsupported_protocol: %s",
             self._device_id,
@@ -446,8 +523,8 @@ class MideaDevice(threading.Thread):
             self._message_protocol_version,
             self._unsupported_protocol,
         )
-        # Index-based so a follow-up init query armed while processing a reply
-        # can be inserted and validated within this same checked pass.
+        # Index-based so the next stage, built only once the current reply is
+        # parsed, can be appended and validated within this same checked pass.
         index = 0
         while index < len(cmds):
             cmd = cmds[index]
@@ -459,37 +536,7 @@ class MideaDevice(threading.Thread):
                 # init check_protocol, skip timeout exception
                 if check_protocol:
                     try:
-                        while True:
-                            if not self._socket:
-                                _LOGGER.debug(
-                                    "[%s] device socket is none",
-                                    self._device_id,
-                                )
-                                # raise exception to connect/main loop
-                                raise SocketException
-                            msg = self._socket.recv(512)
-                            if len(msg) == 0:
-                                raise ConnectionResetError("Connection closed by peer.")
-                            result = self.parse_message(msg)
-                            # Prevent infinite loop
-                            if result == MessageResult.SUCCESS:
-                                break
-                            elif result == MessageResult.PADDING:  # noqa: RET508
-                                continue
-                            else:
-                                raise ResponseException  # noqa: TRY301
-                        # recovery SOCKET_TIMEOUT after recv msg
-                        self._socket.settimeout(SOCKET_TIMEOUT)
-                        # A reply may arm a follow-up init query (e.g. the AC
-                        # additional-capability probe, armed only once the basic
-                        # frame advertises it). Splice any newly-armed probe in
-                        # at the read cursor so it is the next command sent and
-                        # validated within this checked pass.
-                        self._splice_followup_init_queries(
-                            cmds,
-                            index,
-                            queued_init,
-                        )
+                        self._await_query_reply()
                     # only catch TimoutError for check_protocol
                     # unexpected exception in recv/settimeout, catch by main loop
                     except TimeoutError:
@@ -512,6 +559,18 @@ class MideaDevice(threading.Thread):
                             cmd.__class__.__name__,
                             cmd,
                         )
+                    # The reply (or its absence) may resolve the state the next
+                    # stage depends on -- the appliance reply enables the
+                    # capability probes, a capability reply the status queries.
+                    # Append that stage now so it is sent and validated in this
+                    # same checked pass, not deferred to an unchecked refresh
+                    # where a timeout could never blacklist it.
+                    real_cmds, status_appended, _ = self._advance_query_stage(
+                        cmds,
+                        queued,
+                        real_cmds,
+                        status_appended,
+                    )
             else:
                 _LOGGER.debug(
                     "[%s] refresh_status with cmd: %s, unsupported protocol, SKIP",
@@ -520,6 +579,15 @@ class MideaDevice(threading.Thread):
                 )
                 if cmd in real_cmds:
                     error_count += 1
+                # A skipped (already-unsupported) stage command still resolves
+                # its stage, so advance to the next one in the checked pass.
+                if check_protocol:
+                    real_cmds, status_appended, _ = self._advance_query_stage(
+                        cmds,
+                        queued,
+                        real_cmds,
+                        status_appended,
+                    )
             # All the REAL status queries failed. The appliance query is excluded: it
             # answers even when the device serves no status protocol, so counting it
             # left error_count one short of len(cmds) and the failure was masked --
@@ -656,12 +724,19 @@ class MideaDevice(threading.Thread):
     def build_init_query(self) -> list:
         """Build one-time queries to run once at connect time.
 
-        These are prepended ahead of build_query() during refresh_status(), so
-        their replies are processed before the recurring status queries. A
-        device only needs to send these once (e.g. capability probes whose reply
-        never changes); the subclass clears its own arming flags when the reply
-        is parsed, and any query that times out is recorded in
-        _unsupported_protocol and skipped from then on. The base class has none.
+        refresh_status() sends these after the appliance query and before the
+        recurring build_query() status queries, and -- crucially -- builds them
+        only once the appliance reply has set the message protocol version, so
+        they can depend on it. Their own replies are then processed before the
+        status queries are built, so a status query can react to the result
+        (e.g. the AC B5 capability probes decoded here). A device only needs to
+        send these once (their reply never changes); the subclass clears its own
+        arming flags when the reply is parsed, and any query that times out is
+        recorded in _unsupported_protocol and skipped from then on. The subclass
+        may return a follow-up query only after an earlier init reply is parsed
+        (e.g. the AC additional-capability probe); refresh_status() keeps
+        offering build_init_query() until it is exhausted. The base class has
+        none.
         """
         return []
 

--- a/midealan/devices/ac/__init__.py
+++ b/midealan/devices/ac/__init__.py
@@ -321,8 +321,18 @@ class MideaACDevice(MideaDevice):
         self._bb_timer: bool = False
         # per-mode setpoint limits from the B5 capability, keyed by mode value
         self._temperature_limits: dict[int, tuple[float, float]] | None = None
-        # decoded B5 capability flags (accumulated across B5 frames)
-        self._capabilities: dict[str, bool] = {}
+        # decoded B5 capability flags (accumulated across B5 frames). Values are
+        # mostly booleans, but some (e.g. rate_select level count) are ints.
+        self._capabilities: dict[str, bool | int] = {}
+        # B5 capability query control. Both queries run once, like the appliance
+        # query: on success the flag is cleared so it is never re-sent (the reply
+        # never changes); on timeout the device layer records it in
+        # _unsupported_protocol so it is skipped too. The additional query is
+        # only armed after the basic frame advertises a second frame.
+        self._capability_query = True
+        self._capability_addition_query = False
+        self._support_capability = False
+        self._support_capability_addition = False
         # manual setpoint limits from customize (highest priority)
         self._customize_min_temperature: float | None = None
         self._customize_max_temperature: float | None = None
@@ -386,7 +396,9 @@ class MideaACDevice(MideaDevice):
             MessageQuery(self._message_protocol_version),
             NewProtocolQuery(
                 self._message_protocol_version,
-                supports_rate_select=self._capabilities.get("rate_select", False),
+                supports_rate_select=bool(
+                    self._capabilities.get("rate_select", False),
+                ),
             ),
             # Queried on its own so an empty response for the combined
             # new-protocol query does not suppress the self-clean state.
@@ -399,10 +411,45 @@ class MideaACDevice(MideaDevice):
             GroupOneQuery(self._message_protocol_version),
             GroupTwoQuery(self._message_protocol_version),
             GroupSevenQuery(self._message_protocol_version),
-            CapabilitiesQuery(self._message_protocol_version),
-            CapabilitiesAdditionalQuery(self._message_protocol_version),
+            # Capability queries are not part of the recurring status cycle. They
+            # run once at connect time via build_init_query() while the
+            # _capability_query / _capability_addition_query flags are set.
         ]
         return queries
+
+    def build_init_query(self) -> list[ACQuery]:
+        """Return the B5 capability probes that are still due.
+
+        Both probes are one-shot. The basic query is armed at construction; the
+        additional query is armed only after the basic reply advertises a second
+        frame (see _update_capabilities). Each flag is cleared once its reply is
+        parsed, so a fully-probed device returns an empty list and stops sending
+        capability queries. The subprotocol (BB) devices do not use B5.
+        """
+        if self._used_subprotocol:
+            return []
+        queries: list[ACQuery] = []
+        if self._capability_query:
+            queries.append(CapabilitiesQuery(self._message_protocol_version))
+        if self._capability_addition_query:
+            queries.append(
+                CapabilitiesAdditionalQuery(self._message_protocol_version),
+            )
+        return queries
+
+    def reset_init_query(self) -> None:
+        """Re-arm the B5 capability probes after a socket close.
+
+        Mirrors the appliance-query re-arm: a reconnected device re-probes its
+        capabilities from scratch rather than reusing the previous result. The
+        additional probe stays disarmed until the fresh basic frame advertises a
+        second frame again. Accumulated _capabilities are left in place so the
+        HA integration keeps the last known set until the re-probe overwrites it.
+        """
+        self._capability_query = True
+        self._capability_addition_query = False
+        self._support_capability = False
+        self._support_capability_addition = False
 
     def process_message(self, msg: bytes) -> dict[str, Any]:  # noqa: C901
         """Midea AC device process message."""
@@ -529,7 +576,7 @@ class MideaACDevice(MideaDevice):
                 self._attributes[DeviceAttributes.self_clean] = active
                 new_status[DeviceAttributes.self_clean.value] = active
         new_status.update(self._refresh_temperature_limits(message))
-        self._update_capabilities(message)
+        new_status.update(self._update_capabilities(message))
         return new_status
 
     @staticmethod
@@ -557,13 +604,52 @@ class MideaACDevice(MideaDevice):
             else self._default_refresh_interval
         )
 
-    def _update_capabilities(self, message: MessageACResponse) -> None:
-        """Accumulate decoded B5 capability flags from a B5 response."""
-        if hasattr(message, "capabilities"):
-            self._capabilities.update(message.capabilities)
+    def _update_capabilities(self, message: MessageACResponse) -> dict[str, Any]:
+        """Merge B5 capability flags and advance the capability query state.
+
+        A B5 reply resolves the query it answered: the basic frame clears
+        _capability_query (and arms the additional query when the device
+        advertises a second frame), while the additional frame clears
+        _capability_addition_query. Both are one-shot, so once cleared here the
+        query is never re-sent.
+
+        Returns a status update carrying the merged ``capabilities`` dict so the
+        consumer (e.g. the HA integration, which reads ``device.capabilities``)
+        is notified as soon as a frame is decoded, instead of holding the empty
+        dict seen at initialization. Returns an empty dict for non-B5 messages.
+        """
+        if not hasattr(message, "capabilities"):
+            return {}
+        self._capabilities.update(message.capabilities)
+
+        additional_pending = self._capability_addition_query
+        if additional_pending:
+            # This reply answers the additional (all_second_frame) query.
+            self._support_capability_addition = True
+            self._capability_addition_query = False
+        else:
+            # This reply answers the basic (all_first_frame) query.
+            self._support_capability = True
+            self._capability_query = False
+            if getattr(message, "additional_capabilities", False):
+                # Device advertises a second frame; arm the additional query so
+                # the next refresh_status() prepends it.
+                self._capability_addition_query = True
+
+        _LOGGER.debug(
+            "[%s] Capability state: support=%s support_addition=%s "
+            "addition_pending=%s merged=%s",
+            self.device_id,
+            self._support_capability,
+            self._support_capability_addition,
+            self._capability_addition_query,
+            self._capabilities,
+        )
+        # Publish a copy so downstream mutation can't corrupt the cached dict.
+        return {"capabilities": dict(self._capabilities)}
 
     @property
-    def capabilities(self) -> dict[str, bool]:
+    def capabilities(self) -> dict[str, bool | int]:
         """Return the decoded B5 capability flags reported by the device."""
         return self._capabilities
 

--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -118,6 +118,13 @@ B5_TURBO_HEAT_VALUES = frozenset({1, 3})
 B5_DISPLAY_VALUES = frozenset({1, 2, 100})
 B5_ELECTRICITY_UNSUPPORTED_VALUE = 0  # 0 = unsupported; nonzero = rate level count
 
+# A B5 capability body ends with a trailing [flag, message_id, crc] block. The
+# device sets the flag byte non-zero to signal that a second (additional)
+# capability frame is available. Unlike msmart-ng (whose payload ends in
+# [flag, crc]), midea-lan echoes the message_id byte, so the flag sits three
+# bytes from the end of the parsed body.
+B5_ADDITIONAL_CAPABILITIES_TRAILER_LENGTH = 3
+
 
 class PowerFormats(IntEnum):
     """AC Power/Energy analysis formats."""
@@ -1227,15 +1234,31 @@ class CapabilityBody(NewProtocolMessageBody):
         if NewProtocolTags.b5_humidity in params:
             self.b5_humidity = params[NewProtocolTags.b5_humidity][0]
         self._parse_capabilities(params)
+        self.additional_capabilities = self._detect_additional_capabilities()
+
+    def _detect_additional_capabilities(self) -> bool:
+        """Return whether the device advertises a second capability frame.
+
+        After parse() consumes every parameter, the body still holds a trailing
+        [flag, message_id, crc] block. A non-zero flag means the device has more
+        capabilities that only the additional (all_second_frame) query returns.
+        The flag is read relative to parse()'s end position rather than a fixed
+        offset so a body whose parameters are truncated is handled safely.
+        """
+        remaining = self.data[self._params_end_pos :]
+        if len(remaining) < B5_ADDITIONAL_CAPABILITIES_TRAILER_LENGTH:
+            return False
+        return bool(remaining[-B5_ADDITIONAL_CAPABILITIES_TRAILER_LENGTH])
 
     def _parse_capabilities(self, params: dict[int, bytearray]) -> None:
         """Decode B5 capability values into feature flags.
 
         The raw byte of each capability is not a simple 0/1 flag; each one has
         its own value semantics (reverse-engineered, matching the msmart
-        project). Only capabilities actually reported are added.
+        project). Only capabilities actually reported are added. Values are
+        mostly booleans, but some (e.g. rate_select's level count) are ints.
         """
-        caps: dict[str, bool] = {}
+        caps: dict[str, bool | int] = {}
         if NewProtocolTags.b5_mode in params:
             value = params[NewProtocolTags.b5_mode][0]
             caps["heat_mode"] = value in B5_HEAT_MODE_VALUES

--- a/midealan/message.py
+++ b/midealan/message.py
@@ -828,6 +828,10 @@ class NewProtocolMessageBody(MessageBody):
     def __init__(self, body: bytearray) -> None:
         """Initialize new protocol message body."""
         super().__init__(body)
+        # Offset in ``data`` just past the last parsed parameter. Set by
+        # parse(); subclasses (e.g. AC's CapabilityBody) read the bytes after
+        # this point without re-walking the parameter list.
+        self._params_end_pos = 0
         if self.body_type == ListTypes.B5:
             self._pack_len = NewProtocolPackLength.FOUR
         elif self.body_type in [ListTypes.B0, ListTypes.B1]:
@@ -877,8 +881,10 @@ class NewProtocolMessageBody(MessageBody):
         # (e.g. bytearray([0xB1])) returns {} instead of leaving param_count
         # unbound for the debug log below (would raise UnboundLocalError).
         param_count = 0
+        # Declared before the try so it survives an early IndexError and can be
+        # recorded in _params_end_pos below.
+        pos = 2  # # 跳过协议头(b1)和参数数量
         try:
-            pos = 2  # # 跳过协议头(b1)和参数数量
             param_count = self.data[1]  # 参数数量
             for _ in range(param_count):
                 if pos + 2 > len(self.data):  # 防止越界
@@ -906,6 +912,9 @@ class NewProtocolMessageBody(MessageBody):
         except IndexError:
             # Some device used non-standard new-protocol(美的乐享三代中央空调?)
             _LOGGER.debug("Non-standard new-protocol %s", self.data.hex())
+        # Record where parsing stopped so callers can inspect trailing bytes
+        # (e.g. the B5 additional-capabilities flag) without re-parsing.
+        self._params_end_pos = pos
         # format result key to hex for debug log
         hex_result = {hex(k): v for k, v in result.items()}
         _LOGGER.debug(

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -634,6 +634,14 @@ class TestMideaDevice:
         init_cmd.__class__.__name__ = "InitQuery"
         real_cmd.__class__.__name__ = "StatusQuery"
         sent: list[object] = []
+
+        def parse(_msg: bytes) -> MessageResult:
+            # The appliance reply is what clears _appliance_query in production
+            # (via pre_process_message); model that so the init stage is armed.
+            if sent and sent[-1].__class__.__name__ == "MessageQueryAppliance":
+                self.device._appliance_query = False
+            return MessageResult.SUCCESS
+
         with (
             patch.object(self.device, "build_query", return_value=[real_cmd]),
             patch.object(self.device, "build_init_query", return_value=[init_cmd]),
@@ -643,11 +651,7 @@ class TestMideaDevice:
                 "build_send",
                 side_effect=lambda cmd, query=False: sent.append(cmd),  # noqa: ARG005
             ),
-            patch.object(
-                self.device,
-                "parse_message",
-                side_effect=[MessageResult.SUCCESS] * 3,
-            ),
+            patch.object(self.device, "parse_message", side_effect=parse),
         ):
             self.device._socket = socket_mock
             assert self.device._appliance_query is True
@@ -657,6 +661,56 @@ class TestMideaDevice:
         assert sent[0].__class__.__name__ == "MessageQueryAppliance"
         assert sent[1] is init_cmd
         assert sent[2] is real_cmd
+
+    def test_unresolved_appliance_query_skips_init_probes(self) -> None:
+        """A failed appliance query must not arm the init/capability probes.
+
+        The init probes (e.g. AC B5 capability queries) need the message
+        protocol version the appliance reply reports. If the appliance query
+        times out, _appliance_query stays True and the version is unresolved, so
+        the checked pass must advance straight to build_query() rather than probe
+        with a stale version -- a probe timing out here would be blacklisted for
+        the whole connection, costing capability discovery on a device whose
+        status queries work.
+        """
+        socket_mock = MagicMock()
+        init_cmd = MagicMock(name="init_cmd")
+        real_cmd = MagicMock(name="real_cmd")
+        init_cmd.__class__.__name__ = "InitQuery"
+        real_cmd.__class__.__name__ = "StatusQuery"
+        sent: list[object] = []
+
+        # Appliance query times out (no reply clears _appliance_query), then the
+        # status query answers.
+        with (
+            patch.object(self.device, "build_query", return_value=[real_cmd]),
+            patch.object(self.device, "build_init_query", return_value=[init_cmd]),
+            patch.object(
+                socket_mock,
+                "recv",
+                side_effect=[TimeoutError(), bytearray([0x0])],
+            ),
+            patch.object(
+                self.device,
+                "build_send",
+                side_effect=lambda cmd, query=False: sent.append(cmd),  # noqa: ARG005
+            ),
+            patch.object(
+                self.device,
+                "parse_message",
+                side_effect=[MessageResult.SUCCESS],
+            ),
+        ):
+            self.device._socket = socket_mock
+            assert self.device._appliance_query is True
+            self.device.refresh_status(True)
+
+        # appliance query, then straight to the status query -- no init probe.
+        assert sent[0].__class__.__name__ == "MessageQueryAppliance"
+        assert init_cmd not in sent
+        assert sent[1] is real_cmd
+        # _appliance_query is still armed for the next connect-time probe.
+        assert self.device._appliance_query is True
 
     def test_followup_init_query_spliced_into_checked_pass(self) -> None:
         """A reply that arms a follow-up init query gets it validated in-pass.

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -764,6 +764,52 @@ class TestMideaDevice:
         # Sent exactly once despite still being reported as armed.
         assert sum(isinstance(c, _Additional) for c in sent) == 1
 
+    def test_blacklisted_init_query_still_advances_stage_in_checked_pass(self) -> None:
+        """A skipped (already-unsupported) init stage still advances to the next.
+
+        When an init query is already in _unsupported_protocol its send is
+        skipped, but its stage is still resolved: the checked pass must build and
+        send the next stage (the status queries) rather than stalling on the
+        skipped command.
+        """
+        socket_mock = MagicMock()
+        self.device._appliance_query = False
+
+        class _Init:
+            pass
+
+        init_cmd = _Init()
+        self.device._unsupported_protocol = ["_Init"]
+        real_cmd = MagicMock(name="real_cmd")
+        real_cmd.__class__.__name__ = "StatusQuery"
+        armed = {"init": True}
+        sent: list[object] = []
+
+        def build_init() -> list[object]:
+            return [init_cmd] if armed["init"] else []
+
+        with (
+            patch.object(self.device, "build_query", return_value=[real_cmd]),
+            patch.object(self.device, "build_init_query", side_effect=build_init),
+            patch.object(socket_mock, "recv", side_effect=[bytearray([0x0])]),
+            patch.object(
+                self.device,
+                "build_send",
+                side_effect=lambda cmd, query=False: sent.append(cmd),  # noqa: ARG005
+            ),
+            patch.object(
+                self.device,
+                "parse_message",
+                side_effect=[MessageResult.SUCCESS],
+            ),
+        ):
+            self.device._socket = socket_mock
+            self.device.refresh_status(True)
+
+        # The skipped init query is never sent, but the status stage still runs.
+        assert init_cmd not in sent
+        assert sent == [real_cmd]
+
     def test_run_loop_reconnects_when_no_protocol_is_supported(self) -> None:
         """NoSupportedProtocol must drop the socket, like every other error here.
 
@@ -912,6 +958,31 @@ class TestMideaDevice:
             self.device.refresh_status()
 
         build_send_mock.assert_called_once_with(cmd, query=True)
+
+    def test_unchecked_refresh_skips_unsupported_query_without_advancing(self) -> None:
+        """An unchecked refresh skips an unsupported query and sends the rest.
+
+        With check_protocol=False no reply is awaited inline, so a command in
+        _unsupported_protocol takes the SKIP branch and does not trigger a stage
+        advance -- the periodic refresh must simply pass over it and still send
+        the remaining, supported query.
+        """
+        supported = type("Supported", (), {})()
+        unsupported = type("Unsupported", (), {})()
+        self.device._appliance_query = False
+        self.device._unsupported_protocol = ["Unsupported"]
+        with (
+            patch.object(
+                self.device,
+                "build_query",
+                return_value=[unsupported, supported],
+            ),
+            patch.object(self.device, "build_send") as build_send_mock,
+        ):
+            self.device.refresh_status()
+
+        # Only the supported query is sent; the unsupported one is skipped.
+        build_send_mock.assert_called_once_with(supported, query=True)
 
     def test_parse_message(self) -> None:
         """Test parse message."""

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -658,6 +658,112 @@ class TestMideaDevice:
         assert sent[1] is init_cmd
         assert sent[2] is real_cmd
 
+    def test_followup_init_query_spliced_into_checked_pass(self) -> None:
+        """A reply that arms a follow-up init query gets it validated in-pass.
+
+        The AC additional-capability probe is armed only after the basic frame's
+        reply, i.e. after the command list was built. It must be sent and
+        validated inside the same check_protocol pass, not deferred to an
+        unchecked refresh where a timeout could never blacklist it.
+        """
+        socket_mock = MagicMock()
+        self.device._appliance_query = False
+
+        class _Basic:
+            pass
+
+        class _Additional:
+            pass
+
+        basic = _Basic()
+        additional = _Additional()
+        real_cmd = MagicMock(name="real_cmd")
+        real_cmd.__class__.__name__ = "StatusQuery"
+        # Arm the follow-up only after the basic probe's reply is processed.
+        armed = {"additional": False}
+        sent: list[object] = []
+
+        def build_init() -> list[object]:
+            return [additional] if armed["additional"] else [basic]
+
+        def parse(_msg: bytes) -> MessageResult:
+            if sent and isinstance(sent[-1], _Basic):
+                armed["additional"] = True
+            return MessageResult.SUCCESS
+
+        with (
+            patch.object(self.device, "build_query", return_value=[real_cmd]),
+            patch.object(self.device, "build_init_query", side_effect=build_init),
+            patch.object(socket_mock, "recv", side_effect=[bytearray([0x0])] * 3),
+            patch.object(
+                self.device,
+                "build_send",
+                side_effect=lambda cmd, query=False: sent.append(cmd),  # noqa: ARG005
+            ),
+            patch.object(self.device, "parse_message", side_effect=parse),
+        ):
+            self.device._socket = socket_mock
+            self.device.refresh_status(True)
+
+        # basic probe, then the spliced additional probe, then the status query.
+        assert sent[0] is basic
+        assert sent[1] is additional
+        assert sent[2] is real_cmd
+
+    def test_followup_init_query_blacklisted_on_timeout(self) -> None:
+        """An armed follow-up probe that times out is recorded, not re-sent.
+
+        Once the additional probe is spliced in and times out during the checked
+        pass, it lands in _unsupported_protocol, so it is never queued again even
+        though build_init_query() keeps reporting it as armed.
+        """
+        socket_mock = MagicMock()
+        self.device._appliance_query = False
+
+        class _Basic:
+            pass
+
+        class _Additional:
+            pass
+
+        basic = _Basic()
+        additional = _Additional()
+        real_cmd = MagicMock(name="real_cmd")
+        real_cmd.__class__.__name__ = "StatusQuery"
+        armed = {"additional": False}
+        sent: list[object] = []
+
+        def build_init() -> list[object]:
+            return [additional] if armed["additional"] else [basic]
+
+        def parse(_msg: bytes) -> MessageResult:
+            if sent and isinstance(sent[-1], _Basic):
+                armed["additional"] = True
+            return MessageResult.SUCCESS
+
+        # basic reply succeeds, additional probe times out, status query succeeds.
+        with (
+            patch.object(self.device, "build_query", return_value=[real_cmd]),
+            patch.object(self.device, "build_init_query", side_effect=build_init),
+            patch.object(
+                socket_mock,
+                "recv",
+                side_effect=[bytearray([0x0]), TimeoutError(), bytearray([0x0])],
+            ),
+            patch.object(
+                self.device,
+                "build_send",
+                side_effect=lambda cmd, query=False: sent.append(cmd),  # noqa: ARG005
+            ),
+            patch.object(self.device, "parse_message", side_effect=parse),
+        ):
+            self.device._socket = socket_mock
+            self.device.refresh_status(True)  # must not raise (real query answered)
+
+        assert "_Additional" in self.device._unsupported_protocol
+        # Sent exactly once despite still being reported as armed.
+        assert sum(isinstance(c, _Additional) for c in sent) == 1
+
     def test_run_loop_reconnects_when_no_protocol_is_supported(self) -> None:
         """NoSupportedProtocol must drop the socket, like every other error here.
 

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -621,6 +621,43 @@ class TestMideaDevice:
             self.device._socket = socket_mock
             self.device.refresh_status(True)
 
+    def test_build_init_query_prepended_before_status_queries(self) -> None:
+        """Init queries run after the appliance query and before status queries.
+
+        build_init_query() (e.g. AC's one-shot B5 capability probes) must be
+        prepended ahead of build_query() so their replies are processed before
+        the recurring status queries, but still after the appliance query.
+        """
+        socket_mock = MagicMock()
+        init_cmd = MagicMock(name="init_cmd")
+        real_cmd = MagicMock(name="real_cmd")
+        init_cmd.__class__.__name__ = "InitQuery"
+        real_cmd.__class__.__name__ = "StatusQuery"
+        sent: list[object] = []
+        with (
+            patch.object(self.device, "build_query", return_value=[real_cmd]),
+            patch.object(self.device, "build_init_query", return_value=[init_cmd]),
+            patch.object(socket_mock, "recv", side_effect=[bytearray([0x0])] * 3),
+            patch.object(
+                self.device,
+                "build_send",
+                side_effect=lambda cmd, query=False: sent.append(cmd),  # noqa: ARG005
+            ),
+            patch.object(
+                self.device,
+                "parse_message",
+                side_effect=[MessageResult.SUCCESS] * 3,
+            ),
+        ):
+            self.device._socket = socket_mock
+            assert self.device._appliance_query is True
+            self.device.refresh_status(True)
+
+        # appliance query first, then the init query, then the status query.
+        assert sent[0].__class__.__name__ == "MessageQueryAppliance"
+        assert sent[1] is init_cmd
+        assert sent[2] is real_cmd
+
     def test_run_loop_reconnects_when_no_protocol_is_supported(self) -> None:
         """NoSupportedProtocol must drop the socket, like every other error here.
 

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -311,7 +311,9 @@ class TestMideaACDevice:
 
         self.device._used_subprotocol = False
         queries = self.device.build_query()
-        assert len(queries) == 11
+        # Capability queries are no longer part of the recurring status cycle;
+        # they are returned by build_init_query() instead.
+        assert len(queries) == 9
         assert isinstance(queries[0], MessageQuery)
         assert isinstance(queries[1], NewProtocolQuery)
         assert isinstance(queries[2], NewProtocolSelfCleanQuery)
@@ -321,8 +323,39 @@ class TestMideaACDevice:
         assert isinstance(queries[6], GroupOneQuery)
         assert isinstance(queries[7], GroupTwoQuery)
         assert isinstance(queries[8], GroupSevenQuery)
-        assert isinstance(queries[9], CapabilitiesQuery)
-        assert isinstance(queries[10], CapabilitiesAdditionalQuery)
+        assert not any(
+            isinstance(q, CapabilitiesQuery | CapabilitiesAdditionalQuery)
+            for q in queries
+        )
+
+    def test_build_init_query_capability_lifecycle(self) -> None:
+        """Test build_init_query arms/clears the one-shot B5 capability probes."""
+        self.device._used_subprotocol = False
+        # Basic query is armed at construction; additional is not yet.
+        assert self.device._capability_query is True
+        assert self.device._capability_addition_query is False
+        init = self.device.build_init_query()
+        assert len(init) == 1
+        assert isinstance(init[0], CapabilitiesQuery)
+        assert not isinstance(init[0], CapabilitiesAdditionalQuery)
+
+        # After the basic reply advertises a second frame, only the additional
+        # query is due.
+        self.device._capability_query = False
+        self.device._capability_addition_query = True
+        init = self.device.build_init_query()
+        assert len(init) == 1
+        assert isinstance(init[0], CapabilitiesAdditionalQuery)
+
+        # Once both are resolved, no capability query is sent.
+        self.device._capability_addition_query = False
+        assert self.device.build_init_query() == []
+
+        # Subprotocol (BB) devices never use B5 capability probes.
+        self.device._used_subprotocol = True
+        self.device._capability_query = True
+        self.device._capability_addition_query = True
+        assert self.device.build_init_query() == []
 
     def test_build_query_omits_rate_select_until_capability_confirmed(self) -> None:
         """Test rate_select stays out of the B1 query until b5_electricity confirms it.
@@ -549,6 +582,126 @@ class TestMideaACDevice:
             "eco": True,
             "anion": True,
         }
+
+    def test_b5_response_publishes_capabilities_in_status(self) -> None:
+        """Test the merged capabilities dict is pushed through update_all.
+
+        The HA integration reads ``device.capabilities`` on each status update,
+        so process_message must surface the decoded dict rather than only
+        caching it internally.
+        """
+        body = bytearray([0xB5, 0x02])
+        body += bytearray([0x14, 0x02, 0x01, 7])  # b5_mode
+        body += bytearray([0x12, 0x02, 0x01, 1])  # b5_eco
+
+        # process_message's return value is what parse_message forwards verbatim
+        # to update_all(), so the dict here is what listeners receive.
+        status = self.device.process_message(self._response(body))
+
+        assert "capabilities" in status
+        assert status["capabilities"]["heat_mode"] is True
+        assert status["capabilities"] == self.device.capabilities
+        # It is a copy, not the internal dict, so listeners cannot corrupt it.
+        assert status["capabilities"] is not self.device.capabilities
+
+    def test_non_b5_response_omits_capabilities_from_status(self) -> None:
+        """Test non-capability responses do not carry a capabilities key."""
+        # A plain C0 state body has no capabilities.
+        body = bytearray([0xC0]) + bytearray(20)
+        status = self.device.process_message(self._response(body))
+
+        assert "capabilities" not in status
+
+    def test_reset_init_query_re_arms_capability_probes(self) -> None:
+        """Test close_socket re-arms the B5 probes like the appliance query.
+
+        A reconnected device must re-probe capabilities from scratch instead of
+        reusing the previous result.
+        """
+        basic = bytearray.fromhex(
+            "aa3dac00000000000803b50a1202010114020101150201001e020101170201021a"
+            "02010110020101250207203c203c203c00240201014800010101199831",
+        )
+        additional = bytearray.fromhex(
+            "aa2fac00000000000803b5081f0201002c020101160201043900010151000101e3"
+            "00010113020101cd000103001a6910",
+        )
+        self.device.process_message(bytes(basic))
+        self.device.process_message(bytes(additional))
+        # Snapshot into locals: mypy narrows an asserted attribute to a literal
+        # and can't see the opaque reset_init_query() below flips it back, so a
+        # direct `is True`/`is False` pair would be reported unreachable.
+        probed = (
+            self.device._capability_query,
+            self.device._support_capability,
+            self.device._support_capability_addition,
+        )
+        assert probed == (False, True, True)
+
+        # A socket close re-arms the basic probe (additional stays disarmed until
+        # a fresh basic frame advertises it again).
+        self.device.reset_init_query()
+        rearmed = (
+            self.device._capability_query,
+            self.device._capability_addition_query,
+            self.device._support_capability,
+            self.device._support_capability_addition,
+        )
+        assert rearmed == (True, False, False, False)
+        assert [type(q) for q in self.device.build_init_query()] == [CapabilitiesQuery]
+
+    def test_capability_query_lifecycle_stops_after_both_frames(self) -> None:
+        """Test the two B5 probes run once then stop, merging both frames.
+
+        The basic frame advertises a second frame, which arms the additional
+        query; once the additional frame is parsed, both flags are cleared so no
+        capability query is ever sent again.
+        """
+        basic = bytearray.fromhex(
+            "aa3dac00000000000803b50a1202010114020101150201001e020101170201021a"
+            "02010110020101250207203c203c203c00240201014800010101199831",
+        )
+        additional = bytearray.fromhex(
+            "aa2fac00000000000803b5081f0201002c020101160201043900010151000101e3"
+            "00010113020101cd000103001a6910",
+        )
+
+        # Initial state: only the basic probe is armed. Snapshot into a local so
+        # mypy's warn_unreachable does not treat the later contradicting asserts
+        # (after the opaque process_message calls) as unreachable.
+        initial = (
+            self.device._capability_query,
+            self.device._capability_addition_query,
+            self.device._support_capability,
+            self.device._support_capability_addition,
+        )
+        assert initial == (True, False, False, False)
+        assert [type(q) for q in self.device.build_init_query()] == [CapabilitiesQuery]
+
+        # Basic frame: records support, clears the basic probe, arms additional.
+        self.device.process_message(bytes(basic))
+        after_basic = (
+            self.device._support_capability,
+            self.device._capability_query,
+            self.device._capability_addition_query,
+        )
+        assert after_basic == (True, False, True)
+        assert [type(q) for q in self.device.build_init_query()] == [
+            CapabilitiesAdditionalQuery,
+        ]
+
+        # Additional frame: records support and clears the additional probe.
+        self.device.process_message(bytes(additional))
+        after_additional = (
+            self.device._support_capability_addition,
+            self.device._capability_addition_query,
+        )
+        assert after_additional == (True, False)
+        assert self.device.build_init_query() == []
+
+        # Both frames merged into a single capability dict.
+        assert self.device.capabilities["rate_select"] is True
+        assert self.device.capabilities["cool_mode"] is True
 
     def test_process_message(self) -> None:
         """Test process message."""

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -1012,6 +1012,30 @@ class TestMessageACResponse:
             "display_control": True,
         }
 
+    def test_message_query_b5_detects_additional_capabilities(self) -> None:
+        """Test the basic B5 frame's trailing flag arms the additional query.
+
+        These are full frames captured from a PortaSplit AC. The basic frame
+        ends in a non-zero flag (device has a second frame); the additional
+        frame ends in a zero flag (no more frames).
+        """
+        basic = bytearray.fromhex(
+            "aa3dac00000000000803b50a1202010114020101150201001e020101170201021a"
+            "02010110020101250207203c203c203c00240201014800010101199831",
+        )
+        additional = bytearray.fromhex(
+            "aa2fac00000000000803b5081f0201002c020101160201043900010151000101e3"
+            "00010113020101cd000103001a6910",
+        )
+
+        basic_response = MessageACResponse(basic)
+        assert hasattr(basic_response, "additional_capabilities")
+        assert basic_response.additional_capabilities is True
+
+        additional_response = MessageACResponse(additional)
+        assert hasattr(additional_response, "additional_capabilities")
+        assert additional_response.additional_capabilities is False
+
     @pytest.mark.parametrize(
         ("raw_value", "expected"),
         [(4, True), (1, True), (0, False)],


### PR DESCRIPTION
## Summary

Reworks how the 0xAC device handles the two B5 capability queries
(`CapabilitiesQuery` / `CapabilitiesAdditionalQuery`) so they behave like the
one-shot appliance query instead of being re-sent on every status refresh, and
surfaces the decoded capability flags to the Home Assistant integration.

The queries now run in strict dependency order — **appliance query →
capability query → additional capability query → recurring status queries** —
with each stage built only *after* the previous stage's reply is parsed, so
every stage sees the state that reply produced.

## What changed

**Query lifecycle (one-shot, built in dependency order)**
- New generic hooks on `MideaDevice`: `build_init_query()` (default `[]`) and
  `reset_init_query()` (default no-op).
- `refresh_status()` no longer builds the whole command list up front. It builds
  each stage lazily, one reply at a time, via `_advance_query_stage()`:
  1. the appliance query (reports the message protocol version),
  2. the one-shot init/capability probes — built only once the appliance reply
     has set the protocol version they depend on,
  3. the recurring `build_query()` status queries — built only once the
     capability replies have populated `_capabilities` they depend on.

  This fixes an ordering bug: previously the send order was right, but each
  command's constructor captured **stale** state (capability probes built with
  the pre-appliance-reply protocol version; status queries built with the
  pre-capability-reply `_capabilities`). In the checked (connect) pass each
  stage is appended right after its predecessor's reply so it is validated in
  the same pass; in the unchecked periodic refresh every still-armed stage is
  built back to back.
- AC arms the basic B5 probe at construction. The additional probe is armed
  **only** after the basic frame advertises a second frame. Each probe clears
  its own flag once its reply is parsed, so a fully-probed device sends neither
  again. A probe that times out is recorded in `_unsupported_protocol` and
  skipped from then on. BB subprotocol devices never send B5 probes.

**Additional-frame detection (reuses `parse()`)**
- `NewProtocolMessageBody.parse()` now records where it stopped in
  `_params_end_pos`, so `CapabilityBody` reads the trailing additional-capability
  flag without re-walking the parameter list. The flag sits at `remaining[-3]`
  (`[flag, message_id, crc]`) — midea-lan echoes a `message_id` byte that
  msmart-ng's payload does not, so this differs from msmart-ng's `remaining[-2]`.
  Verified against real captured PortaSplit frames.

**Re-probe on reconnect**
- `close_socket()` calls `reset_init_query()` alongside the `_appliance_query`
  re-arm, so a reconnected device re-probes capabilities from scratch rather
  than reusing the previous result. Accumulated `_capabilities` are kept in
  place so the integration keeps the last-known set until the re-probe
  overwrites it.

**Publish capabilities to consumers**
- `_capabilities` value type widened to `dict[str, bool | int]` (e.g.
  rate_select level count).
- `_update_capabilities()` returns the merged dict, which `process_message()`
  merges into the status; `parse_message()` forwards it verbatim to
  `update_all()`. The HA integration (which reads `device.capabilities` on each
  update) is now notified as frames arrive instead of holding the empty
  init-time dict. A copy is published so listeners cannot mutate the cache.

## Testing

- `uv run python -m pytest ./tests/` — 1862 passed
- `uv run prek run --all-files` — all hooks pass (ruff, mypy, pylint, commitlint)
- New code is 100% covered; `device.py` and `message.py` report 100%, and every
  added line/branch in the AC modules is exercised. Remaining partial branches
  in the AC files are pre-existing fresh-air / BB-subprotocol code untouched by
  this PR.

New tests cover: additional-flag detection (message level), the full
basic→additional→stop lifecycle, re-arm on reconnect, capabilities published
through the status update, non-B5 responses omitting the key, appliance→init→
status query ordering, follow-up init queries spliced into and blacklisted
within the checked pass, and skipped/unsupported stages still advancing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering and reporting additional air-conditioner capabilities.
  * Capability information is now included in device status updates, including numeric settings where applicable.
* **Bug Fixes**
  * Improved device status refresh sequencing for more reliable initialization and follow-up queries.
  * Prevented unsupported or timed-out queries from being repeatedly retried.
  * Improved handling of capability responses and trailing response data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->