### PR TITLE
fix(ac): remove error_code_query from default list

### DIFF
--- a/midealan/device.py
+++ b/midealan/device.py
@@ -666,9 +666,9 @@ class MideaDevice(threading.Thread):
                             cont = self.pre_process_message(decrypted)
                         if cont:
                             _LOGGER.debug(
-                                "[%s] process message %s for device %s, \
-                                model %s, subtype %s, \
-                                device protocol %s, message procol %s",
+                                "[%s] process message %s for device %s,"
+                                "model %s, subtype %s, "
+                                "device protocol %s, message protocol %s",
                                 self._device_id,
                                 decrypted.hex(),
                                 self._device_name,
@@ -687,9 +687,9 @@ class MideaDevice(threading.Thread):
                                 )
                     except Exception:
                         _LOGGER.exception(
-                            "[%s] Error in process message %s, \
-                                model %s, subtype %s, \
-                                device protocol %s, message procol %s",
+                            "[%s] Error in process message %s, "
+                            "model %s, subtype %s, "
+                            "device protocol %s, message protocol %s",
                             self._device_id,
                             decrypted.hex(),
                             self._model,

--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -465,9 +465,9 @@ class NewProtocolQuery(MessageACBase):
         NewProtocolTags.fresh_air_2,
         NewProtocolTags.wind_lr_angle,
         NewProtocolTags.wind_ud_angle,
-        NewProtocolTags.out_silent,
-        NewProtocolTags.buzzer_all,
-        NewProtocolTags.error_code_query,
+        # NewProtocolTags.out_silent,
+        # NewProtocolTags.buzzer_all,
+        # NewProtocolTags.error_code_query,
     )
 
     def __init__(

--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -465,8 +465,8 @@ class NewProtocolQuery(MessageACBase):
         NewProtocolTags.fresh_air_2,
         NewProtocolTags.wind_lr_angle,
         NewProtocolTags.wind_ud_angle,
-        # NewProtocolTags.out_silent,
-        # NewProtocolTags.buzzer_all,
+        NewProtocolTags.out_silent,
+        NewProtocolTags.buzzer_all,
         # NewProtocolTags.error_code_query,
     )
 

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -270,7 +270,7 @@ class TestNewProtocolQuery:
         expected_body = bytearray(
             [
                 0xB1,
-                0x0B,
+                0x0A,  # params count
                 NewProtocolTags.indirect_wind & 0xFF,
                 NewProtocolTags.indirect_wind >> 8,
                 NewProtocolTags.breezeless & 0xFF,
@@ -291,8 +291,8 @@ class TestNewProtocolQuery:
                 NewProtocolTags.out_silent >> 8,
                 NewProtocolTags.buzzer_all & 0xFF,
                 NewProtocolTags.buzzer_all >> 8,
-                NewProtocolTags.error_code_query & 0xFF,
-                NewProtocolTags.error_code_query >> 8,
+                # NewProtocolTags.error_code_query & 0xFF,
+                # NewProtocolTags.error_code_query >> 8,
             ],
         )
 
@@ -309,7 +309,7 @@ class TestNewProtocolQuery:
         expected_body = bytearray(
             [
                 0xB1,
-                0x0C,
+                0x0B,  # params count
                 NewProtocolTags.indirect_wind & 0xFF,
                 NewProtocolTags.indirect_wind >> 8,
                 NewProtocolTags.breezeless & 0xFF,
@@ -330,8 +330,8 @@ class TestNewProtocolQuery:
                 NewProtocolTags.out_silent >> 8,
                 NewProtocolTags.buzzer_all & 0xFF,
                 NewProtocolTags.buzzer_all >> 8,
-                NewProtocolTags.error_code_query & 0xFF,
-                NewProtocolTags.error_code_query >> 8,
+                # NewProtocolTags.error_code_query & 0xFF,
+                # NewProtocolTags.error_code_query >> 8,
                 NewProtocolTags.rate_select & 0xFF,
                 NewProtocolTags.rate_select >> 8,
             ],


### PR DESCRIPTION
1. confirmed with 3 0xAC devices, if `error_code_query` add to query list, `NewProtocolQuery` will add to `unsupported_protocol: ['CapabilitiesQuery', 'NewProtocolQuery']`
2. removed `error_code_query`, it works well

we should remove it and consider to add it via device/message `_capabilities` in future release

as this feature original add via @tilalx , we can try to confirm the future solution with query params.
anyway, to prevent bug at first, we can temp disable it before got a good solution.
as I don't have a device to test it, so I can't confirm the finally solution now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated device message processing logs for clearer protocol-related status and error messages.
  * New-protocol B1 queries no longer request the error code field, improving compatibility with supported devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->