### PR TITLE
fix(release): correct tag naming to match existing format

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,7 @@
 {
   "include-commit-authors": true,
   "include-v-in-tag": true,
-  "include-component-in-tag": false,
+  "include-component-in-tag": true,
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
## Problem

The release-please workflow had a tag naming mismatch:
- **Existing tags**: `midea-lan-v2026.8.0` (with component prefix)
- **Config expected**: `v2026.8.0` (`include-component-in-tag: false`)

This caused release-please to fail finding the previous release, resulting in:
1. **Wrong version**: 2027.0.0 instead of 2026.9.0 (due to breaking changes in full history)
2. **Wrong changelog**: included all 615 commits instead of changes since v2026.8.0
3. **Ignored `release-as` input**: the manual version override didn't work

## Solution

Changed `include-component-in-tag` to `true` in `release-please-config.json` to match existing tag format.

## Verification

After merging, the next workflow_dispatch with `release-as: 2026.9.0` will:
- Find the previous release at `midea-lan-v2026.8.0`
- Generate changelog from commits since that tag
- Create proper version bump to 2026.9.0
- Future tags will be `midea-lan-v2026.X.Y`

## Related

- Closes incorrect PR #73 (which generated 2027.0.0)