### PR TITLE
fix(ci): add push trigger to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,9 @@
 name: release-please
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Problem

When PR #77 (release PR) was merged, the release-please workflow did not run automatically, so no git tag or GitHub Release was created. This prevented the PyPI upload job from running.

## Root Cause

The workflow was missing the `push` trigger. It only had `workflow_dispatch` (manual trigger), so it wouldn't run when commits were pushed to main.

## Solution

Added `push` trigger for the `main` branch, so the workflow runs automatically when:
- Release PRs are merged → creates tag and GitHub Release
- Any commit is pushed to main → checks if a release is needed

This matches the standard release-please workflow pattern.

## Verification

After merging this PR, the workflow should:
1. Detect the release commit `e7c9f87` (PR #77)
2. Create tag `v2026.9.0`
3. Create GitHub Release
4. Trigger the PyPI upload workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)