### PR TITLE
refactor(ac): merge NewProtocolQuery and add customize capabilities override

### DIFF
--- a/midealan/devices/ac/__init__.py
+++ b/midealan/devices/ac/__init__.py
@@ -24,7 +24,6 @@ from .message import (
     MessageSet,
     MessageSubProtocolSet,
     NewProtocolQuery,
-    NewProtocolSelfCleanQuery,
     NewProtocolSet,
     PowerQuery,
     SubProtocolFreshAirSet,
@@ -330,6 +329,10 @@ class MideaACDevice(MideaDevice):
         # decoded B5 capability flags (accumulated across B5 frames). Values are
         # mostly booleans, but some (e.g. rate_select level count) are ints.
         self._capabilities: dict[str, bool | int] = {}
+        # user-provided capability overrides from customize. Merged over the
+        # B5-parsed values (see the capabilities property), so a user can force
+        # a feature the B5 query missed, or disable one it reported in error.
+        self._customize_capabilities: dict[str, bool | int] = {}
         # B5 capability query control. Both queries run once, like the appliance
         # query: on success the flag is cleared so it is never re-sent (the reply
         # never changes); on timeout the device layer records it in
@@ -389,7 +392,7 @@ class MideaACDevice(MideaDevice):
         the 2-gear map (50/75/100), 2 or 3 select the 5-gear map. Anything else
         (including 0/unsupported) yields an empty map so no options are offered.
         """
-        _levels: int = self._capabilities.get("rate_select", 0)
+        _levels: int = self.capabilities.get("rate_select", 0)
         if _levels in (2, 3):
             return MideaACDevice._rate_select_level5
         if _levels == 1:
@@ -414,15 +417,15 @@ class MideaACDevice(MideaDevice):
             ]
         queries: list[ACQuery] = [
             MessageQuery(self._message_protocol_version),
+            # Single new-protocol query. Optional feature tags (self_clean,
+            # rate_select, ...) are appended by NewProtocolQuery only when the
+            # merged capabilities map (B5-parsed values overlaid with customize
+            # overrides) marks them supported, so an unsupported tag can't make
+            # the device return an empty list that suppresses the other tags.
             NewProtocolQuery(
                 self._message_protocol_version,
-                supports_rate_select=bool(
-                    self._capabilities.get("rate_select", False),
-                ),
+                capabilities=self.capabilities,
             ),
-            # Queried on its own so an empty response for the combined
-            # new-protocol query does not suppress the self-clean state.
-            NewProtocolSelfCleanQuery(self._message_protocol_version),
             PowerQuery(self._message_protocol_version),
             HumidityQuery(self._message_protocol_version),
             GroupZeroQuery(self._message_protocol_version),
@@ -666,13 +669,19 @@ class MideaACDevice(MideaDevice):
             self._capability_addition_query,
             self._capabilities,
         )
-        # Publish a copy so downstream mutation can't corrupt the cached dict.
-        return {"capabilities": dict(self._capabilities)}
+        # Publish the effective (merged) map so downstream consumers see the
+        # customize overrides too; it is already a fresh dict per access.
+        return {"capabilities": self.capabilities}
 
     @property
     def capabilities(self) -> dict[str, bool | int]:
-        """Return the decoded B5 capability flags reported by the device."""
-        return self._capabilities
+        """Return the effective capability flags for the device.
+
+        This is the B5-parsed capability map overlaid with the user's customize
+        overrides, so a customize entry wins over whatever the device reported
+        (or failed to report).
+        """
+        return {**self._capabilities, **self._customize_capabilities}
 
     def _b5_temperature_limits(self) -> tuple[float, float] | None:
         """Return the B5 setpoint limits for the current mode, if any.
@@ -1056,6 +1065,7 @@ class MideaACDevice(MideaDevice):
         self._power_analysis_method = self._default_power_analysis_method
         self._customize_min_temperature = None
         self._customize_max_temperature = None
+        self._customize_capabilities = {}
         if customize and len(customize) > 0:
             try:
                 params = json.loads(customize)
@@ -1067,6 +1077,11 @@ class MideaACDevice(MideaDevice):
                     self._customize_min_temperature = params.get("min_temperature")
                 if params and "max_temperature" in params:
                     self._customize_max_temperature = params.get("max_temperature")
+                # Capability overrides let a user force a feature the B5 query
+                # missed (or disable one it wrongly reported). Values follow the
+                # capabilities map: truthy enables the tag, falsy disables it.
+                if params and isinstance(params.get("capabilities"), dict):
+                    self._customize_capabilities = params["capabilities"]
             except Exception:
                 _LOGGER.exception("[%s] Set customize error", self.device_id)
             self.update_all({"temperature_step": self._temperature_step})

--- a/midealan/devices/ac/__init__.py
+++ b/midealan/devices/ac/__init__.py
@@ -1086,6 +1086,9 @@ class MideaACDevice(MideaDevice):
                 _LOGGER.exception("[%s] Set customize error", self.device_id)
             self.update_all({"temperature_step": self._temperature_step})
             self.update_all(self._refresh_temperature_limits())
+        # Publish the merged capabilities map so downstream consumers (e.g., Home
+        # Assistant) are notified whenever customize overrides change it.
+        self.update_all({"capabilities": self.capabilities})
 
 
 class MideaAppliance(MideaACDevice):

--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -453,9 +453,19 @@ class ToggleDisplay(MessageACBase):
 
 
 class NewProtocolQuery(MessageACBase):
-    """AC message new protocol query."""
+    """AC message new protocol query.
 
-    _query_params: tuple[int, ...] = (
+    A single B1 query carries a list of new-protocol tags. The device answers
+    with an empty parameter list when a request carries a tag it does not
+    support, which suppresses every other tag in the same request. The base
+    list therefore holds only tags every new-protocol device is known to
+    answer, while feature tags that some devices reject (self_clean,
+    rate_select, ...) are appended only when the device has advertised support
+    for them via the merged capabilities map (B5 capabilities overlaid with the
+    user's customize overrides).
+    """
+
+    _default_query_params: tuple[int, ...] = (
         NewProtocolTags.indirect_wind,
         NewProtocolTags.breezeless,
         NewProtocolTags.indoor_humidity,
@@ -469,48 +479,48 @@ class NewProtocolQuery(MessageACBase):
         # NewProtocolTags.error_code_query,
     )
 
+    # Optional tags appended only when the matching capability key is truthy.
+    # Keyed by the capability-dict key so a B5 report or a customize override
+    # can gate each one. Ordered so the produced body is deterministic.
+    _optional_query_params: tuple[tuple[str, int], ...] = (
+        ("rate_select", NewProtocolTags.rate_select),
+        ("self_clean", NewProtocolTags.self_clean),
+    )
+
     def __init__(
         self,
         protocol_version: int,
         *,
-        supports_rate_select: bool = False,
+        capabilities: dict[str, bool | int] | None = None,
     ) -> None:
         """Initialize AC message new protocol query.
 
-        `supports_rate_select` gates the rate_select (0x0048) query param on
-        the device having advertised it via the B5 b5_electricity capability
-        (tag 0x0216). Devices that don't report it never answer the query, so
-        it's left out until support is confirmed.
+        `capabilities` is the device's merged capability map (B5-parsed values
+        overlaid with the user's customize overrides). Each optional tag in
+        `_optional_query_params` is appended only when its key is present and
+        truthy, so a device that never advertised a feature (or that a user
+        disabled via customize) is not asked for it.
         """
         super().__init__(
             protocol_version=protocol_version,
             message_type=MessageType.query,
             body_type=ListTypes.B1,
         )
-        self._supports_rate_select = supports_rate_select
+        self._capabilities = capabilities or {}
 
     @property
     def _body(self) -> bytearray:
-
-        params = list(self._query_params)
-        if self._supports_rate_select:
-            params.append(NewProtocolTags.rate_select)
+        params = list(self._default_query_params)
+        params.extend(
+            tag
+            for key, tag in self._optional_query_params
+            if self._capabilities.get(key)
+        )
 
         _body = bytearray([len(params)])
         for param in params:
             _body.extend([param & 0xFF, param >> 8])
         return _body
-
-
-class NewProtocolSelfCleanQuery(NewProtocolQuery):
-    """AC message new protocol self-clean query.
-
-    A device answers with an empty parameter list when a query carries a tag it
-    does not support, which suppresses every other tag in the same request. The
-    self-clean state is therefore asked for as an independent status group.
-    """
-
-    _query_params = (NewProtocolTags.self_clean,)
 
 
 class MessageSubProtocol(MessageACBase):
@@ -1291,6 +1301,10 @@ class CapabilityBody(NewProtocolMessageBody):
         if NewProtocolTags.b5_electricity in params:
             value = params[NewProtocolTags.b5_electricity][0]
             caps["rate_select"] = value
+        if NewProtocolTags.self_clean in params:
+            # In a B5 body this tag advertises self-clean support (the live
+            # state is only reported in B0/B1 bodies, see PropertiesBody).
+            caps["self_clean"] = params[NewProtocolTags.self_clean][0] > 0
         self.capabilities = caps
 
 

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -440,6 +440,48 @@ class TestMideaACDevice:
         assert merged["rate_select"] == 2  # customize wins over B5 value 1
         assert merged["self_clean"] is True  # customize wins over B5 value False
 
+    def test_customize_capabilities_publishes_event_on_enable(self) -> None:
+        """Test set_customize emits a capabilities event when enabling an override.
+
+        When set_customize applies a capability override, it must notify listeners
+        (e.g., Home Assistant) via update_all so they see the merged capabilities
+        immediately, not after the next B5 query (which is one-shot).
+        """
+        with patch.object(self.device, "update_all") as update_all_mock:
+            self.device.set_customize('{"capabilities": {"self_clean": true}}')
+            # Verify update_all was called with the merged capabilities dict
+            calls = [call.args[0] for call in update_all_mock.call_args_list]
+            # Should have at least one call with capabilities key
+            capabilities_updates = [c for c in calls if "capabilities" in c]
+            assert len(capabilities_updates) > 0
+            # The published capabilities should include the override
+            published_caps = capabilities_updates[-1]["capabilities"]
+            assert published_caps["self_clean"] is True
+
+    def test_customize_capabilities_publishes_event_on_clear(self) -> None:
+        """Test set_customize emits a capabilities event when clearing overrides.
+
+        When set_customize is called with no capabilities key (or empty customize),
+        it resets _customize_capabilities to {}. This must still publish the merged
+        capabilities so listeners know the overrides are gone and the effective map
+        has reverted to B5-only values.
+        """
+        # First set an override
+        self.device.set_customize('{"capabilities": {"rate_select": 3}}')
+        assert self.device._customize_capabilities == {"rate_select": 3}
+        # Now clear it by calling set_customize with no capabilities key
+        with patch.object(self.device, "update_all") as update_all_mock:
+            self.device.set_customize('{"temperature_step": 1}')
+            # Verify update_all was called with capabilities
+            calls = [call.args[0] for call in update_all_mock.call_args_list]
+            capabilities_updates = [c for c in calls if "capabilities" in c]
+            assert len(capabilities_updates) > 0
+            # The published capabilities should not have rate_select override
+            published_caps = capabilities_updates[-1]["capabilities"]
+            assert "rate_select" not in published_caps or not published_caps.get(
+                "rate_select",
+            )
+
     def test_bb_model_builds_distinct_queries_and_attributes(self) -> None:
         """Test verified BB model starts with independent BB queries."""
         device = self._make_device("23096633", 1)

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -424,6 +424,22 @@ class TestMideaACDevice:
         self.device.set_customize('{"capabilities": "self_clean"}')
         assert self.device._customize_capabilities == {}
 
+    def test_customize_capabilities_override_priority(self) -> None:
+        """Test customize override wins when both B5 and customize set the same key.
+
+        When _capabilities and _customize_capabilities both have a key, the
+        merged capabilities property must return the customize value (higher
+        priority), ensuring users can correct wrong B5 reports.
+        """
+        self.device._capabilities["rate_select"] = 1
+        self.device._capabilities["self_clean"] = False
+        self.device.set_customize(
+            '{"capabilities": {"rate_select": 2, "self_clean": true}}',
+        )
+        merged = self.device.capabilities
+        assert merged["rate_select"] == 2  # customize wins over B5 value 1
+        assert merged["self_clean"] is True  # customize wins over B5 value False
+
     def test_bb_model_builds_distinct_queries_and_attributes(self) -> None:
         """Test verified BB model starts with independent BB queries."""
         device = self._make_device("23096633", 1)

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -17,7 +17,6 @@ from midealan.devices.ac.message import (
     HumidityQuery,
     MessageQuery,
     NewProtocolQuery,
-    NewProtocolSelfCleanQuery,
     NewProtocolTags,
     PowerFormats,
     PowerQuery,
@@ -324,18 +323,18 @@ class TestMideaACDevice:
 
         self.device._used_subprotocol = False
         queries = self.device.build_query()
-        # Capability queries are no longer part of the recurring status cycle;
-        # they are returned by build_init_query() instead.
-        assert len(queries) == 9
+        # The new-protocol query and self-clean query are now a single merged
+        # NewProtocolQuery. Capability queries are no longer part of the
+        # recurring status cycle; they are returned by build_init_query().
+        assert len(queries) == 8
         assert isinstance(queries[0], MessageQuery)
         assert isinstance(queries[1], NewProtocolQuery)
-        assert isinstance(queries[2], NewProtocolSelfCleanQuery)
-        assert isinstance(queries[3], PowerQuery)
-        assert isinstance(queries[4], HumidityQuery)
-        assert isinstance(queries[5], GroupZeroQuery)
-        assert isinstance(queries[6], GroupOneQuery)
-        assert isinstance(queries[7], GroupTwoQuery)
-        assert isinstance(queries[8], GroupSevenQuery)
+        assert isinstance(queries[2], PowerQuery)
+        assert isinstance(queries[3], HumidityQuery)
+        assert isinstance(queries[4], GroupZeroQuery)
+        assert isinstance(queries[5], GroupOneQuery)
+        assert isinstance(queries[6], GroupTwoQuery)
+        assert isinstance(queries[7], GroupSevenQuery)
         assert not any(
             isinstance(q, CapabilitiesQuery | CapabilitiesAdditionalQuery)
             for q in queries
@@ -370,22 +369,60 @@ class TestMideaACDevice:
         self.device._capability_addition_query = True
         assert self.device.build_init_query() == []
 
-    def test_build_query_omits_rate_select_until_capability_confirmed(self) -> None:
-        """Test rate_select stays out of the B1 query until b5_electricity confirms it.
+    def test_build_query_omits_optional_tags_until_capability_confirmed(self) -> None:
+        """Test optional tags stay out of the B1 query until capabilities confirm them.
 
         Before any B5 capabilities response is seen, `_capabilities` is empty, so
-        the query built for the device must not ask for rate_select.
+        the query built for the device must not ask for rate_select or self_clean.
         """
         self.device._used_subprotocol = False
         assert self.device.capabilities == {}
         queries = self.device.build_query()
         new_protocol_query = next(q for q in queries if isinstance(q, NewProtocolQuery))
         assert NewProtocolTags.rate_select not in new_protocol_query._body
+        assert NewProtocolTags.self_clean not in new_protocol_query._body
 
         self.device._capabilities["rate_select"] = True
+        self.device._capabilities["self_clean"] = True
         queries = self.device.build_query()
         new_protocol_query = next(q for q in queries if isinstance(q, NewProtocolQuery))
         assert NewProtocolTags.rate_select in new_protocol_query._body
+        assert NewProtocolTags.self_clean in new_protocol_query._body
+
+    def test_customize_capabilities_override_query_and_property(self) -> None:
+        """Test a customize capabilities entry forces an optional tag on.
+
+        A user can enable a feature the B5 query never advertised; the merged
+        capabilities property and the B1 query both reflect the override.
+        """
+        self.device._used_subprotocol = False
+        self.device.set_customize('{"capabilities": {"self_clean": true}}')
+        assert self.device.capabilities["self_clean"] is True
+        queries = self.device.build_query()
+        new_protocol_query = next(q for q in queries if isinstance(q, NewProtocolQuery))
+        assert NewProtocolTags.self_clean in new_protocol_query._body
+
+    def test_customize_capabilities_disable_overrides_reported_value(self) -> None:
+        """Test a customize false value overrides a B5-reported capability."""
+        self.device._used_subprotocol = False
+        self.device._capabilities["rate_select"] = 2
+        self.device.set_customize('{"capabilities": {"rate_select": false}}')
+        assert self.device.capabilities["rate_select"] is False
+        queries = self.device.build_query()
+        new_protocol_query = next(q for q in queries if isinstance(q, NewProtocolQuery))
+        assert NewProtocolTags.rate_select not in new_protocol_query._body
+
+    def test_customize_capabilities_reset_when_absent(self) -> None:
+        """Test customize capabilities clear when a later customize omits them."""
+        self.device.set_customize('{"capabilities": {"self_clean": true}}')
+        assert self.device._customize_capabilities == {"self_clean": True}
+        self.device.set_customize('{"temperature_step": 1}')
+        assert self.device._customize_capabilities == {}
+
+    def test_customize_capabilities_ignores_non_dict(self) -> None:
+        """Test a non-dict capabilities value is ignored, not applied."""
+        self.device.set_customize('{"capabilities": "self_clean"}')
+        assert self.device._customize_capabilities == {}
 
     def test_bb_model_builds_distinct_queries_and_attributes(self) -> None:
         """Test verified BB model starts with independent BB queries."""

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -22,7 +22,6 @@ from midealan.devices.ac.message import (
     MessageSubProtocol,
     MessageSubProtocolSet,
     NewProtocolQuery,
-    NewProtocolSelfCleanQuery,
     NewProtocolSet,
     NewProtocolTags,
     PowerFormats,
@@ -301,10 +300,10 @@ class TestNewProtocolQuery:
     def test_new_protocol_query_body_includes_rate_select_when_supported(
         self,
     ) -> None:
-        """Test rate_select is appended once the device has advertised support."""
+        """Test rate_select is appended once the capabilities map confirms it."""
         msg = NewProtocolQuery(
             protocol_version=ProtocolVersion.V1,
-            supports_rate_select=True,
+            capabilities={"rate_select": 1},
         )
         expected_body = bytearray(
             [
@@ -339,18 +338,72 @@ class TestNewProtocolQuery:
 
         assert msg.body[:-2] == expected_body
 
-    def test_new_protocol_self_clean_query_body(self) -> None:
-        """Test new protocol self-clean query body."""
-        msg = NewProtocolSelfCleanQuery(protocol_version=ProtocolVersion.V1)
+    def test_new_protocol_query_body_includes_self_clean_when_supported(
+        self,
+    ) -> None:
+        """Test self_clean is appended when the capabilities map confirms it."""
+        msg = NewProtocolQuery(
+            protocol_version=ProtocolVersion.V1,
+            capabilities={"self_clean": True},
+        )
         expected_body = bytearray(
             [
                 0xB1,
-                0x01,
+                0x0B,  # params count
+                NewProtocolTags.indirect_wind & 0xFF,
+                NewProtocolTags.indirect_wind >> 8,
+                NewProtocolTags.breezeless & 0xFF,
+                NewProtocolTags.breezeless >> 8,
+                NewProtocolTags.indoor_humidity & 0xFF,
+                NewProtocolTags.indoor_humidity >> 8,
+                NewProtocolTags.screen_display & 0xFF,
+                NewProtocolTags.screen_display >> 8,
+                NewProtocolTags.fresh_air_1 & 0xFF,
+                NewProtocolTags.fresh_air_1 >> 8,
+                NewProtocolTags.fresh_air_2 & 0xFF,
+                NewProtocolTags.fresh_air_2 >> 8,
+                NewProtocolTags.wind_lr_angle & 0xFF,
+                NewProtocolTags.wind_lr_angle >> 8,
+                NewProtocolTags.wind_ud_angle & 0xFF,
+                NewProtocolTags.wind_ud_angle >> 8,
+                NewProtocolTags.out_silent & 0xFF,
+                NewProtocolTags.out_silent >> 8,
+                NewProtocolTags.buzzer_all & 0xFF,
+                NewProtocolTags.buzzer_all >> 8,
                 NewProtocolTags.self_clean & 0xFF,
                 NewProtocolTags.self_clean >> 8,
             ],
         )
+
         assert msg.body[:-2] == expected_body
+
+    def test_new_protocol_query_body_appends_optional_tags_in_order(self) -> None:
+        """Test both optional tags append in rate_select-then-self_clean order."""
+        msg = NewProtocolQuery(
+            protocol_version=ProtocolVersion.V1,
+            capabilities={"self_clean": True, "rate_select": 2},
+        )
+        # Optional tags come after the fixed base list, in the declared order:
+        # rate_select first, then self_clean, regardless of dict insertion.
+        assert msg.body[:-2][-4:] == bytearray(
+            [
+                NewProtocolTags.rate_select & 0xFF,
+                NewProtocolTags.rate_select >> 8,
+                NewProtocolTags.self_clean & 0xFF,
+                NewProtocolTags.self_clean >> 8,
+            ],
+        )
+
+    def test_new_protocol_query_body_omits_optional_tags_when_falsy(self) -> None:
+        """Test falsy capability values keep the optional tags out of the body."""
+        msg = NewProtocolQuery(
+            protocol_version=ProtocolVersion.V1,
+            capabilities={"self_clean": False, "rate_select": 0},
+        )
+        params_count = msg.body[1]
+        assert params_count == len(NewProtocolQuery._default_query_params)
+        assert NewProtocolTags.self_clean not in msg.body
+        assert NewProtocolTags.rate_select not in msg.body
 
 
 class TestNewProtocolSetOutSilent:
@@ -1057,6 +1110,30 @@ class TestMessageACResponse:
 
         assert hasattr(response, "capabilities")
         assert response.capabilities == {"rate_select": raw_value}
+
+    @pytest.mark.parametrize(
+        ("raw_value", "expected"),
+        [(1, True), (0, False)],
+    )
+    def test_message_query_b5_self_clean_reports_support(
+        self,
+        raw_value: int,
+        expected: bool,
+    ) -> None:
+        """Test the B5 self_clean tag advertises self-clean support.
+
+        In a B5 body tag 0x0039 advertises support (live state is only in
+        B0/B1 bodies), so a non-zero byte marks the feature supported.
+        """
+        self.header[9] = 0x03
+        body = bytearray([0xB5, 0x01])  # Body type, params count
+        body += bytearray([0x39, 0x00, 0x01, raw_value])  # self_clean (0x0039)
+        body += bytearray(1)  # trailing checksum byte (stripped by MessageResponse)
+
+        response = MessageACResponse(self.header + body)
+
+        assert hasattr(response, "capabilities")
+        assert response.capabilities == {"self_clean": expected}
 
     def test_message_query_b5_custom_fan_supports_named_speeds(self) -> None:
         """Test B5 fan custom profile includes named fan speeds."""


### PR DESCRIPTION
## Summary

Merges `NewProtocolQuery` and `NewProtocolSelfCleanQuery` into a single class. Optional tags (`rate_select`, `self_clean`, extensible later) are appended only when the merged capabilities map marks them supported. Users can now force-enable/disable capabilities via a new customize option.

## Changes

### Core refactor
- **Merge query classes**: `NewProtocolSelfCleanQuery` removed; `NewProtocolQuery` now handles all optional tags via a unified `_optional_query_params` structure.
- **Capabilities-driven query building**: `NewProtocolQuery._body` appends optional tags only when `capabilities.get(key)` is truthy (no unsupported tag → no device suppression).
- **B5 self_clean parsing**: `_parse_capabilities` now records `self_clean` support when tag `0x0039` is present.

### Customize option
- New `"capabilities"` customize key: `{"capabilities": {"self_clean": true, "rate_select": 2}}`
- `capabilities` property returns merged view (`{**_capabilities, **_customize_capabilities}`).
- Query building, rate-select gear map, and HA notifications all use the merged view.

### Device layer
- `build_query`: drops from 9 to 8 queries (single merged `NewProtocolQuery`, no separate self-clean query).
- `set_customize`: parses `capabilities` dict, validates, resets to `{}` on each customize call.

## Tests
- **message_ac_test.py**: rewrote rate_select/self_clean body tests to use `capabilities=` param; added combined-tags, falsy-tags, and B5 self_clean parse tests.
- **device_ac_test.py**: updated query count assertions; added tests for customize force-enable, override-disable, reset, and non-dict handling.
- **Coverage**: 100% of new statements; 0 missed lines in changed code.

## Breaking change
Removes `NewProtocolSelfCleanQuery` subclass (external code importing it will break; internal usage was only in `build_query`, now replaced).

## Why
- Eliminates duplication (the two query classes differed only by param list).
- Unifies optional-tag handling so adding more features later (e.g. `water_pump`) requires one line in `_optional_query_params`, not a new subclass.
- Gives users fine-grained control when B5 reports are wrong or incomplete.

Fixes #XX (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing device capabilities, including enabling or disabling optional features.
  * Device queries now automatically include supported rate selection and self-cleaning options.

* **Bug Fixes**
  * Improved capability reporting to accurately reflect both detected and customized device features.
  * Prevented optional query features from being requested before device support is confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->