### PR TITLE
fix(ac): correct rate_select gears and set path for reported levels

### DIFF
--- a/midealan/devices/ac/__init__.py
+++ b/midealan/devices/ac/__init__.py
@@ -231,7 +231,7 @@ class MideaACDevice(MideaDevice):
 
     _rate_select_level2: ClassVar[dict[int, str]] = {
         50: "50",
-        70: "70",
+        75: "75",
         100: "100",
     }
 
@@ -382,15 +382,24 @@ class MideaACDevice(MideaDevice):
         """Midea AC device wind_ud_angle."""
         return list(MideaACDevice._wind_ud_angles.values())
 
+    def _rate_select_map(self) -> dict[int, str]:
+        """Return the rate_select value map for the device-reported level count.
+
+        The B5 b5_electricity capability reports a rate level count: 1 selects
+        the 2-gear map (50/75/100), 2 or 3 select the 5-gear map. Anything else
+        (including 0/unsupported) yields an empty map so no options are offered.
+        """
+        _levels: int = self._capabilities.get("rate_select", 0)
+        if _levels in (2, 3):
+            return MideaACDevice._rate_select_level5
+        if _levels == 1:
+            return MideaACDevice._rate_select_level2
+        return {}
+
     @property
     def rate_selects(self) -> list[str]:
         """Midea AC device rate_select options."""
-        _levels: int = self._capabilities.get("rate_select", 0)
-        if _levels in (2, 3):
-            return list(MideaACDevice._rate_select_level5.values())
-        if _levels == 1:
-            return list(MideaACDevice._rate_select_level2.values())
-        return []
+        return list(self._rate_select_map().values())
 
     def build_query(self) -> list[ACQuery]:
         """Midea AC device build query."""
@@ -540,15 +549,7 @@ class MideaACDevice(MideaDevice):
                     self._attributes[attr] = MideaACDevice._wind_ud_angles.get(value)
                 # rate_select
                 elif attr == DeviceAttributes.rate_select:
-                    _levels: int = self._capabilities.get("rate_select", 0)
-                    if _levels in (2, 3):
-                        self._attributes[attr] = MideaACDevice._rate_select_level5.get(
-                            value,
-                        )
-                    if _levels == 1:
-                        self._attributes[attr] = MideaACDevice._rate_select_level2.get(
-                            value,
-                        )
+                    self._attributes[attr] = self._rate_select_map().get(value)
                 else:
                     self._attributes[attr] = value
                 new_status[str(attr)] = self._attributes[attr]
@@ -799,9 +800,10 @@ class MideaACDevice(MideaDevice):
                 setattr(message, str(self._fresh_air_version), fresh_air)
         # rate_select
         elif attr == DeviceAttributes.rate_select:
-            message.rate_select = MideaACDevice.get_dict_key_by_value(
-                "_rate_selects",
-                str(value),
+            rate_map = self._rate_select_map()
+            message.rate_select = next(
+                (key for key, val in rate_map.items() if val == str(value)),
+                None,
             )
         # indirect_wind, screen_display_alternate, breezeless
         else:

--- a/midealan/devices/ac/__init__.py
+++ b/midealan/devices/ac/__init__.py
@@ -220,12 +220,18 @@ class MideaACDevice(MideaDevice):
         100: "down",
     }
 
-    _rate_selects: ClassVar[dict[int, str]] = {
+    _rate_select_level5: ClassVar[dict[int, str]] = {
         1: "1",
         20: "20",
         40: "40",
         60: "60",
         80: "80",
+        100: "100",
+    }
+
+    _rate_select_level2: ClassVar[dict[int, str]] = {
+        50: "50",
+        70: "70",
         100: "100",
     }
 
@@ -379,7 +385,12 @@ class MideaACDevice(MideaDevice):
     @property
     def rate_selects(self) -> list[str]:
         """Midea AC device rate_select options."""
-        return list(MideaACDevice._rate_selects.values())
+        _levels: int = self._capabilities.get("rate_select", 0)
+        if _levels in (2, 3):
+            return list(MideaACDevice._rate_select_level5.values())
+        if _levels == 1:
+            return list(MideaACDevice._rate_select_level2.values())
+        return []
 
     def build_query(self) -> list[ACQuery]:
         """Midea AC device build query."""
@@ -527,8 +538,17 @@ class MideaACDevice(MideaDevice):
                 # wind_ud_angle
                 elif attr == DeviceAttributes.wind_ud_angle:
                     self._attributes[attr] = MideaACDevice._wind_ud_angles.get(value)
+                # rate_select
                 elif attr == DeviceAttributes.rate_select:
-                    self._attributes[attr] = MideaACDevice._rate_selects.get(value)
+                    _levels: int = self._capabilities.get("rate_select", 0)
+                    if _levels in (2, 3):
+                        self._attributes[attr] = MideaACDevice._rate_select_level5.get(
+                            value,
+                        )
+                    if _levels == 1:
+                        self._attributes[attr] = MideaACDevice._rate_select_level2.get(
+                            value,
+                        )
                 else:
                     self._attributes[attr] = value
                 new_status[str(attr)] = self._attributes[attr]

--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -116,7 +116,6 @@ B5_ECO_VALUES = frozenset({1, 2})
 B5_ANION_ON_VALUE = 1
 B5_TURBO_HEAT_VALUES = frozenset({1, 3})
 B5_DISPLAY_VALUES = frozenset({1, 2, 100})
-B5_ELECTRICITY_UNSUPPORTED_VALUE = 0  # 0 = unsupported; nonzero = rate level count
 
 # A B5 capability body ends with a trailing [flag, message_id, crc] block. The
 # device sets the flag byte non-zero to signal that a second (additional)
@@ -189,7 +188,7 @@ class NewProtocolTags(IntEnum):
     arom = 0x0069
     # AC outdoor silent mode (PortaSplit)
     out_silent = 0x00CD
-    ieco_switch = 0x00E3
+    ieco = 0x00E3
     pre_cool_hot = 0x0201
     pm25_value = 0x020B
     b5_wind_speed = 0x0210
@@ -1291,7 +1290,7 @@ class CapabilityBody(NewProtocolMessageBody):
             caps["display_control"] = value in B5_DISPLAY_VALUES
         if NewProtocolTags.b5_electricity in params:
             value = params[NewProtocolTags.b5_electricity][0]
-            caps["rate_select"] = value > B5_ELECTRICITY_UNSUPPORTED_VALUE
+            caps["rate_select"] = value
         self.capabilities = caps
 
 

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -195,9 +195,22 @@ class TestMideaACDevice:
             message = mock_build_send.call_args[0][0]
             assert message.wind_ud_angle == 1
 
+            # 5-level device: "40" maps back to raw value 40
+            self.device._capabilities["rate_select"] = 2
             self.device.set_attribute(DeviceAttributes.rate_select.value, "40")
             message = mock_build_send.call_args[0][0]
             assert message.rate_select == 40
+
+            # 2-level device: only 50/75/100 are valid gears
+            self.device._capabilities["rate_select"] = 1
+            self.device.set_attribute(DeviceAttributes.rate_select.value, "75")
+            message = mock_build_send.call_args[0][0]
+            assert message.rate_select == 75
+
+            # Value not in the active level map resolves to None
+            self.device.set_attribute(DeviceAttributes.rate_select.value, "40")
+            message = mock_build_send.call_args[0][0]
+            assert message.rate_select is None
 
     def test_set_attribute_fresh_air_mode_named_speed(self) -> None:
         """Test set attribute for fresh air mode with a named fan speed."""
@@ -562,7 +575,50 @@ class TestMideaACDevice:
             "down-mid",
             "down",
         ]
+        # No rate_select capability reported yet: no options offered
+        assert self.device.rate_selects == []
+
+        # 2-level device (b5_electricity value 1) reports 50/75/100 gears
+        self.device._capabilities["rate_select"] = 1
+        assert self.device.rate_selects == ["50", "75", "100"]
+
+        # 5-level device (b5_electricity value 2 or 3) reports the full ladder
+        self.device._capabilities["rate_select"] = 2
         assert self.device.rate_selects == ["1", "20", "40", "60", "80", "100"]
+        self.device._capabilities["rate_select"] = 3
+        assert self.device.rate_selects == ["1", "20", "40", "60", "80", "100"]
+
+    def test_process_message_decodes_rate_select_per_level(self) -> None:
+        """Test an incoming rate_select value decodes via the reported gear map.
+
+        Regression for the "stays unknown" symptom: the raw value must be
+        mapped through the level-specific gear map instead of a fixed table.
+        """
+        with patch("midealan.devices.ac.MessageACResponse") as mock_message_response:
+            mock_message = mock_message_response.return_value
+            mock_message.used_subprotocol = False
+            mock_message.fresh_air_power = False
+            mock_message.rate_select = 75
+
+            # 2-level device: raw 75 -> gear "75" (the value from issue #980)
+            self.device._capabilities["rate_select"] = 1
+            result = self.device.process_message(b"")
+            assert result[DeviceAttributes.rate_select.value] == "75"
+
+            # 5-level device: 75 is not a valid gear, so it decodes to None
+            self.device._capabilities["rate_select"] = 2
+            result = self.device.process_message(b"")
+            assert result[DeviceAttributes.rate_select.value] is None
+
+            # 5-level device: raw 40 -> gear "40"
+            mock_message.rate_select = 40
+            result = self.device.process_message(b"")
+            assert result[DeviceAttributes.rate_select.value] == "40"
+
+            # No capability reported: no gear map, decodes to None
+            self.device._capabilities["rate_select"] = 0
+            result = self.device.process_message(b"")
+            assert result[DeviceAttributes.rate_select.value] is None
 
     def test_capabilities_property_updates_from_b5_response(self) -> None:
         """Test B5 capability flags accumulate into the capabilities property."""
@@ -699,8 +755,9 @@ class TestMideaACDevice:
         assert after_additional == (True, False)
         assert self.device.build_init_query() == []
 
-        # Both frames merged into a single capability dict.
-        assert self.device.capabilities["rate_select"] is True
+        # Both frames merged into a single capability dict. rate_select carries
+        # the raw B5 b5_electricity level count (4 in this frame), not a bool.
+        assert self.device.capabilities["rate_select"] == 4
         assert self.device.capabilities["cool_mode"] is True
 
     def test_process_message(self) -> None:

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -1036,19 +1036,17 @@ class TestMessageACResponse:
         assert hasattr(additional_response, "additional_capabilities")
         assert additional_response.additional_capabilities is False
 
-    @pytest.mark.parametrize(
-        ("raw_value", "expected"),
-        [(4, True), (1, True), (0, False)],
-    )
-    def test_message_query_b5_electricity_gates_rate_select(
+    @pytest.mark.parametrize("raw_value", [4, 3, 2, 1, 0])
+    def test_message_query_b5_electricity_reports_rate_level_count(
         self,
         raw_value: int,
-        expected: bool,
     ) -> None:
-        """Test b5_electricity capability gates the rate_select capability flag.
+        """Test b5_electricity capability exposes the raw rate level count.
 
-        A nonzero value (rate level count) means the device supports
-        rate_select; 0 means unsupported.
+        The B5 b5_electricity byte is a rate level count, not a boolean:
+        1 selects the 2-gear map, 2/3 select the 5-gear map, 0 means
+        unsupported. The parser stores the raw value so the device layer can
+        pick the right gear map.
         """
         self.header[9] = 0x03
         body = bytearray([0xB5, 0x01])  # Body type, params count
@@ -1058,7 +1056,7 @@ class TestMessageACResponse:
         response = MessageACResponse(self.header + body)
 
         assert hasattr(response, "capabilities")
-        assert response.capabilities == {"rate_select": expected}
+        assert response.capabilities == {"rate_select": raw_value}
 
     def test_message_query_b5_custom_fan_supports_named_speeds(self) -> None:
         """Test B5 fan custom profile includes named fan speeds."""


### PR DESCRIPTION
## Summary

Fixes the Power Rate Limit (`rate_select`) behavior reported in wuwentao/midea_ac_lan#980, where the select offered a generic `1-100` list that did not match the device-reported gears and the state stayed `unknown`.

The B5 `b5_electricity` capability byte is a rate **level count**, not a boolean. This PR derives the gear options from that count, matching msmart-ng:

- level count `1` -> 2-gear map `50 / 75 / 100`
- level count `2` or `3` -> 5-gear map `1 / 20 / 40 / 60 / 80 / 100`
- `0` / unsupported -> no options

### Fixes in this PR

- **Wrong 2-level gear value**: was `50 / 70 / 100`; corrected to `50 / 75 / 100` (msmart-ng `GEAR_75 = 75`, and issue #980 expects `100/75/50`).
- **Broken set path**: `set_attribute` still referenced the removed `_rate_selects` dict, which made `get_dict_key_by_value` raise `ValueError` whenever a rate_select was set. Replaced with a lookup against the active level map.
- **De-duplication**: level -> gear-map selection is centralized in a single `_rate_select_map()` helper reused by the options property, the decode path, and the set path.

## Testing

- `uv run python -m pytest ./tests/` — 1916 passed
- Statement coverage on `midealan/devices/ac/__init__.py` and `message.py`: 100% (0 missed statements); added tests exercise both gear maps, the raw B5 level count, and the decode/set paths for the "stays unknown" symptom.
- `uv run ruff check`, `ruff format --check`, `mypy midealan`, `pylint` — all clean (pylint 10.00/10).

Reference: msmart-ng `command.py` rate select capability parsing (`rate_select_2_level` = value 1, `rate_select_5_level` = any of 2/3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for air conditioners with different fan-speed levels, including two-level and five-level devices.
  * Fan-speed options now accurately reflect the device’s reported capabilities.
  * Improved handling of incoming and outgoing fan-speed selections.

* **Bug Fixes**
  * Corrected fan-speed decoding and command mapping for devices with varying capability levels.
  * Preserved the reported capability level information for more accurate device behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->