### PR TITLE
feat(ac): support iECO query and set

### DIFF
--- a/midealan/devices/ac/__init__.py
+++ b/midealan/devices/ac/__init__.py
@@ -107,6 +107,7 @@ class DeviceAttributes(StrEnum):
     anion = "anion"
     sound = "sound"
     self_clean = "self_clean"
+    ieco = "ieco"
     pmv = "pmv"
     error_code = "error_code"
     # group 1: compressor and refrigerant circuit
@@ -292,6 +293,7 @@ class MideaACDevice(MideaDevice):
                 DeviceAttributes.anion: False,
                 DeviceAttributes.sound: True,
                 DeviceAttributes.self_clean: False,
+                DeviceAttributes.ieco: False,
                 DeviceAttributes.pmv: None,
                 DeviceAttributes.error_code: 0,
                 DeviceAttributes.compressor_frequency: None,
@@ -319,6 +321,8 @@ class MideaACDevice(MideaDevice):
         )
         self._fresh_air_version: DeviceAttributes | None = None
         self._pending_self_clean: tuple[bool, float] | None = None
+        # Current iECO gear the device reports; echoed back when setting iECO.
+        self._ieco_number: int = 1
         self._default_temperature_step: float = 0.5
         self._temperature_step: float = 0.5
         self._used_subprotocol: bool = self._model_capabilities.uses_bb_protocol
@@ -580,6 +584,8 @@ class MideaACDevice(MideaDevice):
             self._fresh_air_version = DeviceAttributes.fresh_air_1
         elif self._attributes[DeviceAttributes.fresh_air_2] is not None:
             self._fresh_air_version = DeviceAttributes.fresh_air_2
+        if hasattr(message, "ieco_number"):
+            self._ieco_number = message.ieco_number
         if hasattr(message, "self_clean_active"):
             active = message.self_clean_active
             update_self_clean = True
@@ -814,6 +820,10 @@ class MideaACDevice(MideaDevice):
                 (key for key, val in rate_map.items() if val == str(value)),
                 None,
             )
+        # iECO on/off — echo the last reported gear number
+        elif attr == DeviceAttributes.ieco:
+            message.ieco = bool(value)
+            message.ieco_number = self._ieco_number
         # indirect_wind, screen_display_alternate, breezeless
         else:
             setattr(message, str(attr), value)
@@ -982,6 +992,7 @@ class MideaACDevice(MideaDevice):
                 DeviceAttributes.out_silent,
                 DeviceAttributes.sound,
                 DeviceAttributes.self_clean,
+                DeviceAttributes.ieco,
             ]:
                 message = self.make_newprotocol_message_set(attr=attr, value=value)
                 if attr == DeviceAttributes.self_clean:

--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -114,6 +114,13 @@ B5_FAN_SILENT_VALUES = frozenset({6, 9})
 B5_FAN_CUSTOM_VALUE = 1
 B5_ECO_VALUES = frozenset({1, 2})
 B5_ANION_ON_VALUE = 1
+# iECO (0x00E3) capability. The B5 body reports a start byte (index 0) and an
+# end byte (index 1); the feature is supported when either names a known iECO
+# value. iECO itself is queried/set as a new-protocol on/off feature.
+B5_IECO_START_VALUES = frozenset({1, 3, 4, 8})
+B5_IECO_END_VALUES = frozenset({1, 2, 3, 8})
+# iECO set frame: [0x00 frame, ieco_number, ieco_switch] + this many zero bytes.
+IECO_SET_PADDING = 10
 B5_TURBO_HEAT_VALUES = frozenset({1, 3})
 B5_DISPLAY_VALUES = frozenset({1, 2, 100})
 
@@ -879,6 +886,8 @@ class NewProtocolSet(MessageACBase):
         self.out_silent: bool | None = None
         self.sound: bool | None = None
         self.self_clean: bool | None = None
+        self.ieco: bool | None = None
+        self.ieco_number: int = 1
 
     @property
     def _body(self) -> bytearray:
@@ -999,6 +1008,18 @@ class NewProtocolSet(MessageACBase):
                 NewProtocolMessageBody.pack(
                     param=NewProtocolTags.rate_select,
                     value=bytearray([int(self.rate_select)]),
+                ),
+            )
+        if self.ieco is not None:
+            pack_count += 1
+            payload.extend(
+                NewProtocolMessageBody.pack(
+                    param=NewProtocolTags.ieco,
+                    # [frame, ieco_number, switch] followed by zero padding.
+                    value=bytearray(
+                        [0x00, self.ieco_number, 0x01 if self.ieco else 0x00],
+                    )
+                    + bytearray(IECO_SET_PADDING),
                 ),
             )
         payload[0] = pack_count
@@ -1152,6 +1173,17 @@ class PropertiesBody(NewProtocolMessageBody):
             # A B5 body carries this tag as a capability flag (always 1 when the
             # model supports self-clean), so only B0/B1 bodies report live state.
             self.self_clean_active: bool = params[NewProtocolTags.self_clean][0] > 0
+        if (
+            NewProtocolTags.ieco in params
+            and self.body_type != ListTypes.B5
+            and len(params[NewProtocolTags.ieco]) > 1
+        ):
+            # data[0] - iECO number (current gear), data[1] - on/off switch.
+            # Only B0/B1 bodies report live state; a B5 body carries this tag as
+            # a capability advertisement instead.
+            ieco_data = params[NewProtocolTags.ieco]
+            self.ieco = ieco_data[1] > 0
+            self.ieco_number = ieco_data[0]
         if (
             new_protocol_temperature
             and NEW_PROTOCOL_TEMPERATURE_TAG in params
@@ -1320,6 +1352,14 @@ class CapabilityBody(NewProtocolMessageBody):
         if NewProtocolTags.self_clean in params:
             caps["self_clean"] = params[NewProtocolTags.self_clean][0] > 0
 
+        if NewProtocolTags.ieco in params:
+            ieco_data = params[NewProtocolTags.ieco]
+            ieco_start = ieco_data[0] if len(ieco_data) > 0 else 0
+            ieco_end = ieco_data[1] if len(ieco_data) > 1 else 0
+            caps["ieco"] = (
+                ieco_start in B5_IECO_START_VALUES or ieco_end in B5_IECO_END_VALUES
+            )
+
         # Tags with special parsing logic (handled above).
         manually_parsed_tags = frozenset(
             {
@@ -1332,6 +1372,7 @@ class CapabilityBody(NewProtocolMessageBody):
                 NewProtocolTags.screen_display_capability,
                 NewProtocolTags.electricity,
                 NewProtocolTags.self_clean,
+                NewProtocolTags.ieco,
             },
         )
 

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -1286,6 +1286,43 @@ class TestMideaACDevice:
         assert updates == []
         assert self.device._pending_self_clean is None
 
+    def test_ieco_in_initial_attributes(self) -> None:
+        """Test iECO defaults to off and gear 1."""
+        assert self.device.attributes[DeviceAttributes.ieco] is False
+        assert self.device._ieco_number == 1
+
+    def test_set_ieco_echoes_reported_number(self) -> None:
+        """Test setting iECO builds a NewProtocolSet echoing the last gear."""
+        self.device._ieco_number = 3
+        with patch.object(self.device, "build_send") as mock_build_send:
+            self.device.set_attribute(DeviceAttributes.ieco.value, True)
+
+        message = mock_build_send.call_args[0][0]
+        assert message.ieco is True
+        assert message.ieco_number == 3
+
+    def test_set_ieco_off(self) -> None:
+        """Test turning iECO off builds a NewProtocolSet with ieco False."""
+        with patch.object(self.device, "build_send") as mock_build_send:
+            self.device.set_attribute(DeviceAttributes.ieco.value, False)
+
+        message = mock_build_send.call_args[0][0]
+        assert message.ieco is False
+
+    def test_process_message_captures_ieco_state_and_number(self) -> None:
+        """Test process_message publishes iECO state and records its gear."""
+        with patch("midealan.devices.ac.MessageACResponse") as mock_message_response:
+            mock_message = mock_message_response.return_value
+            mock_message.used_subprotocol = False
+            mock_message.fresh_air_power = False
+            mock_message.ieco = True
+            mock_message.ieco_number = 5
+
+            result = self.device.process_message(b"")
+
+        assert result[DeviceAttributes.ieco.value] is True
+        assert self.device._ieco_number == 5
+
     def test_invalid_customize_format(self) -> None:
         """Test invalid customize format."""
         self.device.set_customize("{")

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -1312,6 +1312,93 @@ class TestMessageACResponse:
         response = MessageACResponse(self.header + body)
         assert not hasattr(response, "self_clean_active")
 
+    @pytest.mark.parametrize(
+        ("start", "end", "expected"),
+        [
+            (1, 0, True),  # supported via start byte
+            (0, 2, True),  # supported via end byte
+            (8, 8, True),  # ECOMaster
+            (0, 0, False),  # unsupported
+        ],
+    )
+    def test_message_query_b5_ieco_reports_support(
+        self,
+        start: int,
+        end: int,
+        expected: bool,
+    ) -> None:
+        """Test the B5 iECO tag advertises support from start/end bytes."""
+        self.header[9] = 0x03
+        body = bytearray([0xB5, 0x01])  # Body type, params count
+        # iECO (0x00E3): start byte then end byte
+        body += bytearray([0xE3, 0x00, 0x02, start, end])
+        body += bytearray(1)  # trailing checksum byte (stripped by MessageResponse)
+
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "capabilities")
+        assert response.capabilities == {"ieco": expected}
+
+    def test_message_query_b5_ieco_single_byte(self) -> None:
+        """Test the B5 iECO tag with only a start byte still parses."""
+        self.header[9] = 0x03
+        body = bytearray([0xB5, 0x01])  # Body type, params count
+        body += bytearray([0xE3, 0x00, 0x01, 0x03])  # start byte only
+        body += bytearray(1)  # trailing checksum byte
+
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "capabilities")
+        assert response.capabilities == {"ieco": True}
+
+    @pytest.mark.parametrize(
+        ("switch", "number", "expected_state"),
+        [(0x01, 0x03, True), (0x00, 0x02, False)],
+    )
+    def test_message_query_b1_ieco_state(
+        self,
+        switch: int,
+        number: int,
+        expected_state: bool,
+    ) -> None:
+        """Test Message parse query B1 reports live iECO state and number."""
+        self.header[9] = 0x03
+        body = bytearray(
+            [
+                0xB1,  # Body type
+                0x01,  # Params count
+                NewProtocolTags.ieco & 0xFF,
+                NewProtocolTags.ieco >> 8,
+                0x00,
+                0x02,  # Value length
+                number,  # data[0] - iECO number
+                switch,  # data[1] - on/off switch
+                0x00,  # trailing checksum byte (stripped by MessageResponse)
+            ],
+        )
+
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "ieco")
+        assert hasattr(response, "ieco_number")
+        assert response.ieco is expected_state
+        assert response.ieco_number == number
+
+    def test_message_notify2_b5_ieco_is_capability_only(self) -> None:
+        """Test that tag 0x00E3 in a B5 body is not read as live state."""
+        body = bytearray(
+            [
+                0xB5,  # Body type
+                0x01,  # Params count
+                NewProtocolTags.ieco & 0xFF,
+                NewProtocolTags.ieco >> 8,
+                0x02,  # Value length
+                0x01,  # start byte: supported
+                0x01,  # end byte
+                0x00,  # trailing checksum byte (stripped by MessageResponse)
+            ],
+        )
+
+        response = MessageACResponse(self.header + body)
+        assert not hasattr(response, "ieco")
+
     def test_message_query_c0(self) -> None:
         """Test Message parse query C0."""
         self.header[9] = 0x03
@@ -2310,6 +2397,44 @@ class TestNewProtocolSetNewFeatures:
         assert body[3] == NewProtocolTags.self_clean >> 8
         assert body[4] == 0x01
         assert body[5] == expected_byte
+
+
+class TestNewProtocolSetIeco:
+    """Test NewProtocolSet for iECO."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected_switch"),
+        [(True, 0x01), (False, 0x00)],
+    )
+    def test_ieco_on_off(self, value: bool, expected_switch: int) -> None:
+        """Test iECO set to on/off sends the frame/number/switch payload."""
+        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg.ieco = value
+        msg.ieco_number = 3
+        body = msg.body
+        assert body[0] == 0xB0
+        assert body[1] == 0x01  # pack count
+        assert body[2] == NewProtocolTags.ieco & 0xFF
+        assert body[3] == NewProtocolTags.ieco >> 8
+        assert body[4] == 0x0D  # value length: 3 + 10 padding
+        assert body[5] == 0x00  # frame
+        assert body[6] == 0x03  # ieco number
+        assert body[7] == expected_switch  # switch
+        # remaining padding bytes are zero
+        assert body[8:18] == bytearray(10)
+
+    def test_ieco_defaults_number_to_one(self) -> None:
+        """Test iECO uses gear 1 by default when no number is set."""
+        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg.ieco = True
+        body = msg.body
+        assert body[6] == 0x01
+
+    def test_ieco_absent_when_unset(self) -> None:
+        """Test iECO is not packed when left as None."""
+        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
+        body = msg.body
+        assert body[1] == 0x00  # no params packed
 
 
 class TestMessageSetAnion:


### PR DESCRIPTION
## Summary

Wires up the iECO new-protocol tag (`0x00E3`) end to end for AC devices. The tag was already defined in `NewProtocolTags` but was never queried, parsed, or set.

- Parse live iECO on/off state and gear number from B0/B1 bodies (`data[0]` = gear, `data[1]` = switch).
- Decode iECO support from the B5 capability body (start/end bytes), so the recurring `NewProtocolQuery` auto-appends the tag once the device advertises support — no manual query-list change needed.
- Encode iECO set commands as a new-protocol frame carrying the gear number and on/off switch, echoing the last gear the device reported.
- Expose an `ieco` device attribute (default off) and route it through `set_attribute`, following the existing `self_clean` / `out_silent` patterns.

## Testing

- `uv run prek run --all-files` — all hooks pass (ruff, mypy, pylint, commitlint).
- `uv run python -m pytest --cov=midealan ./tests/` — 1946 passed, 100% line coverage (0 missed statements).
- New tests cover query parsing (B1 live state), capability detection (B5 start/end variants incl. ECOMaster and single-byte), set encoding (on/off, default gear, absent-when-unset), and device attribute routing / process_message.

Refs: https://github.com/wuwentao/midea_ac_lan/issues/969

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the iECO intelligent energy-saving mode on compatible Midea AC devices.
  * Displays the device’s iECO availability, current on/off state, and gear number.
  * Preserves the last reported gear when enabling iECO and defaults to gear 1 when unavailable.

* **Bug Fixes**
  * Improved parsing of iECO capabilities and live status from device responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->