### PR TITLE
refactor(ac): auto-parse B5 capabilities with manual overrides

### DIFF
--- a/midealan/devices/ac/__init__.py
+++ b/midealan/devices/ac/__init__.py
@@ -388,8 +388,8 @@ class MideaACDevice(MideaDevice):
     def _rate_select_map(self) -> dict[int, str]:
         """Return the rate_select value map for the device-reported level count.
 
-        The B5 b5_electricity capability reports a rate level count: 1 selects
-        the 2-gear map (50/75/100), 2 or 3 select the 5-gear map. Anything else
+        The electricity_capability reports a rate level count: 1 selects the
+        2-gear map (50/75/100), 2 or 3 select the 5-gear map. Anything else
         (including 0/unsupported) yields an empty map so no options are offered.
         """
         _levels: int = self.capabilities.get("rate_select", 0)
@@ -683,8 +683,8 @@ class MideaACDevice(MideaDevice):
         """
         return {**self._capabilities, **self._customize_capabilities}
 
-    def _b5_temperature_limits(self) -> tuple[float, float] | None:
-        """Return the B5 setpoint limits for the current mode, if any.
+    def _capability_temperature_limits(self) -> tuple[float, float] | None:
+        """Return the capability setpoint limits for the current mode, if any.
 
         An unknown mode (e.g. 0 when off) falls back to the cool range.
         """
@@ -699,18 +699,18 @@ class MideaACDevice(MideaDevice):
     ) -> dict[str, Any]:
         """Resolve min/max setpoint limits.
 
-        Priority: customize option > B5 capability > None (the consumer then
-        falls back to its own default range).
+        Priority: customize option > capability response > None (the consumer
+        then falls back to its own default range).
         """
         if message is not None and hasattr(message, "temperature_limits"):
             self._temperature_limits = message.temperature_limits
-        b5 = self._b5_temperature_limits()
+        capability_limits = self._capability_temperature_limits()
         minimum = self._customize_min_temperature
-        if minimum is None and b5 is not None:
-            minimum = b5[0]
+        if minimum is None and capability_limits is not None:
+            minimum = capability_limits[0]
         maximum = self._customize_max_temperature
-        if maximum is None and b5 is not None:
-            maximum = b5[1]
+        if maximum is None and capability_limits is not None:
+            maximum = capability_limits[1]
         self._attributes[DeviceAttributes.min_temperature] = minimum
         self._attributes[DeviceAttributes.max_temperature] = maximum
         return {

--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -101,6 +101,7 @@ NEW_PROTOCOL_INDOOR_TEMPERATURE_DECIMAL_BYTE = 41
 
 # B5 capability value semantics (reverse-engineered; see _parse_capabilities).
 # The raw byte of each capability is not a 0/1 flag; each has its own value set.
+B5_TAG_RANGE_START = 0x0210  # B5 capability tags start from 0x0210
 B5_HEAT_MODE_VALUES = frozenset({1, 2, 4, 6, 7, 9, 10, 11, 12, 13})
 B5_NO_COOL_MODE_VALUES = frozenset({2, 10, 12})
 B5_DRY_MODE_VALUES = frozenset({0, 1, 5, 6, 9, 11, 13})
@@ -1262,49 +1263,107 @@ class CapabilityBody(NewProtocolMessageBody):
     def _parse_capabilities(self, params: dict[int, bytearray]) -> None:
         """Decode B5 capability values into feature flags.
 
-        The raw byte of each capability is not a simple 0/1 flag; each one has
-        its own value semantics (reverse-engineered, matching the msmart
-        project). Only capabilities actually reported are added. Values are
-        mostly booleans, but some (e.g. rate_select's level count) are ints.
+        Parse capabilities using two strategies:
+        1. Manual parsing for tags with special logic (b5_mode, b5_wind_speed, etc.)
+        2. Auto-parse remaining B5 tags using tag name as key and raw value
+
+        Logs warnings for unknown tags not in NewProtocolTags enum.
         """
         caps: dict[str, bool | int] = {}
+
+        # Manual parsing for tags with complex/special logic
         if NewProtocolTags.b5_mode in params:
             value = params[NewProtocolTags.b5_mode][0]
             caps["heat_mode"] = value in B5_HEAT_MODE_VALUES
             caps["cool_mode"] = value not in B5_NO_COOL_MODE_VALUES
             caps["dry_mode"] = value in B5_DRY_MODE_VALUES
             caps["auto_mode"] = value in B5_AUTO_MODE_VALUES
+
         if NewProtocolTags.b5_wind_swing in params:
             value = params[NewProtocolTags.b5_wind_swing][0]
             caps["swing_horizontal"] = value in B5_SWING_HORIZONTAL_VALUES
             caps["swing_vertical"] = value < B5_LOW_VALUE_MAX
+
         if NewProtocolTags.b5_wind_speed in params:
             value = params[NewProtocolTags.b5_wind_speed][0]
-            fan_custom = value == B5_FAN_CUSTOM_VALUE
-            caps["fan_silent"] = fan_custom or value in B5_FAN_SILENT_VALUES
-            caps["fan_low"] = fan_custom or value in B5_FAN_LOW_HIGH_VALUES
-            caps["fan_medium"] = fan_custom or value in B5_FAN_MEDIUM_VALUES
-            caps["fan_high"] = fan_custom or value in B5_FAN_LOW_HIGH_VALUES
-            caps["fan_auto"] = fan_custom or value in B5_FAN_AUTO_VALUES
-            caps["fan_custom"] = fan_custom
+            caps["fan_silent"] = (
+                value == B5_FAN_CUSTOM_VALUE or value in B5_FAN_SILENT_VALUES
+            )
+            caps["fan_low"] = (
+                value == B5_FAN_CUSTOM_VALUE or value in B5_FAN_LOW_HIGH_VALUES
+            )
+            caps["fan_medium"] = (
+                value == B5_FAN_CUSTOM_VALUE or value in B5_FAN_MEDIUM_VALUES
+            )
+            caps["fan_high"] = (
+                value == B5_FAN_CUSTOM_VALUE or value in B5_FAN_LOW_HIGH_VALUES
+            )
+            caps["fan_auto"] = (
+                value == B5_FAN_CUSTOM_VALUE or value in B5_FAN_AUTO_VALUES
+            )
+            caps["fan_custom"] = value == B5_FAN_CUSTOM_VALUE
+
         if NewProtocolTags.b5_eco in params:
             caps["eco"] = params[NewProtocolTags.b5_eco][0] in B5_ECO_VALUES
+
         if NewProtocolTags.b5_anion in params:
             caps["anion"] = params[NewProtocolTags.b5_anion][0] == B5_ANION_ON_VALUE
+
         if NewProtocolTags.b5_strong_wind in params:
             value = params[NewProtocolTags.b5_strong_wind][0]
             caps["turbo_cool"] = value < B5_LOW_VALUE_MAX
             caps["turbo_heat"] = value in B5_TURBO_HEAT_VALUES
+
         if NewProtocolTags.b5_screen_display in params:
-            value = params[NewProtocolTags.b5_screen_display][0]
-            caps["display_control"] = value in B5_DISPLAY_VALUES
+            caps["display_control"] = (
+                params[NewProtocolTags.b5_screen_display][0] in B5_DISPLAY_VALUES
+            )
+
         if NewProtocolTags.b5_electricity in params:
-            value = params[NewProtocolTags.b5_electricity][0]
-            caps["rate_select"] = value
+            caps["rate_select"] = params[NewProtocolTags.b5_electricity][0]
+
         if NewProtocolTags.self_clean in params:
-            # In a B5 body this tag advertises self-clean support (the live
-            # state is only reported in B0/B1 bodies, see PropertiesBody).
             caps["self_clean"] = params[NewProtocolTags.self_clean][0] > 0
+
+        # Tags with special parsing logic (handled above).
+        manually_parsed_tags = frozenset(
+            {
+                NewProtocolTags.b5_mode,
+                NewProtocolTags.b5_wind_swing,
+                NewProtocolTags.b5_wind_speed,
+                NewProtocolTags.b5_eco,
+                NewProtocolTags.b5_anion,
+                NewProtocolTags.b5_strong_wind,
+                NewProtocolTags.b5_screen_display,
+                NewProtocolTags.b5_electricity,
+                NewProtocolTags.self_clean,
+            },
+        )
+
+        # Auto-parse remaining B5 tags that weren't manually handled above.
+        for tag_id, raw in params.items():
+            if tag_id in manually_parsed_tags:
+                continue  # Already handled above
+
+            try:
+                tag_name = NewProtocolTags(tag_id).name
+            except ValueError:
+                # Unknown tag entirely - not in NewProtocolTags enum.
+                _LOGGER.warning(
+                    "Unknown capability tag in B5 response: 0x%04X, "
+                    "Size: %d, Value: %s",
+                    tag_id,
+                    len(raw),
+                    raw.hex(),
+                )
+                continue
+
+            # Only auto-parse B5 range tags (>= 0x0210). Use the tag name as
+            # capability key and the first raw byte as its value
+            # (0 -> falsy, >=1 -> truthy).
+            if tag_id >= B5_TAG_RANGE_START:
+                caps[tag_name] = raw[0] if len(raw) > 0 else 0
+
         self.capabilities = caps
 
 

--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -99,9 +99,8 @@ NEW_PROTOCOL_LEGACY_SETPOINT_BYTE = 3
 NEW_PROTOCOL_INDOOR_TEMPERATURE_BYTE = 40
 NEW_PROTOCOL_INDOOR_TEMPERATURE_DECIMAL_BYTE = 41
 
-# B5 capability value semantics (reverse-engineered; see _parse_capabilities).
+# Capability value semantics (reverse-engineered; see _parse_capabilities).
 # The raw byte of each capability is not a 0/1 flag; each has its own value set.
-B5_TAG_RANGE_START = 0x0210  # B5 capability tags start from 0x0210
 B5_HEAT_MODE_VALUES = frozenset({1, 2, 4, 6, 7, 9, 10, 11, 12, 13})
 B5_NO_COOL_MODE_VALUES = frozenset({2, 10, 12})
 B5_DRY_MODE_VALUES = frozenset({0, 1, 5, 6, 9, 11, 13})
@@ -192,23 +191,23 @@ class NewProtocolTags(IntEnum):
     ieco = 0x00E3
     pre_cool_hot = 0x0201
     pm25_value = 0x020B
-    b5_wind_speed = 0x0210
-    b5_eco = 0x0212
+    wind_speed = 0x0210
+    eco = 0x0212
     b5_8_heat = 0x0213
-    # b5 device
-    b5_mode = 0x0214
-    b5_wind_swing = 0x0215
-    b5_electricity = 0x0216
-    b5_filter_remind = 0x0217
-    b5_ptc = 0x0219
-    b5_strong_wind = 0x021A
+    # capability tags
+    mode = 0x0214
+    wind_swing = 0x0215
+    electricity = 0x0216
+    filter_remind = 0x0217
+    ptc = 0x0219
+    strong_wind = 0x021A
     little_angel = 0x021B
-    b5_anion = 0x021E
-    b5_humidity = 0x021F
-    b5_filter_check = 0x0221
-    b5_fahrenheit = 0x0222
-    b5_screen_display = 0x0224
-    b5_temperature = 0x0225
+    anion = 0x021E
+    humidity = 0x021F
+    filter_check = 0x0221
+    fahrenheit = 0x0222
+    screen_display_capability = 0x0224
+    temperature = 0x0225
     auto_prevent_straight_wind = 0x0226
     remote_control_lock = 0x0227  # power_lock?
     operating_time = 0x0228
@@ -1202,47 +1201,24 @@ class PropertiesBody(NewProtocolMessageBody):
 
 
 class CapabilityBody(NewProtocolMessageBody):
-    """AC B5 capability response body. body[0] b5, body[1] propertyNumber."""
+    """AC B5 capability response body."""
 
     def __init__(self, body: bytearray) -> None:
         """Initialize AC B5 capability response message body."""
         super().__init__(body)
 
         params = self.parse()
-        # parse b5 protocol, github issue https://github.com/wuwentao/midea_ac_lan/issues/673
-        if NewProtocolTags.b5_mode in params:
-            self.b5_mode = params[NewProtocolTags.b5_mode][0]
-        if NewProtocolTags.b5_anion in params:
-            self.b5_anion = params[NewProtocolTags.b5_anion][0]
-        if NewProtocolTags.b5_filter_remind in params:
-            self.b5_filter_remind = params[NewProtocolTags.b5_filter_remind][0]
-        if NewProtocolTags.b5_strong_wind in params:
-            self.b5_strong_wind = params[NewProtocolTags.b5_strong_wind][0]
-        if NewProtocolTags.b5_wind_speed in params:
-            self.b5_wind_speed = params[NewProtocolTags.b5_wind_speed][0]
-        if NewProtocolTags.b5_temperature in params:
-            self.b5_temperature0 = params[NewProtocolTags.b5_temperature][0]
-            self.b5_temperature1 = params[NewProtocolTags.b5_temperature][1]
-            self.b5_temperature2 = params[NewProtocolTags.b5_temperature][2]
-            self.b5_temperature3 = params[NewProtocolTags.b5_temperature][3]
-            self.b5_temperature4 = params[NewProtocolTags.b5_temperature][4]
-            self.b5_temperature5 = params[NewProtocolTags.b5_temperature][5]
-            self.b5_temperature6 = params[NewProtocolTags.b5_temperature][6]
+        # Parse temperature capability for min/max setpoint limits
+        if NewProtocolTags.temperature in params:
+            temp_data = params[NewProtocolTags.temperature]
             # per-mode setpoint limits in 0.5 C units. the six raw bytes are
             # cool then auto then heat, each a min then a max, plus a flag byte.
             # keyed by mode value: auto is 1, cool 2, dry 3, heat 4, fan 5
             # (dry and fan reuse the cool range).
-            cool = (self.b5_temperature0 / 2, self.b5_temperature1 / 2)
-            auto = (self.b5_temperature2 / 2, self.b5_temperature3 / 2)
-            heat = (self.b5_temperature4 / 2, self.b5_temperature5 / 2)
+            cool = (temp_data[0] / 2, temp_data[1] / 2)
+            auto = (temp_data[2] / 2, temp_data[3] / 2)
+            heat = (temp_data[4] / 2, temp_data[5] / 2)
             self.temperature_limits = {1: auto, 2: cool, 3: cool, 4: heat, 5: cool}
-        if NewProtocolTags.b5_screen_display in params:
-            self.b5_screen_display = params[NewProtocolTags.b5_screen_display][0]
-        if NewProtocolTags.buzzer_all in params:
-            # b5_sound/buzzer_all
-            self.b5_sound = params[NewProtocolTags.buzzer_all][0]
-        if NewProtocolTags.b5_humidity in params:
-            self.b5_humidity = params[NewProtocolTags.b5_humidity][0]
         self._parse_capabilities(params)
         self.additional_capabilities = self._detect_additional_capabilities()
 
@@ -1261,31 +1237,31 @@ class CapabilityBody(NewProtocolMessageBody):
         return bool(remaining[-B5_ADDITIONAL_CAPABILITIES_TRAILER_LENGTH])
 
     def _parse_capabilities(self, params: dict[int, bytearray]) -> None:
-        """Decode B5 capability values into feature flags.
+        """Decode capability values into feature flags.
 
         Parse capabilities using two strategies:
-        1. Manual parsing for tags with special logic (b5_mode, b5_wind_speed, etc.)
-        2. Auto-parse remaining B5 tags using tag name as key and raw value
+        1. Manual parsing for tags with special logic (mode, wind_speed, etc.)
+        2. Auto-parse remaining tags using tag name as key and raw value
 
         Logs warnings for unknown tags not in NewProtocolTags enum.
         """
         caps: dict[str, bool | int] = {}
 
         # Manual parsing for tags with complex/special logic
-        if NewProtocolTags.b5_mode in params:
-            value = params[NewProtocolTags.b5_mode][0]
+        if NewProtocolTags.mode in params:
+            value = params[NewProtocolTags.mode][0]
             caps["heat_mode"] = value in B5_HEAT_MODE_VALUES
             caps["cool_mode"] = value not in B5_NO_COOL_MODE_VALUES
             caps["dry_mode"] = value in B5_DRY_MODE_VALUES
             caps["auto_mode"] = value in B5_AUTO_MODE_VALUES
 
-        if NewProtocolTags.b5_wind_swing in params:
-            value = params[NewProtocolTags.b5_wind_swing][0]
+        if NewProtocolTags.wind_swing in params:
+            value = params[NewProtocolTags.wind_swing][0]
             caps["swing_horizontal"] = value in B5_SWING_HORIZONTAL_VALUES
             caps["swing_vertical"] = value < B5_LOW_VALUE_MAX
 
-        if NewProtocolTags.b5_wind_speed in params:
-            value = params[NewProtocolTags.b5_wind_speed][0]
+        if NewProtocolTags.wind_speed in params:
+            value = params[NewProtocolTags.wind_speed][0]
             caps["fan_silent"] = (
                 value == B5_FAN_CUSTOM_VALUE or value in B5_FAN_SILENT_VALUES
             )
@@ -1303,24 +1279,25 @@ class CapabilityBody(NewProtocolMessageBody):
             )
             caps["fan_custom"] = value == B5_FAN_CUSTOM_VALUE
 
-        if NewProtocolTags.b5_eco in params:
-            caps["eco"] = params[NewProtocolTags.b5_eco][0] in B5_ECO_VALUES
+        if NewProtocolTags.eco in params:
+            caps["eco"] = params[NewProtocolTags.eco][0] in B5_ECO_VALUES
 
-        if NewProtocolTags.b5_anion in params:
-            caps["anion"] = params[NewProtocolTags.b5_anion][0] == B5_ANION_ON_VALUE
+        if NewProtocolTags.anion in params:
+            caps["anion"] = params[NewProtocolTags.anion][0] == B5_ANION_ON_VALUE
 
-        if NewProtocolTags.b5_strong_wind in params:
-            value = params[NewProtocolTags.b5_strong_wind][0]
+        if NewProtocolTags.strong_wind in params:
+            value = params[NewProtocolTags.strong_wind][0]
             caps["turbo_cool"] = value < B5_LOW_VALUE_MAX
             caps["turbo_heat"] = value in B5_TURBO_HEAT_VALUES
 
-        if NewProtocolTags.b5_screen_display in params:
+        if NewProtocolTags.screen_display_capability in params:
             caps["display_control"] = (
-                params[NewProtocolTags.b5_screen_display][0] in B5_DISPLAY_VALUES
+                params[NewProtocolTags.screen_display_capability][0]
+                in B5_DISPLAY_VALUES
             )
 
-        if NewProtocolTags.b5_electricity in params:
-            caps["rate_select"] = params[NewProtocolTags.b5_electricity][0]
+        if NewProtocolTags.electricity in params:
+            caps["rate_select"] = params[NewProtocolTags.electricity][0]
 
         if NewProtocolTags.self_clean in params:
             caps["self_clean"] = params[NewProtocolTags.self_clean][0] > 0
@@ -1328,19 +1305,19 @@ class CapabilityBody(NewProtocolMessageBody):
         # Tags with special parsing logic (handled above).
         manually_parsed_tags = frozenset(
             {
-                NewProtocolTags.b5_mode,
-                NewProtocolTags.b5_wind_swing,
-                NewProtocolTags.b5_wind_speed,
-                NewProtocolTags.b5_eco,
-                NewProtocolTags.b5_anion,
-                NewProtocolTags.b5_strong_wind,
-                NewProtocolTags.b5_screen_display,
-                NewProtocolTags.b5_electricity,
+                NewProtocolTags.mode,
+                NewProtocolTags.wind_swing,
+                NewProtocolTags.wind_speed,
+                NewProtocolTags.eco,
+                NewProtocolTags.anion,
+                NewProtocolTags.strong_wind,
+                NewProtocolTags.screen_display_capability,
+                NewProtocolTags.electricity,
                 NewProtocolTags.self_clean,
             },
         )
 
-        # Auto-parse remaining B5 tags that weren't manually handled above.
+        # Auto-parse remaining tags that weren't manually handled above.
         for tag_id, raw in params.items():
             if tag_id in manually_parsed_tags:
                 continue  # Already handled above
@@ -1358,11 +1335,9 @@ class CapabilityBody(NewProtocolMessageBody):
                 )
                 continue
 
-            # Only auto-parse B5 range tags (>= 0x0210). Use the tag name as
-            # capability key and the first raw byte as its value
-            # (0 -> falsy, >=1 -> truthy).
-            if tag_id >= B5_TAG_RANGE_START:
-                caps[tag_name] = raw[0] if len(raw) > 0 else 0
+            # Use the tag name as capability key and the first raw byte as its
+            # value (0 -> falsy, >=1 -> truthy).
+            caps[tag_name] = raw[0] if len(raw) > 0 else 0
 
         self.capabilities = caps
 

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -1,5 +1,7 @@
 """Test ac message."""
 
+import logging
+
 import pytest
 
 from midealan.const import ProtocolVersion
@@ -1046,6 +1048,7 @@ class TestMessageACResponse:
         }
         assert hasattr(response, "capabilities")
         assert response.capabilities == {
+            # Manually parsed capabilities with special logic
             "heat_mode": True,
             "cool_mode": True,
             "dry_mode": False,
@@ -1063,6 +1066,11 @@ class TestMessageACResponse:
             "turbo_cool": True,
             "turbo_heat": True,
             "display_control": True,
+            # Auto-parsed B5 tags (raw value from first byte)
+            "b5_filter_remind": 1,
+            "b5_temperature": 34,
+            "buzzer_all": 1,
+            "b5_humidity": 1,
         }
 
     def test_message_query_b5_detects_additional_capabilities(self) -> None:
@@ -1174,6 +1182,31 @@ class TestMessageACResponse:
             "fan_auto": True,
             "fan_custom": False,
         }
+
+    def test_message_query_b5_warns_unknown_tag(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Test B5 capability parsing warns about unknown tags."""
+        self.header[9] = 0x03
+        body = bytearray([0xB5, 0x02])  # Body type, 2 params
+        # Add a known tag (b5_mode)
+        body += bytearray([0x14, 0x02, 0x01, 7])  # b5_mode
+        # Add an unknown B5-range tag (0x0299, not in NewProtocolTags)
+        body += bytearray([0x99, 0x02, 0x01, 0x42])
+        body += bytearray(1)  # trailing checksum byte
+
+        with caplog.at_level(logging.WARNING):
+            response = MessageACResponse(self.header + body)
+
+        # Known tag should parse
+        assert hasattr(response, "capabilities")
+        assert "heat_mode" in response.capabilities
+        # Unknown tag should trigger warning
+        assert any(
+            "Unknown capability tag" in record.message and "0x0299" in record.message
+            for record in caplog.records
+        )
 
     @pytest.mark.parametrize(
         ("raw_value", "expected"),

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -1004,40 +1004,22 @@ class TestMessageACResponse:
         """Test Message parse query B5 capabilities."""
         self.header[9] = 0x03
         body = bytearray([0xB5, 0x0B])  # Body type, params count
-        body += bytearray([0x14, 0x02, 0x01, 7])  # b5_mode
-        body += bytearray([0x15, 0x02, 0x01, 1])  # b5_wind_swing
-        body += bytearray([0x10, 0x02, 0x01, 5])  # b5_wind_speed
-        body += bytearray([0x12, 0x02, 0x01, 1])  # b5_eco
-        body += bytearray([0x1E, 0x02, 0x01, 1])  # b5_anion
-        body += bytearray([0x17, 0x02, 0x01, 1])  # b5_filter_remind
-        body += bytearray([0x1A, 0x02, 0x01, 1])  # b5_strong_wind
+        body += bytearray([0x14, 0x02, 0x01, 7])  # mode
+        body += bytearray([0x15, 0x02, 0x01, 1])  # wind_swing
+        body += bytearray([0x10, 0x02, 0x01, 5])  # wind_speed
+        body += bytearray([0x12, 0x02, 0x01, 1])  # eco
+        body += bytearray([0x1E, 0x02, 0x01, 1])  # anion
+        body += bytearray([0x17, 0x02, 0x01, 1])  # filter_remind
+        body += bytearray([0x1A, 0x02, 0x01, 1])  # strong_wind
         body += bytearray([0x25, 0x02, 0x07, 34, 60, 34, 60, 34, 60, 0])  # temperature
-        body += bytearray([0x24, 0x02, 0x01, 1])  # b5_screen_display
-        body += bytearray([0x2C, 0x02, 0x01, 1])  # b5_sound
-        body += bytearray([0x1F, 0x02, 0x01, 1])  # b5_humidity
+        # screen_display_capability
+        body += bytearray([0x24, 0x02, 0x01, 1])
+        body += bytearray([0x2C, 0x02, 0x01, 1])  # buzzer_all
+        body += bytearray([0x1F, 0x02, 0x01, 1])  # humidity
         body += bytearray(1)  # trailing checksum byte (stripped by MessageResponse)
 
         response = MessageACResponse(self.header + body)
-        assert hasattr(response, "b5_mode")
-        assert response.b5_mode == 7
-        assert hasattr(response, "b5_anion")
-        assert response.b5_anion == 1
-        assert hasattr(response, "b5_filter_remind")
-        assert response.b5_filter_remind == 1
-        assert hasattr(response, "b5_strong_wind")
-        assert response.b5_strong_wind == 1
-        assert hasattr(response, "b5_wind_speed")
-        assert response.b5_wind_speed == 5
-        assert hasattr(response, "b5_screen_display")
-        assert response.b5_screen_display == 1
-        assert hasattr(response, "b5_sound")
-        assert response.b5_sound == 1
-        assert hasattr(response, "b5_humidity")
-        assert response.b5_humidity == 1
-        assert hasattr(response, "b5_temperature0")
-        assert response.b5_temperature0 == 34
-        assert hasattr(response, "b5_temperature6")
-        assert response.b5_temperature6 == 0
+        # Temperature limits are extracted into temperature_limits attribute
         assert hasattr(response, "temperature_limits")
         assert response.temperature_limits == {
             1: (17.0, 30.0),
@@ -1046,6 +1028,7 @@ class TestMessageACResponse:
             4: (17.0, 30.0),
             5: (17.0, 30.0),
         }
+        # All capability tags are parsed into capabilities dict
         assert hasattr(response, "capabilities")
         assert response.capabilities == {
             # Manually parsed capabilities with special logic
@@ -1066,11 +1049,11 @@ class TestMessageACResponse:
             "turbo_cool": True,
             "turbo_heat": True,
             "display_control": True,
-            # Auto-parsed B5 tags (raw value from first byte)
-            "b5_filter_remind": 1,
-            "b5_temperature": 34,
+            # Auto-parsed tags (raw value from first byte)
+            "filter_remind": 1,
+            "temperature": 34,
             "buzzer_all": 1,
-            "b5_humidity": 1,
+            "humidity": 1,
         }
 
     def test_message_query_b5_detects_additional_capabilities(self) -> None:
@@ -1102,16 +1085,16 @@ class TestMessageACResponse:
         self,
         raw_value: int,
     ) -> None:
-        """Test b5_electricity capability exposes the raw rate level count.
+        """Test electricity capability exposes the raw rate level count.
 
-        The B5 b5_electricity byte is a rate level count, not a boolean:
+        The electricity byte is a rate level count, not a boolean:
         1 selects the 2-gear map, 2/3 select the 5-gear map, 0 means
         unsupported. The parser stores the raw value so the device layer can
         pick the right gear map.
         """
         self.header[9] = 0x03
         body = bytearray([0xB5, 0x01])  # Body type, params count
-        body += bytearray([0x16, 0x02, 0x01, raw_value])  # b5_electricity
+        body += bytearray([0x16, 0x02, 0x01, raw_value])  # electricity
         body += bytearray(1)  # trailing checksum byte (stripped by MessageResponse)
 
         response = MessageACResponse(self.header + body)


### PR DESCRIPTION
## Summary

Refactor AC capability parsing to combine special-case handling with automatic parsing for remaining B5 tags, eliminating the need to manually add parsing for each new tag.

## Changes

- **Keep manual parsing** for complex tags (, , etc.) that extract multiple capability keys or use value-set semantics
- **Auto-parse remaining B5 tags** using tag name as capability key and raw  as its int value
- **Log warnings** for unknown tags not in NewProtocolTags enum
- **Update test** to include auto-parsed capabilities (, , , )

## Benefits

- ✅ Eliminates missed tags - all B5 tags in NewProtocolTags are automatically captured
- ✅ Preserves existing special-case logic for complex parsing
- ✅ Provides visibility when devices report unsupported capabilities (warnings in logs)
- ✅ Reduces maintenance burden - no need to manually add parsing for simple tags

## Testing

- All 114 AC message tests pass
- Verified manual parsing still works correctly for existing tags
- Verified auto-parsing adds new capability keys with raw values

## Related

Part 1 of 2-part refactoring. Part 2 will auto-build NewProtocolQuery params from capabilities dict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatically recognizing additional B5 device capabilities.
  * Newly recognized capabilities, including temperature, humidity, filter reminders, and buzzer settings, are now shown in capability results.

* **Bug Fixes**
  * Unknown capability tags are safely skipped with a warning instead of disrupting capability parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->