### PR TITLE
refactor(ac): rename ac device message classes

### DIFF
--- a/midealan/devices/ac/__init__.py
+++ b/midealan/devices/ac/__init__.py
@@ -20,12 +20,12 @@ from .message import (
     GroupZeroQuery,
     HumidityQuery,
     MessageACResponse,
-    MessageQuery,
-    MessageSet,
     MessageSubProtocolSet,
-    NewProtocolQuery,
-    NewProtocolSet,
     PowerQuery,
+    PropertiesQuery,
+    PropertiesSet,
+    StateQuery,
+    StateSet,
     SubProtocolFreshAirSet,
     SubProtocolQuery,
     SubProtocolQuery10,
@@ -38,8 +38,8 @@ _LOGGER = logging.getLogger(__name__)
 
 ACQuery = (
     SubProtocolQuery
-    | MessageQuery
-    | NewProtocolQuery
+    | StateQuery
+    | PropertiesQuery
     | PowerQuery
     | HumidityQuery
     | GroupZeroQuery
@@ -420,13 +420,13 @@ class MideaACDevice(MideaDevice):
                 SubProtocolQuery30(self._message_protocol_version),
             ]
         queries: list[ACQuery] = [
-            MessageQuery(self._message_protocol_version),
+            StateQuery(self._message_protocol_version),
             # Single new-protocol query. Status feature tags (self_clean,
-            # rate_select, ...) are appended by NewProtocolQuery automatically
+            # rate_select, ...) are appended by PropertiesQuery automatically
             # from the merged capabilities map (B5-parsed values overlaid with
             # customize overrides), so an unsupported tag can't make the device
             # return an empty list that suppresses the other tags.
-            NewProtocolQuery(
+            PropertiesQuery(
                 self._message_protocol_version,
                 capabilities=self.capabilities,
             ),
@@ -724,9 +724,9 @@ class MideaACDevice(MideaDevice):
             DeviceAttributes.max_temperature.value: maximum,
         }
 
-    def make_message_set(self) -> MessageSet:
+    def make_message_set(self) -> StateSet:
         """Midea AC device make message set."""
-        message = MessageSet(self._message_protocol_version)
+        message = StateSet(self._message_protocol_version)
         message.power = self._attributes[DeviceAttributes.power]
         message.prompt_tone = self._attributes[DeviceAttributes.prompt_tone]
         message.mode = self._attributes[DeviceAttributes.mode]
@@ -754,9 +754,9 @@ class MideaACDevice(MideaDevice):
         self,
         attr: str,
         value: bool | float | str,
-    ) -> NewProtocolSet:
+    ) -> PropertiesSet:
         """Midea AC device make newprotocol message set."""
-        message = NewProtocolSet(self._message_protocol_version)
+        message = PropertiesSet(self._message_protocol_version)
 
         # wind_lr_angle
         if attr == DeviceAttributes.wind_lr_angle:
@@ -912,9 +912,9 @@ class MideaACDevice(MideaDevice):
             exhaust=exhaust,
         )
 
-    def make_message_uniq_set(self) -> MessageSubProtocolSet | MessageSet:
+    def make_message_uniq_set(self) -> MessageSubProtocolSet | StateSet:
         """Midea AC device make message unique set."""
-        message: MessageSubProtocolSet | MessageSet
+        message: MessageSubProtocolSet | StateSet
         if self._used_subprotocol:
             message = self.make_subprotocol_message_set()
         else:
@@ -926,10 +926,10 @@ class MideaACDevice(MideaDevice):
         # if nat a sensor
         message: (
             ToggleDisplay
-            | NewProtocolSet
+            | PropertiesSet
             | SubProtocolFreshAirSet
             | MessageSubProtocolSet
-            | MessageSet
+            | StateSet
             | None
         ) = None
         optimistic_self_clean: bool | None = None
@@ -1013,7 +1013,7 @@ class MideaACDevice(MideaDevice):
                     DeviceAttributes.eco_mode,
                 ]:
                     message.boost_mode = False
-                    if isinstance(message, MessageSet):
+                    if isinstance(message, StateSet):
                         message.power_saving = False
                     message.sleep_mode = False
                     message.eco_mode = False
@@ -1055,7 +1055,7 @@ class MideaACDevice(MideaDevice):
         zone: int | None = None,  # noqa: ARG002
     ) -> None:
         """Midea AC device set target temperature."""
-        message: MessageSubProtocolSet | MessageSet = self.make_message_uniq_set()
+        message: MessageSubProtocolSet | StateSet = self.make_message_uniq_set()
         message.target_temperature = target_temperature
         if mode is not None:
             message.power = True
@@ -1064,8 +1064,8 @@ class MideaACDevice(MideaDevice):
 
     def set_swing(self, swing_vertical: bool, swing_horizontal: bool) -> None:
         """Midea AC device set swing."""
-        message: MessageSubProtocolSet | MessageSet = self.make_message_uniq_set()
-        if isinstance(message, MessageSet):
+        message: MessageSubProtocolSet | StateSet = self.make_message_uniq_set()
+        if isinstance(message, StateSet):
             message.swing_vertical = swing_vertical
             message.swing_horizontal = swing_horizontal
         self.build_send(message)

--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -143,7 +143,7 @@ class PowerFormats(IntEnum):
     BCD_ENERGY_BINARY_POWER = 101
 
 
-class NewProtocolTags(IntEnum):
+class CapabilityTag(IntEnum):
     """New protocol tags in query and response."""
 
     wind_ud_angle = 0x0009
@@ -299,7 +299,7 @@ class MessageA0LongQuery(MessageACBase):
         return bytearray(19)
 
 
-class MessageQuery(MessageACBase):
+class StateQuery(MessageACBase):
     """AC message query(queryType == nil)."""
 
     def __init__(self, protocol_version: int) -> None:
@@ -459,7 +459,7 @@ class ToggleDisplay(MessageACBase):
         )
 
 
-class NewProtocolQuery(MessageACBase):
+class PropertiesQuery(MessageACBase):
     """AC message new protocol query.
 
     A single B1 query carries a list of new-protocol tags. The device answers
@@ -469,7 +469,7 @@ class NewProtocolQuery(MessageACBase):
     answer, while status feature tags that some devices reject (self_clean,
     rate_select, ...) are appended automatically from the merged capabilities
     map (B5 capabilities overlaid with the user's customize overrides): any
-    capability key that names a NewProtocolTags member and is truthy is added.
+    capability key that names a CapabilityTag member and is truthy is added.
     """
 
     # Tags that only ever appear in B5 capability advertisements, never as valid
@@ -479,31 +479,31 @@ class NewProtocolQuery(MessageACBase):
     # tag in the same request. See docs/protocol/ac_newprotocol_tags.md.
     _CAPABILITY_ONLY_TAGS: frozenset[int] = frozenset(
         {
-            NewProtocolTags.wind_speed,  # 0x0210
-            NewProtocolTags.eco,  # 0x0212
-            NewProtocolTags.b5_8_heat,  # 0x0213
-            NewProtocolTags.mode,  # 0x0214
-            NewProtocolTags.wind_swing,  # 0x0215
-            NewProtocolTags.electricity,  # 0x0216
-            NewProtocolTags.filter_remind,  # 0x0217
-            NewProtocolTags.ptc,  # 0x0219
-            NewProtocolTags.strong_wind,  # 0x021A
-            NewProtocolTags.humidity,  # 0x021F
-            NewProtocolTags.filter_check,  # 0x0221
-            NewProtocolTags.fahrenheit,  # 0x0222
-            NewProtocolTags.screen_display_capability,  # 0x0224
+            CapabilityTag.wind_speed,  # 0x0210
+            CapabilityTag.eco,  # 0x0212
+            CapabilityTag.b5_8_heat,  # 0x0213
+            CapabilityTag.mode,  # 0x0214
+            CapabilityTag.wind_swing,  # 0x0215
+            CapabilityTag.electricity,  # 0x0216
+            CapabilityTag.filter_remind,  # 0x0217
+            CapabilityTag.ptc,  # 0x0219
+            CapabilityTag.strong_wind,  # 0x021A
+            CapabilityTag.humidity,  # 0x021F
+            CapabilityTag.filter_check,  # 0x0221
+            CapabilityTag.fahrenheit,  # 0x0222
+            CapabilityTag.screen_display_capability,  # 0x0224
         },
     )
 
     _default_query_params: tuple[int, ...] = (
-        NewProtocolTags.indirect_wind,
-        NewProtocolTags.breezeless,
-        NewProtocolTags.indoor_humidity,
-        NewProtocolTags.screen_display,
-        NewProtocolTags.fresh_air_1,
-        NewProtocolTags.fresh_air_2,
-        NewProtocolTags.wind_lr_angle,
-        NewProtocolTags.wind_ud_angle,
+        CapabilityTag.indirect_wind,
+        CapabilityTag.breezeless,
+        CapabilityTag.indoor_humidity,
+        CapabilityTag.screen_display,
+        CapabilityTag.fresh_air_1,
+        CapabilityTag.fresh_air_2,
+        CapabilityTag.wind_lr_angle,
+        CapabilityTag.wind_ud_angle,
     )
 
     def __init__(
@@ -516,7 +516,7 @@ class NewProtocolQuery(MessageACBase):
 
         `capabilities` is the device's merged capability map (B5-parsed values
         overlaid with the user's customize overrides). Every capability key that
-        names a NewProtocolTags member and is truthy is appended to the query,
+        names a CapabilityTag member and is truthy is appended to the query,
         so a device that never advertised a feature (or that a user disabled via
         customize) is not asked for it.
         """
@@ -536,18 +536,18 @@ class NewProtocolQuery(MessageACBase):
         default_tags = frozenset(self._default_query_params)
 
         # Auto-append tags from the merged capabilities map. A capability key is
-        # queried only when it names a NewProtocolTags member and its value is
+        # queried only when it names a CapabilityTag member and its value is
         # truthy, so a device that never advertised a feature (or that a user
         # disabled via customize) is not asked for it. Tags are sorted by value
         # so the produced body is deterministic.
-        additional_tags: list[NewProtocolTags] = []
+        additional_tags: list[CapabilityTag] = []
         for key, value in self._capabilities.items():
             if not value:
                 continue  # Skip falsy values (0, False, None).
             try:
-                tag = NewProtocolTags[key]
+                tag = CapabilityTag[key]
             except KeyError:
-                continue  # Key does not name a NewProtocolTags member.
+                continue  # Key does not name a CapabilityTag member.
             if tag in default_tags:
                 continue
             if tag in self._CAPABILITY_ONLY_TAGS:
@@ -558,9 +558,9 @@ class NewProtocolQuery(MessageACBase):
         if not self._build_logged:
             self._build_logged = True
             _LOGGER.debug(
-                "NewProtocolQuery build: appended=%s query_tags=%s capabilities=%s",
+                "PropertiesQuery build: appended=%s query_tags=%s capabilities=%s",
                 [tag.name for tag in additional_tags],
-                [NewProtocolTags(param).name for param in params],
+                [CapabilityTag(param).name for param in params],
                 self._capabilities,
             )
 
@@ -790,7 +790,7 @@ class SubProtocolFreshAirSet(MessageSubProtocol):
         return body
 
 
-class MessageSet(MessageACBase):
+class StateSet(MessageACBase):
     """AC message general set."""
 
     def __init__(self, protocol_version: int) -> None:
@@ -886,7 +886,7 @@ class MessageSet(MessageACBase):
         )
 
 
-class NewProtocolSet(MessageACBase):
+class PropertiesSet(MessageACBase):
     """AC message new protocol set."""
 
     def __init__(self, protocol_version: int) -> None:
@@ -919,7 +919,7 @@ class NewProtocolSet(MessageACBase):
             pack_count += 1
             payload.extend(
                 NewProtocolMessageBody.pack(
-                    param=NewProtocolTags.breezeless,
+                    param=CapabilityTag.breezeless,
                     value=bytearray([0x01 if self.breezeless else 0x00]),
                 ),
             )
@@ -927,7 +927,7 @@ class NewProtocolSet(MessageACBase):
             pack_count += 1
             payload.extend(
                 NewProtocolMessageBody.pack(
-                    param=NewProtocolTags.indirect_wind,
+                    param=CapabilityTag.indirect_wind,
                     value=bytearray([0x02 if self.indirect_wind else 0x01]),
                 ),
             )
@@ -935,7 +935,7 @@ class NewProtocolSet(MessageACBase):
             pack_count += 1
             payload.extend(
                 NewProtocolMessageBody.pack(
-                    param=NewProtocolTags.prompt_tone,
+                    param=CapabilityTag.prompt_tone,
                     value=bytearray([0x01 if self.prompt_tone else 0x00]),
                 ),
             )
@@ -943,7 +943,7 @@ class NewProtocolSet(MessageACBase):
             pack_count += 1
             payload.extend(
                 NewProtocolMessageBody.pack(
-                    param=NewProtocolTags.screen_display,
+                    param=CapabilityTag.screen_display,
                     value=bytearray([0x64 if self.screen_display_alternate else 0x00]),
                 ),
             )
@@ -953,7 +953,7 @@ class NewProtocolSet(MessageACBase):
             fresh_air_fan_speed = list(self.fresh_air_1)[1]
             payload.extend(
                 NewProtocolMessageBody.pack(
-                    param=NewProtocolTags.fresh_air_1,
+                    param=CapabilityTag.fresh_air_1,
                     value=bytearray(
                         [
                             fresh_air_power,
@@ -976,7 +976,7 @@ class NewProtocolSet(MessageACBase):
             fresh_air_fan_speed = list(self.fresh_air_2)[1]
             payload.extend(
                 NewProtocolMessageBody.pack(
-                    param=NewProtocolTags.fresh_air_2,
+                    param=CapabilityTag.fresh_air_2,
                     value=bytearray([fresh_air_power, fresh_air_fan_speed, 0xFF]),
                 ),
             )
@@ -985,7 +985,7 @@ class NewProtocolSet(MessageACBase):
             wind_lr_angle = int(self.wind_lr_angle)
             payload.extend(
                 NewProtocolMessageBody.pack(
-                    param=NewProtocolTags.wind_lr_angle,
+                    param=CapabilityTag.wind_lr_angle,
                     value=bytearray([wind_lr_angle if wind_lr_angle else 0x00]),
                 ),
             )
@@ -994,7 +994,7 @@ class NewProtocolSet(MessageACBase):
             wind_ud_angle = int(self.wind_ud_angle)
             payload.extend(
                 NewProtocolMessageBody.pack(
-                    param=NewProtocolTags.wind_ud_angle,
+                    param=CapabilityTag.wind_ud_angle,
                     value=bytearray([wind_ud_angle if wind_ud_angle else 0x00]),
                 ),
             )
@@ -1002,7 +1002,7 @@ class NewProtocolSet(MessageACBase):
             pack_count += 1
             payload.extend(
                 NewProtocolMessageBody.pack(
-                    param=NewProtocolTags.out_silent,
+                    param=CapabilityTag.out_silent,
                     # Device requires 0x03 to activate, 0x00 to deactivate
                     # Sending 0x01 results in an error from the firmware
                     value=bytearray([OUT_SILENT_VALUE if self.out_silent else 0x00]),
@@ -1012,7 +1012,7 @@ class NewProtocolSet(MessageACBase):
             pack_count += 1
             payload.extend(
                 NewProtocolMessageBody.pack(
-                    param=NewProtocolTags.sound,
+                    param=CapabilityTag.sound,
                     value=bytearray([0x01 if self.sound else 0x00]),
                 ),
             )
@@ -1020,7 +1020,7 @@ class NewProtocolSet(MessageACBase):
             pack_count += 1
             payload.extend(
                 NewProtocolMessageBody.pack(
-                    param=NewProtocolTags.self_clean,
+                    param=CapabilityTag.self_clean,
                     value=bytearray([0x01 if self.self_clean else 0x00]),
                 ),
             )
@@ -1028,7 +1028,7 @@ class NewProtocolSet(MessageACBase):
             pack_count += 1
             payload.extend(
                 NewProtocolMessageBody.pack(
-                    param=NewProtocolTags.rate_select,
+                    param=CapabilityTag.rate_select,
                     value=bytearray([int(self.rate_select)]),
                 ),
             )
@@ -1036,7 +1036,7 @@ class NewProtocolSet(MessageACBase):
             pack_count += 1
             payload.extend(
                 NewProtocolMessageBody.pack(
-                    param=NewProtocolTags.ieco,
+                    param=CapabilityTag.ieco,
                     # [frame, ieco_number, switch] followed by zero padding.
                     value=bytearray(
                         [0x00, self.ieco_number, 0x01 if self.ieco else 0x00],
@@ -1155,55 +1155,53 @@ class PropertiesBody(NewProtocolMessageBody):
         super().__init__(body)
 
         params = self.parse()
-        if NewProtocolTags.indirect_wind in params:
+        if CapabilityTag.indirect_wind in params:
             self.indirect_wind = (
-                params[NewProtocolTags.indirect_wind][0] == INDIRECT_WIND_VALUE
+                params[CapabilityTag.indirect_wind][0] == INDIRECT_WIND_VALUE
             )
-        if NewProtocolTags.indoor_humidity in params:
-            indoor_humidity = params[NewProtocolTags.indoor_humidity][0]
+        if CapabilityTag.indoor_humidity in params:
+            indoor_humidity = params[CapabilityTag.indoor_humidity][0]
             self.indoor_humidity = indoor_humidity if indoor_humidity != 0 else None
-        if NewProtocolTags.breezeless in params:
-            self.breezeless = params[NewProtocolTags.breezeless][0] == 1
-        if NewProtocolTags.screen_display in params:
-            self.screen_display_alternate = (
-                params[NewProtocolTags.screen_display][0] > 0
-            )
+        if CapabilityTag.breezeless in params:
+            self.breezeless = params[CapabilityTag.breezeless][0] == 1
+        if CapabilityTag.screen_display in params:
+            self.screen_display_alternate = params[CapabilityTag.screen_display][0] > 0
             self.screen_display_new = True
-        if NewProtocolTags.fresh_air_1 in params:
+        if CapabilityTag.fresh_air_1 in params:
             self.fresh_air_1 = True
-            data = params[NewProtocolTags.fresh_air_1]
+            data = params[CapabilityTag.fresh_air_1]
             self.fresh_air_power = data[0] == INDIRECT_WIND_VALUE
             self.fresh_air_fan_speed = data[1]
-        if NewProtocolTags.fresh_air_2 in params:
+        if CapabilityTag.fresh_air_2 in params:
             self.fresh_air_2 = True
-            data = params[NewProtocolTags.fresh_air_2]
+            data = params[CapabilityTag.fresh_air_2]
             self.fresh_air_power = data[0] > 0
             self.fresh_air_fan_speed = data[1]
-        if NewProtocolTags.wind_lr_angle in params:
-            self.wind_lr_angle = params[NewProtocolTags.wind_lr_angle][0]
-        if NewProtocolTags.wind_ud_angle in params:
-            self.wind_ud_angle = params[NewProtocolTags.wind_ud_angle][0]
-        if NewProtocolTags.rate_select in params:
-            self.rate_select = params[NewProtocolTags.rate_select][0]
-        if NewProtocolTags.out_silent in params:
-            self.out_silent = params[NewProtocolTags.out_silent][0] == OUT_SILENT_VALUE
-        if NewProtocolTags.sound in params:
-            self.sound = params[NewProtocolTags.sound][0] > 0
-        if NewProtocolTags.error_code in params:
-            self.error_code = params[NewProtocolTags.error_code][0]
-        if NewProtocolTags.self_clean in params and self.body_type != ListTypes.B5:
+        if CapabilityTag.wind_lr_angle in params:
+            self.wind_lr_angle = params[CapabilityTag.wind_lr_angle][0]
+        if CapabilityTag.wind_ud_angle in params:
+            self.wind_ud_angle = params[CapabilityTag.wind_ud_angle][0]
+        if CapabilityTag.rate_select in params:
+            self.rate_select = params[CapabilityTag.rate_select][0]
+        if CapabilityTag.out_silent in params:
+            self.out_silent = params[CapabilityTag.out_silent][0] == OUT_SILENT_VALUE
+        if CapabilityTag.sound in params:
+            self.sound = params[CapabilityTag.sound][0] > 0
+        if CapabilityTag.error_code in params:
+            self.error_code = params[CapabilityTag.error_code][0]
+        if CapabilityTag.self_clean in params and self.body_type != ListTypes.B5:
             # A B5 body carries this tag as a capability flag (always 1 when the
             # model supports self-clean), so only B0/B1 bodies report live state.
-            self.self_clean_active: bool = params[NewProtocolTags.self_clean][0] > 0
+            self.self_clean_active: bool = params[CapabilityTag.self_clean][0] > 0
         if (
-            NewProtocolTags.ieco in params
+            CapabilityTag.ieco in params
             and self.body_type != ListTypes.B5
-            and len(params[NewProtocolTags.ieco]) > 1
+            and len(params[CapabilityTag.ieco]) > 1
         ):
             # data[0] - iECO number (current gear), data[1] - on/off switch.
             # Only B0/B1 bodies report live state; a B5 body carries this tag as
             # a capability advertisement instead.
-            ieco_data = params[NewProtocolTags.ieco]
+            ieco_data = params[CapabilityTag.ieco]
             self.ieco = ieco_data[1] > 0
             self.ieco_number = ieco_data[0]
         if (
@@ -1281,8 +1279,8 @@ class CapabilityBody(NewProtocolMessageBody):
 
         params = self.parse()
         # Parse temperature capability for min/max setpoint limits
-        if NewProtocolTags.temperature in params:
-            temp_data = params[NewProtocolTags.temperature]
+        if CapabilityTag.temperature in params:
+            temp_data = params[CapabilityTag.temperature]
             # per-mode setpoint limits in 0.5 C units. the six raw bytes are
             # cool then auto then heat, each a min then a max, plus a flag byte.
             # keyed by mode value: auto is 1, cool 2, dry 3, heat 4, fan 5
@@ -1315,25 +1313,25 @@ class CapabilityBody(NewProtocolMessageBody):
         1. Manual parsing for tags with special logic (mode, wind_speed, etc.)
         2. Auto-parse remaining tags using tag name as key and raw value
 
-        Logs warnings for unknown tags not in NewProtocolTags enum.
+        Logs warnings for unknown tags not in CapabilityTag enum.
         """
         caps: dict[str, bool | int] = {}
 
         # Manual parsing for tags with complex/special logic
-        if NewProtocolTags.mode in params:
-            value = params[NewProtocolTags.mode][0]
+        if CapabilityTag.mode in params:
+            value = params[CapabilityTag.mode][0]
             caps["heat_mode"] = value in B5_HEAT_MODE_VALUES
             caps["cool_mode"] = value not in B5_NO_COOL_MODE_VALUES
             caps["dry_mode"] = value in B5_DRY_MODE_VALUES
             caps["auto_mode"] = value in B5_AUTO_MODE_VALUES
 
-        if NewProtocolTags.wind_swing in params:
-            value = params[NewProtocolTags.wind_swing][0]
+        if CapabilityTag.wind_swing in params:
+            value = params[CapabilityTag.wind_swing][0]
             caps["swing_horizontal"] = value in B5_SWING_HORIZONTAL_VALUES
             caps["swing_vertical"] = value < B5_LOW_VALUE_MAX
 
-        if NewProtocolTags.wind_speed in params:
-            value = params[NewProtocolTags.wind_speed][0]
+        if CapabilityTag.wind_speed in params:
+            value = params[CapabilityTag.wind_speed][0]
             caps["fan_silent"] = (
                 value == B5_FAN_CUSTOM_VALUE or value in B5_FAN_SILENT_VALUES
             )
@@ -1351,55 +1349,54 @@ class CapabilityBody(NewProtocolMessageBody):
             )
             caps["fan_custom"] = value == B5_FAN_CUSTOM_VALUE
 
-        if NewProtocolTags.eco in params:
-            caps["eco"] = params[NewProtocolTags.eco][0] in B5_ECO_VALUES
+        if CapabilityTag.eco in params:
+            caps["eco"] = params[CapabilityTag.eco][0] in B5_ECO_VALUES
 
-        if NewProtocolTags.anion in params:
-            caps["anion"] = params[NewProtocolTags.anion][0] == B5_ANION_ON_VALUE
+        if CapabilityTag.anion in params:
+            caps["anion"] = params[CapabilityTag.anion][0] == B5_ANION_ON_VALUE
 
-        if NewProtocolTags.strong_wind in params:
-            value = params[NewProtocolTags.strong_wind][0]
+        if CapabilityTag.strong_wind in params:
+            value = params[CapabilityTag.strong_wind][0]
             caps["turbo_cool"] = value < B5_LOW_VALUE_MAX
             caps["turbo_heat"] = value in B5_TURBO_HEAT_VALUES
 
-        if NewProtocolTags.screen_display_capability in params:
+        if CapabilityTag.screen_display_capability in params:
             caps["display_control"] = (
-                params[NewProtocolTags.screen_display_capability][0]
-                in B5_DISPLAY_VALUES
+                params[CapabilityTag.screen_display_capability][0] in B5_DISPLAY_VALUES
             )
 
-        if NewProtocolTags.electricity in params:
-            caps["rate_select"] = params[NewProtocolTags.electricity][0]
+        if CapabilityTag.electricity in params:
+            caps["rate_select"] = params[CapabilityTag.electricity][0]
 
-        if NewProtocolTags.self_clean in params:
-            caps["self_clean"] = params[NewProtocolTags.self_clean][0] > 0
+        if CapabilityTag.self_clean in params:
+            caps["self_clean"] = params[CapabilityTag.self_clean][0] > 0
 
-        if NewProtocolTags.ieco in params:
-            ieco_data = params[NewProtocolTags.ieco]
+        if CapabilityTag.ieco in params:
+            ieco_data = params[CapabilityTag.ieco]
             ieco_start = ieco_data[0] if len(ieco_data) > 0 else 0
             ieco_end = ieco_data[1] if len(ieco_data) > 1 else 0
             caps["ieco"] = (
                 ieco_start in B5_IECO_START_VALUES or ieco_end in B5_IECO_END_VALUES
             )
 
-        if NewProtocolTags.sound in params:
+        if CapabilityTag.sound in params:
             # B5 advertises support; live sound state comes from B0/B1 bodies.
             caps["sound"] = True
 
         # Tags with special parsing logic (handled above).
         manually_parsed_tags = frozenset(
             {
-                NewProtocolTags.mode,
-                NewProtocolTags.wind_swing,
-                NewProtocolTags.wind_speed,
-                NewProtocolTags.eco,
-                NewProtocolTags.anion,
-                NewProtocolTags.strong_wind,
-                NewProtocolTags.screen_display_capability,
-                NewProtocolTags.electricity,
-                NewProtocolTags.self_clean,
-                NewProtocolTags.ieco,
-                NewProtocolTags.sound,
+                CapabilityTag.mode,
+                CapabilityTag.wind_swing,
+                CapabilityTag.wind_speed,
+                CapabilityTag.eco,
+                CapabilityTag.anion,
+                CapabilityTag.strong_wind,
+                CapabilityTag.screen_display_capability,
+                CapabilityTag.electricity,
+                CapabilityTag.self_clean,
+                CapabilityTag.ieco,
+                CapabilityTag.sound,
             },
         )
 
@@ -1409,9 +1406,9 @@ class CapabilityBody(NewProtocolMessageBody):
                 continue  # Already handled above
 
             try:
-                tag_name = NewProtocolTags(tag_id).name
+                tag_name = CapabilityTag(tag_id).name
             except ValueError:
-                # Unknown tag entirely - not in NewProtocolTags enum.
+                # Unknown tag entirely - not in CapabilityTag enum.
                 _LOGGER.warning(
                     "Unknown capability tag in B5 response: 0x%04X, "
                     "Size: %d, Value: %s",

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -1131,6 +1131,13 @@ class TestMideaACDevice:
             self.device.set_swing(True, False)
             mock_build_send.assert_called()
 
+    def test_set_swing_subprotocol(self) -> None:
+        """Test set swing with subprotocol device."""
+        self.device._used_subprotocol = True
+        with patch.object(self.device, "send_message_v2") as mock_build_send:
+            self.device.set_swing(True, False)
+            mock_build_send.assert_called()
+
     def test_self_clean_syncs_from_self_clean_active(self) -> None:
         """Test that self_clean attribute tracks self_clean_active status reports."""
         with patch("midealan.devices.ac.MessageACResponse") as mock_message_response:

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -10,16 +10,16 @@ from midealan.devices.ac import DeviceAttributes, MideaACDevice
 from midealan.devices.ac.message import (
     CapabilitiesAdditionalQuery,
     CapabilitiesQuery,
+    CapabilityTag,
     GroupOneQuery,
     GroupSevenQuery,
     GroupTwoQuery,
     GroupZeroQuery,
     HumidityQuery,
-    MessageQuery,
-    NewProtocolQuery,
-    NewProtocolTags,
     PowerFormats,
     PowerQuery,
+    PropertiesQuery,
+    StateQuery,
     SubProtocolFreshAirSet,
     SubProtocolQuery,
     SubProtocolQuery10,
@@ -324,11 +324,11 @@ class TestMideaACDevice:
         self.device._used_subprotocol = False
         queries = self.device.build_query()
         # The new-protocol query and self-clean query are now a single merged
-        # NewProtocolQuery. Capability queries are no longer part of the
+        # PropertiesQuery. Capability queries are no longer part of the
         # recurring status cycle; they are returned by build_init_query().
         assert len(queries) == 8
-        assert isinstance(queries[0], MessageQuery)
-        assert isinstance(queries[1], NewProtocolQuery)
+        assert isinstance(queries[0], StateQuery)
+        assert isinstance(queries[1], PropertiesQuery)
         assert isinstance(queries[2], PowerQuery)
         assert isinstance(queries[3], HumidityQuery)
         assert isinstance(queries[4], GroupZeroQuery)
@@ -378,16 +378,16 @@ class TestMideaACDevice:
         self.device._used_subprotocol = False
         assert self.device.capabilities == {}
         queries = self.device.build_query()
-        new_protocol_query = next(q for q in queries if isinstance(q, NewProtocolQuery))
-        assert NewProtocolTags.rate_select not in new_protocol_query._body
-        assert NewProtocolTags.self_clean not in new_protocol_query._body
+        new_protocol_query = next(q for q in queries if isinstance(q, PropertiesQuery))
+        assert CapabilityTag.rate_select not in new_protocol_query._body
+        assert CapabilityTag.self_clean not in new_protocol_query._body
 
         self.device._capabilities["rate_select"] = True
         self.device._capabilities["self_clean"] = True
         queries = self.device.build_query()
-        new_protocol_query = next(q for q in queries if isinstance(q, NewProtocolQuery))
-        assert NewProtocolTags.rate_select in new_protocol_query._body
-        assert NewProtocolTags.self_clean in new_protocol_query._body
+        new_protocol_query = next(q for q in queries if isinstance(q, PropertiesQuery))
+        assert CapabilityTag.rate_select in new_protocol_query._body
+        assert CapabilityTag.self_clean in new_protocol_query._body
 
     def test_customize_capabilities_override_query_and_property(self) -> None:
         """Test a customize capabilities entry forces an optional tag on.
@@ -399,8 +399,8 @@ class TestMideaACDevice:
         self.device.set_customize('{"capabilities": {"self_clean": true}}')
         assert self.device.capabilities["self_clean"] is True
         queries = self.device.build_query()
-        new_protocol_query = next(q for q in queries if isinstance(q, NewProtocolQuery))
-        assert NewProtocolTags.self_clean in new_protocol_query._body
+        new_protocol_query = next(q for q in queries if isinstance(q, PropertiesQuery))
+        assert CapabilityTag.self_clean in new_protocol_query._body
 
     def test_customize_capabilities_disable_overrides_reported_value(self) -> None:
         """Test a customize false value overrides a B5-reported capability."""
@@ -409,8 +409,8 @@ class TestMideaACDevice:
         self.device.set_customize('{"capabilities": {"rate_select": false}}')
         assert self.device.capabilities["rate_select"] is False
         queries = self.device.build_query()
-        new_protocol_query = next(q for q in queries if isinstance(q, NewProtocolQuery))
-        assert NewProtocolTags.rate_select not in new_protocol_query._body
+        new_protocol_query = next(q for q in queries if isinstance(q, PropertiesQuery))
+        assert CapabilityTag.rate_select not in new_protocol_query._body
 
     def test_customize_capabilities_reset_when_absent(self) -> None:
         """Test customize capabilities clear when a later customize omits them."""
@@ -520,7 +520,7 @@ class TestMideaACDevice:
 
         assert DeviceAttributes.fresh_air_exhaust_power not in device.attributes
         queries = device.build_query()
-        assert isinstance(queries[0], MessageQuery)
+        assert isinstance(queries[0], StateQuery)
         assert not any(
             isinstance(
                 query,
@@ -1292,7 +1292,7 @@ class TestMideaACDevice:
         assert self.device._ieco_number == 1
 
     def test_set_ieco_echoes_reported_number(self) -> None:
-        """Test setting iECO builds a NewProtocolSet echoing the last gear."""
+        """Test setting iECO builds a PropertiesSet echoing the last gear."""
         self.device._ieco_number = 3
         with patch.object(self.device, "build_send") as mock_build_send:
             self.device.set_attribute(DeviceAttributes.ieco.value, True)
@@ -1302,7 +1302,7 @@ class TestMideaACDevice:
         assert message.ieco_number == 3
 
     def test_set_ieco_off(self) -> None:
-        """Test turning iECO off builds a NewProtocolSet with ieco False."""
+        """Test turning iECO off builds a PropertiesSet with ieco False."""
         with patch.object(self.device, "build_send") as mock_build_send:
             self.device.set_attribute(DeviceAttributes.ieco.value, False)
 

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -10,6 +10,7 @@ from midealan.devices.ac.message import (
     A1_MIN_BODY_LENGTH,
     CapabilitiesQuery,
     CapabilityBody,
+    CapabilityTag,
     GroupDataQuery,
     GroupOneQuery,
     GroupSevenQuery,
@@ -20,15 +21,14 @@ from midealan.devices.ac.message import (
     MessageA0Query,
     MessageACBase,
     MessageACResponse,
-    MessageQuery,
-    MessageSet,
     MessageSubProtocol,
     MessageSubProtocolSet,
-    NewProtocolQuery,
-    NewProtocolSet,
-    NewProtocolTags,
     PowerFormats,
     PowerQuery,
+    PropertiesQuery,
+    PropertiesSet,
+    StateQuery,
+    StateSet,
     SubProtocolFreshAirSet,
     SubProtocolQuery10,
     SubProtocolQuery11,
@@ -79,7 +79,7 @@ class TestMessageQuery:
 
     def test_query_body(self) -> None:
         """Test query body."""
-        msg = MessageQuery(protocol_version=ProtocolVersion.V1)
+        msg = StateQuery(protocol_version=ProtocolVersion.V1)
         expected_body = bytearray(
             [
                 0x41,
@@ -268,29 +268,29 @@ class TestNewProtocolQuery:
         via the B5 b5_electricity capability; devices that never advertise it
         don't answer the query.
         """
-        msg = NewProtocolQuery(protocol_version=ProtocolVersion.V1)
+        msg = PropertiesQuery(protocol_version=ProtocolVersion.V1)
         expected_body = bytearray(
             [
                 0xB1,
                 0x08,  # params count
-                NewProtocolTags.indirect_wind & 0xFF,
-                NewProtocolTags.indirect_wind >> 8,
-                NewProtocolTags.breezeless & 0xFF,
-                NewProtocolTags.breezeless >> 8,
-                NewProtocolTags.indoor_humidity & 0xFF,
-                NewProtocolTags.indoor_humidity >> 8,
-                NewProtocolTags.screen_display & 0xFF,
-                NewProtocolTags.screen_display >> 8,
-                NewProtocolTags.fresh_air_1 & 0xFF,
-                NewProtocolTags.fresh_air_1 >> 8,
-                NewProtocolTags.fresh_air_2 & 0xFF,
-                NewProtocolTags.fresh_air_2 >> 8,
-                NewProtocolTags.wind_lr_angle & 0xFF,
-                NewProtocolTags.wind_lr_angle >> 8,
-                NewProtocolTags.wind_ud_angle & 0xFF,
-                NewProtocolTags.wind_ud_angle >> 8,
-                # NewProtocolTags.error_code & 0xFF,
-                # NewProtocolTags.error_code >> 8,
+                CapabilityTag.indirect_wind & 0xFF,
+                CapabilityTag.indirect_wind >> 8,
+                CapabilityTag.breezeless & 0xFF,
+                CapabilityTag.breezeless >> 8,
+                CapabilityTag.indoor_humidity & 0xFF,
+                CapabilityTag.indoor_humidity >> 8,
+                CapabilityTag.screen_display & 0xFF,
+                CapabilityTag.screen_display >> 8,
+                CapabilityTag.fresh_air_1 & 0xFF,
+                CapabilityTag.fresh_air_1 >> 8,
+                CapabilityTag.fresh_air_2 & 0xFF,
+                CapabilityTag.fresh_air_2 >> 8,
+                CapabilityTag.wind_lr_angle & 0xFF,
+                CapabilityTag.wind_lr_angle >> 8,
+                CapabilityTag.wind_ud_angle & 0xFF,
+                CapabilityTag.wind_ud_angle >> 8,
+                # CapabilityTag.error_code & 0xFF,
+                # CapabilityTag.error_code >> 8,
             ],
         )
 
@@ -300,7 +300,7 @@ class TestNewProtocolQuery:
         self,
     ) -> None:
         """Test rate_select is appended once the capabilities map confirms it."""
-        msg = NewProtocolQuery(
+        msg = PropertiesQuery(
             protocol_version=ProtocolVersion.V1,
             capabilities={"rate_select": 1},
         )
@@ -308,24 +308,24 @@ class TestNewProtocolQuery:
             [
                 0xB1,
                 0x09,  # params count (8 default + rate_select)
-                NewProtocolTags.indirect_wind & 0xFF,
-                NewProtocolTags.indirect_wind >> 8,
-                NewProtocolTags.breezeless & 0xFF,
-                NewProtocolTags.breezeless >> 8,
-                NewProtocolTags.indoor_humidity & 0xFF,
-                NewProtocolTags.indoor_humidity >> 8,
-                NewProtocolTags.screen_display & 0xFF,
-                NewProtocolTags.screen_display >> 8,
-                NewProtocolTags.fresh_air_1 & 0xFF,
-                NewProtocolTags.fresh_air_1 >> 8,
-                NewProtocolTags.fresh_air_2 & 0xFF,
-                NewProtocolTags.fresh_air_2 >> 8,
-                NewProtocolTags.wind_lr_angle & 0xFF,
-                NewProtocolTags.wind_lr_angle >> 8,
-                NewProtocolTags.wind_ud_angle & 0xFF,
-                NewProtocolTags.wind_ud_angle >> 8,
-                NewProtocolTags.rate_select & 0xFF,
-                NewProtocolTags.rate_select >> 8,
+                CapabilityTag.indirect_wind & 0xFF,
+                CapabilityTag.indirect_wind >> 8,
+                CapabilityTag.breezeless & 0xFF,
+                CapabilityTag.breezeless >> 8,
+                CapabilityTag.indoor_humidity & 0xFF,
+                CapabilityTag.indoor_humidity >> 8,
+                CapabilityTag.screen_display & 0xFF,
+                CapabilityTag.screen_display >> 8,
+                CapabilityTag.fresh_air_1 & 0xFF,
+                CapabilityTag.fresh_air_1 >> 8,
+                CapabilityTag.fresh_air_2 & 0xFF,
+                CapabilityTag.fresh_air_2 >> 8,
+                CapabilityTag.wind_lr_angle & 0xFF,
+                CapabilityTag.wind_lr_angle >> 8,
+                CapabilityTag.wind_ud_angle & 0xFF,
+                CapabilityTag.wind_ud_angle >> 8,
+                CapabilityTag.rate_select & 0xFF,
+                CapabilityTag.rate_select >> 8,
             ],
         )
 
@@ -335,7 +335,7 @@ class TestNewProtocolQuery:
         self,
     ) -> None:
         """Test self_clean is appended when the capabilities map confirms it."""
-        msg = NewProtocolQuery(
+        msg = PropertiesQuery(
             protocol_version=ProtocolVersion.V1,
             capabilities={"self_clean": True},
         )
@@ -343,24 +343,24 @@ class TestNewProtocolQuery:
             [
                 0xB1,
                 0x09,  # params count (8 default + self_clean)
-                NewProtocolTags.indirect_wind & 0xFF,
-                NewProtocolTags.indirect_wind >> 8,
-                NewProtocolTags.breezeless & 0xFF,
-                NewProtocolTags.breezeless >> 8,
-                NewProtocolTags.indoor_humidity & 0xFF,
-                NewProtocolTags.indoor_humidity >> 8,
-                NewProtocolTags.screen_display & 0xFF,
-                NewProtocolTags.screen_display >> 8,
-                NewProtocolTags.fresh_air_1 & 0xFF,
-                NewProtocolTags.fresh_air_1 >> 8,
-                NewProtocolTags.fresh_air_2 & 0xFF,
-                NewProtocolTags.fresh_air_2 >> 8,
-                NewProtocolTags.wind_lr_angle & 0xFF,
-                NewProtocolTags.wind_lr_angle >> 8,
-                NewProtocolTags.wind_ud_angle & 0xFF,
-                NewProtocolTags.wind_ud_angle >> 8,
-                NewProtocolTags.self_clean & 0xFF,
-                NewProtocolTags.self_clean >> 8,
+                CapabilityTag.indirect_wind & 0xFF,
+                CapabilityTag.indirect_wind >> 8,
+                CapabilityTag.breezeless & 0xFF,
+                CapabilityTag.breezeless >> 8,
+                CapabilityTag.indoor_humidity & 0xFF,
+                CapabilityTag.indoor_humidity >> 8,
+                CapabilityTag.screen_display & 0xFF,
+                CapabilityTag.screen_display >> 8,
+                CapabilityTag.fresh_air_1 & 0xFF,
+                CapabilityTag.fresh_air_1 >> 8,
+                CapabilityTag.fresh_air_2 & 0xFF,
+                CapabilityTag.fresh_air_2 >> 8,
+                CapabilityTag.wind_lr_angle & 0xFF,
+                CapabilityTag.wind_lr_angle >> 8,
+                CapabilityTag.wind_ud_angle & 0xFF,
+                CapabilityTag.wind_ud_angle >> 8,
+                CapabilityTag.self_clean & 0xFF,
+                CapabilityTag.self_clean >> 8,
             ],
         )
 
@@ -368,7 +368,7 @@ class TestNewProtocolQuery:
 
     def test_new_protocol_query_body_appends_optional_tags_in_order(self) -> None:
         """Test both optional tags append in sorted (by tag value) order."""
-        msg = NewProtocolQuery(
+        msg = PropertiesQuery(
             protocol_version=ProtocolVersion.V1,
             capabilities={"rate_select": 2, "self_clean": True},
         )
@@ -377,32 +377,32 @@ class TestNewProtocolQuery:
         # then rate_select (0x48).
         assert msg.body[:-2][-4:] == bytearray(
             [
-                NewProtocolTags.self_clean & 0xFF,
-                NewProtocolTags.self_clean >> 8,
-                NewProtocolTags.rate_select & 0xFF,
-                NewProtocolTags.rate_select >> 8,
+                CapabilityTag.self_clean & 0xFF,
+                CapabilityTag.self_clean >> 8,
+                CapabilityTag.rate_select & 0xFF,
+                CapabilityTag.rate_select >> 8,
             ],
         )
 
     def test_new_protocol_query_body_omits_optional_tags_when_falsy(self) -> None:
         """Test falsy capability values keep the optional tags out of the body."""
-        msg = NewProtocolQuery(
+        msg = PropertiesQuery(
             protocol_version=ProtocolVersion.V1,
             capabilities={"self_clean": False, "rate_select": 0},
         )
         params_count = msg.body[1]
-        assert params_count == len(NewProtocolQuery._default_query_params)
-        assert NewProtocolTags.self_clean not in msg.body
-        assert NewProtocolTags.rate_select not in msg.body
+        assert params_count == len(PropertiesQuery._default_query_params)
+        assert CapabilityTag.self_clean not in msg.body
+        assert CapabilityTag.rate_select not in msg.body
 
     def test_new_protocol_query_body_appends_all_known_tags(self) -> None:
-        """Test any truthy capability key naming a NewProtocolTags member appends.
+        """Test any truthy capability key naming a CapabilityTag member appends.
 
-        Capability keys are appended whenever they name a NewProtocolTags
+        Capability keys are appended whenever they name a CapabilityTag
         member and are truthy, sorted by tag value. Keys already in the default
         list are not duplicated. Capability-only tags (poisoners) are blocked.
         """
-        msg = NewProtocolQuery(
+        msg = PropertiesQuery(
             protocol_version=ProtocolVersion.V1,
             capabilities={
                 "temperature": 34,
@@ -416,32 +416,32 @@ class TestNewProtocolQuery:
         params_count = msg.body[1]
         # Only 3 tags appended: self_clean (0x0039), temperature (0x0225),
         # sound (0x022C). eco/filter_remind/humidity are blocked.
-        assert params_count == len(NewProtocolQuery._default_query_params) + 3
+        assert params_count == len(PropertiesQuery._default_query_params) + 3
         # Appended tags come after the default list, sorted by value:
         # self_clean 0x0039, temperature 0x0225, sound 0x022C.
         assert msg.body[:-2][-6:] == bytearray(
             [
-                NewProtocolTags.self_clean & 0xFF,
-                NewProtocolTags.self_clean >> 8,
-                NewProtocolTags.temperature & 0xFF,
-                NewProtocolTags.temperature >> 8,
-                NewProtocolTags.sound & 0xFF,
-                NewProtocolTags.sound >> 8,
+                CapabilityTag.self_clean & 0xFF,
+                CapabilityTag.self_clean >> 8,
+                CapabilityTag.temperature & 0xFF,
+                CapabilityTag.temperature >> 8,
+                CapabilityTag.sound & 0xFF,
+                CapabilityTag.sound >> 8,
             ],
         )
 
     def test_new_protocol_query_body_ignores_unknown_capability_keys(self) -> None:
-        """Test capability keys that name no NewProtocolTags member are skipped.
+        """Test capability keys that name no CapabilityTag member are skipped.
 
         Manually-parsed capability keys (heat_mode, fan_low, ...) are not tag
         names and must not raise or be appended to the query.
         """
-        msg = NewProtocolQuery(
+        msg = PropertiesQuery(
             protocol_version=ProtocolVersion.V1,
             capabilities={"heat_mode": True, "fan_low": True, "cool_mode": True},
         )
         params_count = msg.body[1]
-        assert params_count == len(NewProtocolQuery._default_query_params)
+        assert params_count == len(PropertiesQuery._default_query_params)
 
     def test_new_protocol_query_body_blocks_capability_only_poisoners(self) -> None:
         """Test B5-only poisoner tags never appear in B1 query even when truthy.
@@ -451,7 +451,7 @@ class TestNewProtocolQuery:
         dict echoes them from B5 parsing.
         """
         # All 13 capability-only tags from the blocklist.
-        msg = NewProtocolQuery(
+        msg = PropertiesQuery(
             protocol_version=ProtocolVersion.V1,
             capabilities={
                 "wind_speed": 1,
@@ -471,50 +471,50 @@ class TestNewProtocolQuery:
         )
         params_count = msg.body[1]
         # None of the 13 poisoners should be appended.
-        assert params_count == len(NewProtocolQuery._default_query_params)
+        assert params_count == len(PropertiesQuery._default_query_params)
 
     def test_new_protocol_query_sound_appends_when_b5_advertises(self) -> None:
         """Test sound appends when B5 capability parsing sets it to True."""
-        msg = NewProtocolQuery(
+        msg = PropertiesQuery(
             protocol_version=ProtocolVersion.V1,
             capabilities={"sound": True},
         )
         params_count = msg.body[1]
-        assert params_count == len(NewProtocolQuery._default_query_params) + 1
+        assert params_count == len(PropertiesQuery._default_query_params) + 1
         assert msg.body[:-2][-2:] == bytearray(
             [
-                NewProtocolTags.sound & 0xFF,
-                NewProtocolTags.sound >> 8,
+                CapabilityTag.sound & 0xFF,
+                CapabilityTag.sound >> 8,
             ],
         )
 
     def test_new_protocol_query_out_silent_via_customize_only(self) -> None:
         """Test out_silent appends only when explicitly set via customize caps."""
-        msg = NewProtocolQuery(
+        msg = PropertiesQuery(
             protocol_version=ProtocolVersion.V1,
             capabilities={"out_silent": True},
         )
         params_count = msg.body[1]
-        assert params_count == len(NewProtocolQuery._default_query_params) + 1
+        assert params_count == len(PropertiesQuery._default_query_params) + 1
         assert msg.body[:-2][-2:] == bytearray(
             [
-                NewProtocolTags.out_silent & 0xFF,
-                NewProtocolTags.out_silent >> 8,
+                CapabilityTag.out_silent & 0xFF,
+                CapabilityTag.out_silent >> 8,
             ],
         )
 
     def test_new_protocol_query_error_code_via_customize_only(self) -> None:
         """Test error_code appends only when explicitly set via customize caps."""
-        msg = NewProtocolQuery(
+        msg = PropertiesQuery(
             protocol_version=ProtocolVersion.V1,
             capabilities={"error_code": True},
         )
         params_count = msg.body[1]
-        assert params_count == len(NewProtocolQuery._default_query_params) + 1
+        assert params_count == len(PropertiesQuery._default_query_params) + 1
         assert msg.body[:-2][-2:] == bytearray(
             [
-                NewProtocolTags.error_code & 0xFF,
-                NewProtocolTags.error_code >> 8,
+                CapabilityTag.error_code & 0xFF,
+                CapabilityTag.error_code >> 8,
             ],
         )
 
@@ -522,16 +522,16 @@ class TestNewProtocolQuery:
         """Test that a truthy capability key matching a default tag is skipped."""
         # fresh_air_1 is in _default_query_params; even if caps["fresh_air_1"]
         # is truthy, it must not be appended a second time.
-        msg = NewProtocolQuery(
+        msg = PropertiesQuery(
             protocol_version=ProtocolVersion.V1,
             capabilities={"fresh_air_1": True},
         )
         params_count = msg.body[1]
         # Count should equal defaults (no additional tag appended).
-        assert params_count == len(NewProtocolQuery._default_query_params)
+        assert params_count == len(PropertiesQuery._default_query_params)
         # Verify fresh_air_1 appears exactly once in the body.
         tag_bytes = bytearray(
-            [NewProtocolTags.fresh_air_1 & 0xFF, NewProtocolTags.fresh_air_1 >> 8],
+            [CapabilityTag.fresh_air_1 & 0xFF, CapabilityTag.fresh_air_1 >> 8],
         )
         body_hex = msg.body[:-2].hex()
         assert body_hex.count(tag_bytes.hex()) == 1
@@ -552,12 +552,12 @@ class TestCapabilityBodyParsing:
             [
                 0xB5,
                 0x02,  # 2 params
-                NewProtocolTags.eco & 0xFF,
-                NewProtocolTags.eco >> 8,
+                CapabilityTag.eco & 0xFF,
+                CapabilityTag.eco >> 8,
                 0x01,  # length
                 0x01,  # eco supported
-                NewProtocolTags.filter_remind & 0xFF,
-                NewProtocolTags.filter_remind >> 8,
+                CapabilityTag.filter_remind & 0xFF,
+                CapabilityTag.filter_remind >> 8,
                 0x01,  # length
                 0x01,  # filter_remind supported
             ],
@@ -570,10 +570,10 @@ class TestCapabilityBodyParsing:
         assert "filter_remind" in caps
 
         # Now build a query with those capabilities.
-        msg = NewProtocolQuery(protocol_version=ProtocolVersion.V1, capabilities=caps)
+        msg = PropertiesQuery(protocol_version=ProtocolVersion.V1, capabilities=caps)
         params_count = msg.body[1]
         # Neither eco nor filter_remind should be in the query (blocked).
-        assert params_count == len(NewProtocolQuery._default_query_params)
+        assert params_count == len(PropertiesQuery._default_query_params)
 
     def test_b5_sound_presence_yields_true_capability(self) -> None:
         """Test B5 sound presence sets caps['sound'] = True."""
@@ -582,8 +582,8 @@ class TestCapabilityBodyParsing:
             [
                 0xB5,
                 0x01,  # 1 param
-                NewProtocolTags.sound & 0xFF,
-                NewProtocolTags.sound >> 8,
+                CapabilityTag.sound & 0xFF,
+                CapabilityTag.sound >> 8,
                 0x01,  # length
                 0x00,  # raw value 0 (but presence -> True)
             ],
@@ -594,9 +594,9 @@ class TestCapabilityBodyParsing:
         assert caps.get("sound") is True
 
         # Query with this capability should include sound.
-        msg = NewProtocolQuery(protocol_version=ProtocolVersion.V1, capabilities=caps)
+        msg = PropertiesQuery(protocol_version=ProtocolVersion.V1, capabilities=caps)
         params_count = msg.body[1]
-        assert params_count == len(NewProtocolQuery._default_query_params) + 1
+        assert params_count == len(PropertiesQuery._default_query_params) + 1
 
 
 class TestNewProtocolSetOutSilent:
@@ -608,19 +608,19 @@ class TestNewProtocolSetOutSilent:
     )
     def test_out_silent_on_off(self, value: bool, expected_byte: int) -> None:
         """Test out_silent set to on/off sends correct byte."""
-        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = PropertiesSet(protocol_version=ProtocolVersion.V1)
         msg.out_silent = value
         body = msg.body
         assert body[0] == 0xB0
         assert body[1] == 0x01  # 1 param packed
-        assert body[2] == NewProtocolTags.out_silent & 0xFF  # 0xCD
-        assert body[3] == NewProtocolTags.out_silent >> 8  # 0x00
+        assert body[2] == CapabilityTag.out_silent & 0xFF  # 0xCD
+        assert body[3] == CapabilityTag.out_silent >> 8  # 0x00
         assert body[4] == 0x01  # length byte
         assert body[5] == expected_byte
 
     def test_out_silent_none_not_packed(self) -> None:
         """Test out_silent None does not add to payload."""
-        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = PropertiesSet(protocol_version=ProtocolVersion.V1)
         # out_silent defaults to None, should not be packed
         body = msg.body
         assert body[0] == 0xB0
@@ -636,14 +636,14 @@ class TestNewProtocolSetAngles:
     )
     def test_wind_lr_angle(self, value: int, expected_byte: int) -> None:
         """Test wind_lr_angle set sends correct byte."""
-        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = PropertiesSet(protocol_version=ProtocolVersion.V1)
         # source annotates wind_lr_angle as bytes | None but the device sets ints
         setattr(msg, "wind_lr_angle", value)  # noqa: B010
         body = msg.body
         assert body[0] == 0xB0
         assert body[1] == 0x01  # 1 param packed
-        assert body[2] == NewProtocolTags.wind_lr_angle & 0xFF  # 0x0A
-        assert body[3] == NewProtocolTags.wind_lr_angle >> 8  # 0x00
+        assert body[2] == CapabilityTag.wind_lr_angle & 0xFF  # 0x0A
+        assert body[3] == CapabilityTag.wind_lr_angle >> 8  # 0x00
         assert body[4] == 0x01  # length byte
         assert body[5] == expected_byte
 
@@ -653,26 +653,26 @@ class TestNewProtocolSetAngles:
     )
     def test_wind_ud_angle(self, value: int, expected_byte: int) -> None:
         """Test wind_ud_angle set sends correct byte."""
-        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = PropertiesSet(protocol_version=ProtocolVersion.V1)
         # source annotates wind_ud_angle as bytes | None but the device sets ints
         setattr(msg, "wind_ud_angle", value)  # noqa: B010
         body = msg.body
         assert body[0] == 0xB0
         assert body[1] == 0x01  # 1 param packed
-        assert body[2] == NewProtocolTags.wind_ud_angle & 0xFF  # 0x09
-        assert body[3] == NewProtocolTags.wind_ud_angle >> 8  # 0x00
+        assert body[2] == CapabilityTag.wind_ud_angle & 0xFF  # 0x09
+        assert body[3] == CapabilityTag.wind_ud_angle >> 8  # 0x00
         assert body[4] == 0x01  # length byte
         assert body[5] == expected_byte
 
     def test_rate_select(self) -> None:
         """Test rate_select set sends correct byte."""
-        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = PropertiesSet(protocol_version=ProtocolVersion.V1)
         msg.rate_select = 60
         body = msg.body
         assert body[0] == 0xB0
         assert body[1] == 0x01  # 1 param packed
-        assert body[2] == NewProtocolTags.rate_select & 0xFF  # 0x48
-        assert body[3] == NewProtocolTags.rate_select >> 8  # 0x00
+        assert body[2] == CapabilityTag.rate_select & 0xFF  # 0x48
+        assert body[3] == CapabilityTag.rate_select >> 8  # 0x00
         assert body[4] == 0x01  # length byte
         assert body[5] == 60
 
@@ -876,7 +876,7 @@ class TestMessageSet:
 
     def test_general_set_body(self) -> None:
         """Test general set body."""
-        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg = StateSet(protocol_version=ProtocolVersion.V1)
         expected_body = bytearray(
             [
                 0x40,
@@ -1128,24 +1128,24 @@ class TestMessageACResponse:
         body = bytearray(29)
         body[0] = 0xB0  # Body type
         body[1] = 0x05  # Params count
-        body[2] = NewProtocolTags.indirect_wind & 0xFF  # Low byte param
-        body[3] = NewProtocolTags.indirect_wind >> 8  # High byte param
+        body[2] = CapabilityTag.indirect_wind & 0xFF  # Low byte param
+        body[3] = CapabilityTag.indirect_wind >> 8  # High byte param
         body[5] = 0x01  # Value length
         body[6] = 0x02  # Value True
-        body[7] = NewProtocolTags.indoor_humidity & 0xFF  # Low byte param
-        body[8] = NewProtocolTags.indoor_humidity >> 8  # High byte param
+        body[7] = CapabilityTag.indoor_humidity & 0xFF  # Low byte param
+        body[8] = CapabilityTag.indoor_humidity >> 8  # High byte param
         body[10] = 0x01  # Value length
         body[11] = 30  # Value 30
-        body[12] = NewProtocolTags.breezeless & 0xFF  # Low byte param
-        body[13] = NewProtocolTags.breezeless >> 8  # High byte param
+        body[12] = CapabilityTag.breezeless & 0xFF  # Low byte param
+        body[13] = CapabilityTag.breezeless >> 8  # High byte param
         body[15] = 0x01  # Value length
         body[16] = 0x01  # Value True
-        body[17] = NewProtocolTags.screen_display & 0xFF  # Low byte param
-        body[18] = NewProtocolTags.screen_display >> 8  # High byte param
+        body[17] = CapabilityTag.screen_display & 0xFF  # Low byte param
+        body[18] = CapabilityTag.screen_display >> 8  # High byte param
         body[20] = 0x01  # Value length
         body[21] = 0x01  # Value True
-        body[22] = NewProtocolTags.fresh_air_1 & 0xFF  # Low byte param
-        body[23] = NewProtocolTags.fresh_air_1 >> 8  # High byte param
+        body[22] = CapabilityTag.fresh_air_1 & 0xFF  # Low byte param
+        body[23] = CapabilityTag.fresh_air_1 >> 8  # High byte param
         body[25] = 0x02  # Value length
         body[26] = 0x02  # Value Power True
         body[27] = 10  # Value Speed 10
@@ -1163,8 +1163,8 @@ class TestMessageACResponse:
         assert hasattr(response, "fresh_air_fan_speed")
         assert response.fresh_air_fan_speed == 10
 
-        body[22] = NewProtocolTags.fresh_air_2 & 0xFF  # Low byte param
-        body[23] = NewProtocolTags.fresh_air_2 >> 8  # High byte param
+        body[22] = CapabilityTag.fresh_air_2 & 0xFF  # Low byte param
+        body[23] = CapabilityTag.fresh_air_2 >> 8  # High byte param
         body[25] = 0x02  # Value length
         body[26] = 0x01  # Value Power True
         body[27] = 20  # Value Speed 20
@@ -1181,8 +1181,8 @@ class TestMessageACResponse:
         body = bytearray(10)
         body[0] = 0xB0  # Body type
         body[1] = 0x01  # Params count
-        body[2] = NewProtocolTags.rate_select & 0xFF  # Low byte 0x48
-        body[3] = NewProtocolTags.rate_select >> 8  # High byte 0x00
+        body[2] = CapabilityTag.rate_select & 0xFF  # Low byte 0x48
+        body[3] = CapabilityTag.rate_select >> 8  # High byte 0x00
         body[4] = 0x00  # Padding
         body[5] = 0x01  # Value length
         body[6] = 40  # Value 40
@@ -1367,7 +1367,7 @@ class TestMessageACResponse:
         body = bytearray([0xB5, 0x02])  # Body type, 2 params
         # Add a known tag (b5_mode)
         body += bytearray([0x14, 0x02, 0x01, 7])  # b5_mode
-        # Add an unknown B5-range tag (0x0299, not in NewProtocolTags)
+        # Add an unknown B5-range tag (0x0299, not in CapabilityTag)
         body += bytearray([0x99, 0x02, 0x01, 0x42])
         body += bytearray(1)  # trailing checksum byte
 
@@ -1396,8 +1396,8 @@ class TestMessageACResponse:
         body = bytearray(10)
         body[0] = 0xB0  # Body type
         body[1] = 0x01  # Params count
-        body[2] = NewProtocolTags.out_silent & 0xFF  # Low byte 0xCD
-        body[3] = NewProtocolTags.out_silent >> 8  # High byte 0x00
+        body[2] = CapabilityTag.out_silent & 0xFF  # Low byte 0xCD
+        body[3] = CapabilityTag.out_silent >> 8  # High byte 0x00
         body[4] = 0x00  # Padding
         body[5] = 0x01  # Value length
         body[6] = raw_value
@@ -1422,8 +1422,8 @@ class TestMessageACResponse:
             [
                 0xB1,  # Body type
                 0x01,  # Params count
-                NewProtocolTags.self_clean & 0xFF,
-                NewProtocolTags.self_clean >> 8,
+                CapabilityTag.self_clean & 0xFF,
+                CapabilityTag.self_clean >> 8,
                 0x00,
                 0x01,  # Value length
                 raw_value,
@@ -1443,8 +1443,8 @@ class TestMessageACResponse:
             [
                 0xB5,  # Body type
                 0x01,  # Params count
-                NewProtocolTags.self_clean & 0xFF,
-                NewProtocolTags.self_clean >> 8,
+                CapabilityTag.self_clean & 0xFF,
+                CapabilityTag.self_clean >> 8,
                 0x01,  # Value length
                 0x01,  # Capability: supported
                 0x00,  # trailing checksum byte (stripped by MessageResponse)
@@ -1507,8 +1507,8 @@ class TestMessageACResponse:
             [
                 0xB1,  # Body type
                 0x01,  # Params count
-                NewProtocolTags.ieco & 0xFF,
-                NewProtocolTags.ieco >> 8,
+                CapabilityTag.ieco & 0xFF,
+                CapabilityTag.ieco >> 8,
                 0x00,
                 0x02,  # Value length
                 number,  # data[0] - iECO number
@@ -1529,8 +1529,8 @@ class TestMessageACResponse:
             [
                 0xB5,  # Body type
                 0x01,  # Params count
-                NewProtocolTags.ieco & 0xFF,
-                NewProtocolTags.ieco >> 8,
+                CapabilityTag.ieco & 0xFF,
+                CapabilityTag.ieco >> 8,
                 0x02,  # Value length
                 0x01,  # start byte: supported
                 0x01,  # end byte
@@ -2178,8 +2178,8 @@ class TestMessageACResponse:
         body = bytearray(10)
         body[0] = 0xB1
         body[1] = 0x01  # 1 param
-        body[2] = NewProtocolTags.error_code & 0xFF
-        body[3] = NewProtocolTags.error_code >> 8
+        body[2] = CapabilityTag.error_code & 0xFF
+        body[3] = CapabilityTag.error_code >> 8
         body[4] = 0x00  # padding
         body[5] = 0x01  # length
         body[6] = 0x05  # error code 5
@@ -2193,8 +2193,8 @@ class TestMessageACResponse:
         body = bytearray(10)
         body[0] = 0xB1
         body[1] = 0x01
-        body[2] = NewProtocolTags.sound & 0xFF
-        body[3] = NewProtocolTags.sound >> 8
+        body[2] = CapabilityTag.sound & 0xFF
+        body[3] = CapabilityTag.sound >> 8
         body[4] = 0x00
         body[5] = 0x01
         body[6] = 0x01  # sound on
@@ -2506,7 +2506,7 @@ class TestMessageACResponse:
 
 
 class TestNewProtocolSetNewFeatures:
-    """Test NewProtocolSet for sound and self_clean."""
+    """Test PropertiesSet for sound and self_clean."""
 
     @pytest.mark.parametrize(
         ("value", "expected_byte"),
@@ -2514,13 +2514,13 @@ class TestNewProtocolSetNewFeatures:
     )
     def test_sound_on_off(self, value: bool, expected_byte: int) -> None:
         """Test sound set to on/off sends correct byte."""
-        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = PropertiesSet(protocol_version=ProtocolVersion.V1)
         msg.sound = value
         body = msg.body
         assert body[0] == 0xB0
         assert body[1] == 0x01
-        assert body[2] == NewProtocolTags.sound & 0xFF
-        assert body[3] == NewProtocolTags.sound >> 8
+        assert body[2] == CapabilityTag.sound & 0xFF
+        assert body[3] == CapabilityTag.sound >> 8
         assert body[4] == 0x01
         assert body[5] == expected_byte
 
@@ -2530,19 +2530,19 @@ class TestNewProtocolSetNewFeatures:
     )
     def test_self_clean_on_off(self, value: bool, expected_byte: int) -> None:
         """Test self_clean set to on/off sends correct byte."""
-        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = PropertiesSet(protocol_version=ProtocolVersion.V1)
         msg.self_clean = value
         body = msg.body
         assert body[0] == 0xB0
         assert body[1] == 0x01
-        assert body[2] == NewProtocolTags.self_clean & 0xFF
-        assert body[3] == NewProtocolTags.self_clean >> 8
+        assert body[2] == CapabilityTag.self_clean & 0xFF
+        assert body[3] == CapabilityTag.self_clean >> 8
         assert body[4] == 0x01
         assert body[5] == expected_byte
 
 
 class TestNewProtocolSetIeco:
-    """Test NewProtocolSet for iECO."""
+    """Test PropertiesSet for iECO."""
 
     @pytest.mark.parametrize(
         ("value", "expected_switch"),
@@ -2550,14 +2550,14 @@ class TestNewProtocolSetIeco:
     )
     def test_ieco_on_off(self, value: bool, expected_switch: int) -> None:
         """Test iECO set to on/off sends the frame/number/switch payload."""
-        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = PropertiesSet(protocol_version=ProtocolVersion.V1)
         msg.ieco = value
         msg.ieco_number = 3
         body = msg.body
         assert body[0] == 0xB0
         assert body[1] == 0x01  # pack count
-        assert body[2] == NewProtocolTags.ieco & 0xFF
-        assert body[3] == NewProtocolTags.ieco >> 8
+        assert body[2] == CapabilityTag.ieco & 0xFF
+        assert body[3] == CapabilityTag.ieco >> 8
         assert body[4] == 0x0D  # value length: 3 + 10 padding
         assert body[5] == 0x00  # frame
         assert body[6] == 0x03  # ieco number
@@ -2567,20 +2567,20 @@ class TestNewProtocolSetIeco:
 
     def test_ieco_defaults_number_to_one(self) -> None:
         """Test iECO uses gear 1 by default when no number is set."""
-        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = PropertiesSet(protocol_version=ProtocolVersion.V1)
         msg.ieco = True
         body = msg.body
         assert body[6] == 0x01
 
     def test_ieco_absent_when_unset(self) -> None:
         """Test iECO is not packed when left as None."""
-        msg = NewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg = PropertiesSet(protocol_version=ProtocolVersion.V1)
         body = msg.body
         assert body[1] == 0x00  # no params packed
 
 
 class TestMessageSetAnion:
-    """Test MessageSet anion (purifier) bit."""
+    """Test StateSet anion (purifier) bit."""
 
     @pytest.mark.parametrize(
         ("value", "expected_bit"),
@@ -2588,6 +2588,6 @@ class TestMessageSetAnion:
     )
     def test_anion_bit_in_body(self, value: bool, expected_bit: int) -> None:
         """Test anion sets bit 0x20 in body byte index 8."""
-        msg = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg = StateSet(protocol_version=ProtocolVersion.V1)
         msg.anion = value
         assert msg._body[8] & 0x20 == expected_bit


### PR DESCRIPTION
## Summary

This PR renames AC message classes to match msmart-ng naming conventions for better consistency and clarity.

## Changes

- `MessageQuery` → `StateQuery`
- `MessageSet` → `StateSet`
- `NewProtocolQuery` → `PropertiesQuery`
- `NewProtocolSet` → `PropertiesSet`
- `NewProtocolTags` → `CapabilityTag`

## Testing

- All existing tests pass (192 tests in tests/devices/ac/)
- Linting and formatting applied
- No functionality changes, pure refactoring

## Scope

Only affects the `midealan/devices/ac/` package. Other device types (a1, e2, e3) have their own independent message classes that are not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed air conditioner protocol message types and capability tags to clearer state- and properties-based names.
  * Updated air conditioner command and query interfaces to use the renamed types.
  * Preserved existing message behavior and serialization.

* **Tests**
  * Updated air conditioner tests to reflect the renamed protocol types while retaining existing expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->