### PR TITLE
feat(c3): add human-readable error_code_description

### DIFF
--- a/midealan/devices/c3/__init__.py
+++ b/midealan/devices/c3/__init__.py
@@ -91,6 +91,7 @@ class DeviceAttributes(StrEnum):
     eco_mode = "eco_mode"
     tbh = "tbh"
     error_code = "error_code"
+    error_code_description = "error_code_description"
 
 
 class MideaC3Device(MideaDevice):
@@ -174,6 +175,7 @@ class MideaC3Device(MideaDevice):
                 DeviceAttributes.fg_capacity_need: None,
                 DeviceAttributes.instant_power0: None,
                 DeviceAttributes.error_code: 0,
+                DeviceAttributes.error_code_description: "No error",
             },
         )
         self._default_temperature_step: float = 0.5

--- a/midealan/devices/c3/message.py
+++ b/midealan/devices/c3/message.py
@@ -15,6 +15,74 @@ TEMP_NEG_VALUE = 127
 # Outdoor fan speed is transmitted as RPM / 10.
 FAN_SPEED_FACTOR = 10
 
+# Error code lookup (source: Midea Modbus documentation V4.7,
+# 0052003044313 V.E, "Error code table 1", page 11).
+# Format: raw_value -> (display_code, human_description).
+# All entries below were cross-checked against that source; the four
+# codes previously marked "unknown" (Hd, HE, L2, L9) plus L8 are now
+# filled in, and three codes (E1, H9, HA) whose text had been
+# shifted from neighbouring rows during transcription are corrected.
+C3_ERROR_CODE_TABLE: dict[int, tuple[str, str]] = {
+    1: ("E0", "Water flow fault (E8 displayed 3 times)"),
+    2: (
+        "E1",
+        (
+            "Phase loss, or neutral and live wire connected reversely "
+            "(three-phase units only)"
+        ),
+    ),
+    3: ("E2", "Communication fault between controller and hydraulic module"),
+    4: ("E3", "Final outlet water temp. sensor (T1) fault"),
+    5: ("E4", "Water tank temp. sensor (T5) fault"),
+    6: ("E5", "Condenser outlet refrigerant temp. sensor (T3) fault"),
+    7: ("E6", "Ambient temp. sensor (T4) fault"),
+    8: ("E7", "Buffer tank up temp. sensor (Tbt1) fault"),
+    9: ("E8", "Water flow failure"),
+    10: ("E9", "Suction temp. sensor (Th) fault"),
+    11: ("EA", "Discharge temp. sensor (Tp) fault"),
+    12: ("Eb", "Solar temp. sensor (Tsolar) fault"),
+    13: ("Ec", "Buffer tank low temp. sensor (Tbt2) fault"),
+    14: ("Ed", "Inlet water temp. sensor (Tw_in) malfunction"),
+    15: ("EE", "Hydraulic module EEPROM failure"),
+    20: ("P0", "Low pressure switch protection"),
+    21: ("P1", "High pressure switch protection"),
+    23: ("P3", "Compressor overcurrent protection"),
+    24: ("P4", "High discharge temperature protection"),
+    25: ("P5", "|Tw_out - Tw_in| value too big protection"),
+    26: ("P6", "Inverter module protection"),
+    31: ("Pb", "Anti-freeze mode"),
+    33: ("Pd", "High refrigerant outlet temp. protection of condenser"),
+    38: ("PP", "Tw_out - Tw_in unusual protection"),
+    39: ("H0", "Communication fault: hydraulic PCB B <-> main control PCB B"),
+    40: ("H1", "Communication fault: inverter PCB A <-> main control PCB B"),
+    41: ("H2", "Refrigerant liquid temp. sensor (T2) fault"),
+    42: ("H3", "Refrigerant gas temp. sensor (T2B) fault"),
+    43: ("H4", "Three times P6 (L0/L1) protection"),
+    44: ("H5", "Room temp. sensor (Ta) fault"),
+    45: ("H6", "DC fan motor fault"),
+    46: ("H7", "Voltage protection"),
+    47: ("H8", "Pressure sensor fault"),
+    48: ("H9", "Outlet water temp. sensor for Zone 2 (Tw2) fault"),
+    49: ("HA", "Outlet water temp. sensor (Tw_out) fault"),
+    50: ("Hb", "3 times PP protection and Tw_out < 7C"),
+    52: ("Hd", "Communication fault between hydraulic modules (parallel)"),
+    53: ("HE", "Communication error: main board <-> thermostat transfer board"),
+    54: ("HF", "Inverter module board EEPROM fault"),
+    55: ("HH", "H6 displayed 10 times in 2 hours"),
+    57: ("HP", "Low pressure protection (Pe<0.6) occurred 3 times in 1 hour"),
+    65: ("C7", "Transducer module temperature too high protection"),
+    112: ("bH", "PED PCB fault"),
+    116: ("F1", "Low DC generatrix voltage protection"),
+    134: ("L0", "Module protection"),
+    135: ("L1", "DC generatrix low voltage protection"),
+    136: ("L2", "DC generatrix high voltage protection"),
+    138: ("L4", "MCE fault"),
+    139: ("L5", "Zero speed protection"),
+    141: ("L7", "Phase sequence fault"),
+    142: ("L8", "Speed difference > 15Hz between front and back clock"),
+    143: ("L9", "Speed difference > 15Hz between real and setting speed"),
+}
+
 
 class C3SilentLevel(IntEnum):
     """C3 Silent Level."""
@@ -308,6 +376,14 @@ class C3BasicBody(MessageBody):
         self.dhw_temp_min = float(body[data_offset + 20])
         self.tank_actual_temperature = float(body[data_offset + 21])
         self.error_code = body[data_offset + 22]
+        if self.error_code == 0:
+            self.error_code_description = "No error"
+        else:
+            _code_info = C3_ERROR_CODE_TABLE.get(self.error_code)
+            if _code_info:
+                self.error_code_description = f"{_code_info[0]}: {_code_info[1]}"
+            else:
+                self.error_code_description = f"Unknown code (raw={self.error_code})"
         self.tbh_control = body[data_offset + 23] & 0x80 > 0
         self.SysEnergyAnaEN = body[data_offset + 23] & 0x20 > 0
         self.HMIEnergyAnaSetEN = body[data_offset + 23] & 0x40 > 0
@@ -593,6 +669,15 @@ class C3UnitParaUpBody(MessageBody):
 
 class MessageC3Response(MessageResponse):
     """C3 message response."""
+
+    # Populated dynamically by MessageResponse.set_attr(), which copies
+    # every attribute of the parsed body onto the response via setattr().
+    # mypy cannot see attributes added that way; declaring them here as
+    # class-level annotations has no effect on runtime behaviour (set_attr()
+    # remains the only place that assigns them) and only gives mypy the
+    # static type it needs for the accesses in message_c3_test.py.
+    error_code: int
+    error_code_description: str
 
     def __init__(self, message: bytes) -> None:
         """Initialize C3 message response."""

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -899,3 +899,140 @@ class TestC3UnitParaOutdoorTelemetryOffsets:
         response = self._build_response(values)
         assert hasattr(response, attribute)
         assert getattr(response, attribute) == expected
+
+
+class TestC3ErrorCodeDescription:
+    """Test C3 error_code_description derived from C3_ERROR_CODE_TABLE."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_header(self) -> None:
+        """Do setup header."""
+        self.header = bytearray(
+            [
+                0xAA,
+                0x00,
+                0xC3,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+                0x00,  # message type
+            ],
+        )
+
+    def _build_body(self, error_code: int) -> bytearray:
+        """Build a minimal X01 body with the given error_code byte."""
+        return bytearray(
+            [
+                ListTypes.X01,
+                0x0,  # BYTE 1
+                0x0,  # BYTE 2
+                0x0,  # BYTE 3
+                0x0,  # BYTE 4: Mode
+                0x0,  # BYTE 5: Mode Auto
+                0,  # BYTE 6: Zone1 Target Temp
+                0,  # BYTE 7: Zone2 Target Temp
+                0,  # BYTE 8: DHW Target Temp
+                0,  # BYTE 9: Room Target Temp * 2
+                0,  # BYTE 10
+                0,  # BYTE 11
+                0,  # BYTE 12
+                0,  # BYTE 13
+                0,  # BYTE 14
+                0,  # BYTE 15
+                0,  # BYTE 16
+                0,  # BYTE 17
+                0,  # BYTE 18
+                0,  # BYTE 19
+                0,  # BYTE 20
+                0,  # BYTE 21
+                0,  # BYTE 22: tank_actual_temperature
+                error_code,  # BYTE 23: error_code
+                0x0,  # BYTE 24; tbh_control
+                0x0,  # CRC
+            ],
+        )
+
+    def test_error_code_zero_is_no_error(self) -> None:
+        """error_code 0 maps to the 'No error' description."""
+        self.header[-1] = MessageType.query
+        response = MessageC3Response(bytes(self.header + self._build_body(0)))
+
+        assert response.error_code == 0
+        assert response.error_code_description == "No error"
+
+    def test_error_code_known_value_maps_to_table_entry(self) -> None:
+        """A known error_code maps to its display code and description."""
+        self.header[-1] = MessageType.query
+        response = MessageC3Response(bytes(self.header + self._build_body(9)))
+
+        assert response.error_code == 9
+        assert response.error_code_description == ("E8: Water flow failure")
+
+    def test_error_code_unknown_value_falls_back_to_raw(self) -> None:
+        """An error_code with no table entry reports the raw value."""
+        self.header[-1] = MessageType.query
+        response = MessageC3Response(bytes(self.header + self._build_body(200)))
+
+        assert response.error_code == 200
+        assert response.error_code_description == "Unknown code (raw=200)"
+
+    @pytest.mark.parametrize(
+        ("error_code", "expected_description"),
+        [
+            (
+                2,
+                (
+                    "E1: Phase loss, or neutral and live wire connected reversely "
+                    "(three-phase units only)"
+                ),
+            ),
+            (48, "H9: Outlet water temp. sensor for Zone 2 (Tw2) fault"),
+            (49, "HA: Outlet water temp. sensor (Tw_out) fault"),
+            (
+                52,
+                "Hd: Communication fault between hydraulic modules (parallel)",
+            ),
+            (
+                53,
+                "HE: Communication error: main board <-> thermostat transfer board",
+            ),
+            (136, "L2: DC generatrix high voltage protection"),
+            (141, "L7: Phase sequence fault"),
+            (142, "L8: Speed difference > 15Hz between front and back clock"),
+            (143, "L9: Speed difference > 15Hz between real and setting speed"),
+        ],
+        ids=[
+            "raw_2_E1",
+            "raw_48_H9",
+            "raw_49_HA",
+            "raw_52_Hd",
+            "raw_53_HE",
+            "raw_136_L2",
+            "raw_141_L7",
+            "raw_142_L8",
+            "raw_143_L9",
+        ],
+    )
+    def test_error_code_corrected_entries_match_source_pdf(
+        self,
+        error_code: int,
+        expected_description: str,
+    ) -> None:
+        """Regression test for entries fixed against Modbus V4.7 table 1.
+
+        These nine raw codes previously either carried text shifted from a
+        neighbouring row (2, 48, 49) or a placeholder "Unknown / description
+        unclear in source document" (52, 53, 136, 142, 143), or an unsourced
+        addition (141). Values are taken from Midea Modbus documentation
+        V4.7 (0052003044313 V.E), "Error code table 1", page 11.
+        """
+        self.header[-1] = MessageType.query
+        response = MessageC3Response(
+            bytes(self.header + self._build_body(error_code)),
+        )
+
+        assert response.error_code == error_code
+        assert response.error_code_description == expected_description


### PR DESCRIPTION
## Summary

Adds a lookup table for C3 error codes (source: Modbus V4.7 documentation,
table 1) and derives a human-readable `error_code_description` from the
existing `error_code` byte in `C3BasicBody`.

This is the first of several smaller, independently verifiable pieces split
out of #46, as suggested by @kmich — so it can be reviewed and merged on its
own rather than as part of a large combined change.

## Behavior

- `error_code == 0` -> `"No error"`
- known code -> `"<display_code>: <description>"` (e.g. `"E8: Water flow failure"`)
- unrecognized code -> `"Unknown code (raw=<value>)"`

All error codes in the table are sourced from Midea Modbus documentation V4.7 (0052003044313 V.E), "Error code table 1", page 11. No entries remain marked as unknown.

## Files changed

- `midealan/devices/c3/__init__.py` — new `error_code_description` attribute
  and default value
- `midealan/devices/c3/message.py` — `C3_ERROR_CODE_TABLE` and description
  derivation in `C3BasicBody`
- `tests/devices/c3/message_c3_test.py` — three new tests covering the zero,
  known, and unknown cases

## Verification

- `pytest tests/devices/c3/` — 58 passed
- `ruff check` / `ruff format --check` — clean
- `mypy` — no issues

Related: #46 (original combined proposal), addresses feedback from @kmich
about splitting that PR into smaller pieces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added human-readable descriptions for C3 device error codes.
  * Displays “No error” when no error is reported.
  * Shows recognized error codes with descriptive messages and identifies unknown codes by their raw values.
  * Corrected descriptions for several error codes and added details for previously unmapped codes.

* **Tests**
  * Added regression coverage to verify corrected descriptions across additional C3 error codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->