### PR TITLE
feat(c3): parse ASCII tail identifier and firmware versions

### DIFF
--- a/midealan/devices/c3/__init__.py
+++ b/midealan/devices/c3/__init__.py
@@ -91,6 +91,9 @@ class DeviceAttributes(StrEnum):
     eco_mode = "eco_mode"
     tbh = "tbh"
     error_code = "error_code"
+    wifi_module_serial = "wifi_module_serial"
+    idu_software_version_str = "idu_software_version_str"
+    odu_software_version_str = "odu_software_version_str"
 
 
 class MideaC3Device(MideaDevice):
@@ -174,6 +177,9 @@ class MideaC3Device(MideaDevice):
                 DeviceAttributes.fg_capacity_need: None,
                 DeviceAttributes.instant_power0: None,
                 DeviceAttributes.error_code: 0,
+                DeviceAttributes.wifi_module_serial: None,
+                DeviceAttributes.idu_software_version_str: None,
+                DeviceAttributes.odu_software_version_str: None,
             },
         )
         self._default_temperature_step: float = 0.5

--- a/midealan/devices/c3/__init__.py
+++ b/midealan/devices/c3/__init__.py
@@ -91,7 +91,7 @@ class DeviceAttributes(StrEnum):
     eco_mode = "eco_mode"
     tbh = "tbh"
     error_code = "error_code"
-    wifi_module_serial = "wifi_module_serial"
+    hmi_sn_code = "hmi_sn_code"
     idu_software_version_str = "idu_software_version_str"
     odu_software_version_str = "odu_software_version_str"
 
@@ -177,7 +177,7 @@ class MideaC3Device(MideaDevice):
                 DeviceAttributes.fg_capacity_need: None,
                 DeviceAttributes.instant_power0: None,
                 DeviceAttributes.error_code: 0,
-                DeviceAttributes.wifi_module_serial: None,
+                DeviceAttributes.hmi_sn_code: None,
                 DeviceAttributes.idu_software_version_str: None,
                 DeviceAttributes.odu_software_version_str: None,
             },

--- a/midealan/devices/c3/message.py
+++ b/midealan/devices/c3/message.py
@@ -559,7 +559,11 @@ class C3UnitParaBody(MessageBody):
         # into X10 telemetry frame). Verified against wired HMI:
         #   raw byte offset 93 = IDU sw version (HMI shows "V<n>")
         #   raw byte offset 94 = ODU sw version (HMI shows "V<n>")
-        # Guard: leave version bytes unset when the frame is short.
+        # Guard: leave version bytes unset when the frame is short. This
+        # reads body[...] directly rather than going through read_byte()
+        # like the rest of the method on purpose -- read_byte() defaults to
+        # 0, which would surface as "V0" and be indistinguishable from a
+        # unit actually reporting version 0. None says "not reported".
         self.idu_software_version: int | None = None
         self.odu_software_version: int | None = None
         if len(body) > data_offset + 94:

--- a/midealan/devices/c3/message.py
+++ b/midealan/devices/c3/message.py
@@ -42,7 +42,17 @@ def _parse_sn_block(
         return None
     block = bytes(body[start:end])
     terminator = block.find(0)
-    if terminator != -1:
+    if terminator == -1:
+        # No NUL in the block: only a fully populated 32-byte value is
+        # valid. A dash-padded block with no terminator is a partial or
+        # corrupt record, not a short serial that happens to fill the slot.
+        if block.strip(b"-") != block:
+            return None
+    else:
+        # Bytes after the terminator must be pure dash padding. Anything
+        # else (garbage, a second value) makes the record untrustworthy.
+        if block[terminator + 1 :].strip(b"-"):
+            return None
         block = block[:terminator]
     candidate = block.strip(b"-").strip()
     if not candidate:

--- a/midealan/devices/c3/message.py
+++ b/midealan/devices/c3/message.py
@@ -12,6 +12,38 @@ from midealan.message import (
 )
 
 TEMP_NEG_VALUE = 127
+
+
+def _parse_ascii_tail(body: bytearray, data_offset: int) -> str | None:
+    """Extract the dash-padded, NUL-terminated ASCII tail identifier.
+
+    The WiFi module serial / model identifier is appended to C3 telemetry
+    frames as an ASCII block preceded by a run of dash ("-") padding bytes
+    and terminated with NUL bytes. Layout observed on captured frames:
+    bytes ~96..159 = dashes, ~160..191 = ASCII serial, then NUL. The exact
+    offsets vary between firmware revisions so the block is located by
+    scanning for the dash run rather than by fixed offset.
+    """
+    dash_idx = body.find(b"-" * 20, data_offset)
+    if dash_idx == -1:
+        return None
+    tail = body[dash_idx:]
+    start = 0
+    while start < len(tail) and tail[start : start + 1] == b"-":
+        start += 1
+    end = start
+    while end < len(tail) and tail[end] != 0:
+        end += 1
+    candidate = bytes(tail[start:end]).strip()
+    if not candidate:
+        return None
+    try:
+        decoded = candidate.decode("ascii")
+    except UnicodeDecodeError:
+        return None
+    return decoded if decoded.isprintable() else None
+
+
 # Outdoor fan speed is transmitted as RPM / 10.
 FAN_SPEED_FACTOR = 10
 
@@ -354,6 +386,12 @@ class C3EnergyBody(MessageBody):
         self.zone2_temp_set = float(body[data_offset + 11])
         self.t5s = body[data_offset + 12]
         self.tas = body[data_offset + 13]
+        # WiFi module serial / model identifier is appended after the
+        # main payload; see _parse_ascii_tail for the layout.
+        self.wifi_module_serial: str | None = _parse_ascii_tail(
+            body,
+            data_offset,
+        )
 
 
 class C3SilenceBody(MessageBody):
@@ -511,6 +549,32 @@ class C3UnitParaBody(MessageBody):
             + (self.read_byte(body, data_offset + 87) << 16)
             + (self.read_byte(body, data_offset + 88) << 8)
             + self.read_byte(body, data_offset + 89)
+        )
+        # ------------------------------------------------------------------
+        # IDU / ODU software versions (Modbus reg 130 / reg 1042 mapped
+        # into X10 telemetry frame). Verified against wired HMI:
+        #   raw byte offset 93 = IDU sw version (HMI shows "V<n>")
+        #   raw byte offset 94 = ODU sw version (HMI shows "V<n>")
+        # Guard: leave version bytes unset when the frame is short.
+        self.idu_software_version: int | None = None
+        self.odu_software_version: int | None = None
+        if len(body) > data_offset + 94:
+            self.idu_software_version = body[data_offset + 93]
+            self.odu_software_version = body[data_offset + 94]
+        self.idu_software_version_str = (
+            f"V{self.idu_software_version}"
+            if self.idu_software_version is not None
+            else None
+        )
+        self.odu_software_version_str = (
+            f"V{self.odu_software_version}"
+            if self.odu_software_version is not None
+            else None
+        )
+        # WiFi module serial: appended as ASCII after a run of "-" padding.
+        self.wifi_module_serial: str | None = _parse_ascii_tail(
+            body,
+            data_offset,
         )
 
 

--- a/midealan/devices/c3/message.py
+++ b/midealan/devices/c3/message.py
@@ -14,27 +14,37 @@ from midealan.message import (
 TEMP_NEG_VALUE = 127
 
 
-def _parse_ascii_tail(body: bytearray, data_offset: int) -> str | None:
-    """Extract the dash-padded, NUL-terminated ASCII tail identifier.
+# Serial-number blocks appended to the X10 telemetry frame. The lua splits
+# the tail into three fixed 32-byte ASCII blocks (1-indexed):
+#   iduSNCode = _bodyBytes[96..127]
+#   oduSNCode = _bodyBytes[128..159]
+#   hmiSNCode = _bodyBytes[160..191]
+# Only the HMI block is decoded; on the captured 171H120F the IDU and ODU
+# blocks are dash-filled. Unused positions are padded with "-", and a block
+# shorter than its full width is NUL-terminated.
+SN_BLOCK_LENGTH = 32
+HMI_SN_BLOCK_OFFSET = 159
 
-    The WiFi module serial / model identifier is appended to C3 telemetry
-    frames as an ASCII block preceded by a run of dash ("-") padding bytes
-    and terminated with NUL bytes. Layout observed on captured frames:
-    bytes ~96..159 = dashes, ~160..191 = ASCII serial, then NUL. The exact
-    offsets vary between firmware revisions so the block is located by
-    scanning for the dash run rather than by fixed offset.
+
+def _parse_sn_block(
+    body: bytearray,
+    data_offset: int,
+    block_offset: int,
+) -> str | None:
+    """Decode one fixed-width, dash-padded ASCII serial-number block.
+
+    Returns None when the frame stops before the block, when the block holds
+    only padding, or when its content is not printable ASCII.
     """
-    dash_idx = body.find(b"-" * 20, data_offset)
-    if dash_idx == -1:
+    start = data_offset + block_offset
+    end = start + SN_BLOCK_LENGTH
+    if len(body) < end:
         return None
-    tail = body[dash_idx:]
-    start = 0
-    while start < len(tail) and tail[start : start + 1] == b"-":
-        start += 1
-    end = start
-    while end < len(tail) and tail[end] != 0:
-        end += 1
-    candidate = bytes(tail[start:end]).strip()
+    block = bytes(body[start:end])
+    terminator = block.find(0)
+    if terminator != -1:
+        block = block[:terminator]
+    candidate = block.strip(b"-").strip()
     if not candidate:
         return None
     try:
@@ -386,12 +396,6 @@ class C3EnergyBody(MessageBody):
         self.zone2_temp_set = float(body[data_offset + 11])
         self.t5s = body[data_offset + 12]
         self.tas = body[data_offset + 13]
-        # WiFi module serial / model identifier is appended after the
-        # main payload; see _parse_ascii_tail for the layout.
-        self.wifi_module_serial: str | None = _parse_ascii_tail(
-            body,
-            data_offset,
-        )
 
 
 class C3SilenceBody(MessageBody):
@@ -571,10 +575,11 @@ class C3UnitParaBody(MessageBody):
             if self.odu_software_version is not None
             else None
         )
-        # WiFi module serial: appended as ASCII after a run of "-" padding.
-        self.wifi_module_serial: str | None = _parse_ascii_tail(
+        # HMI serial number, read at its fixed block offset.
+        self.hmi_sn_code: str | None = _parse_sn_block(
             body,
             data_offset,
+            HMI_SN_BLOCK_OFFSET,
         )
 
 

--- a/midealan/devices/c3/message.py
+++ b/midealan/devices/c3/message.py
@@ -677,6 +677,21 @@ class C3UnitParaUpBody(MessageBody):
 class MessageC3Response(MessageResponse):
     """C3 message response."""
 
+    # Populated dynamically by MessageResponse.set_attr(), which copies
+    # every attribute of the parsed body onto the response via setattr().
+    # mypy cannot see attributes added that way; declaring them here as
+    # class-level annotations has no effect on runtime behaviour (set_attr()
+    # remains the only place that assigns them) and only gives mypy the
+    # static type it needs for the accesses in message_c3_test.py.
+    idu_software_version: int | None
+    odu_software_version: int | None
+    idu_software_version_str: str | None
+    odu_software_version_str: str | None
+    fg_capacity_need: int
+    current_unit_capacity: int
+    total_energy_consumption: int
+    total_produced_energy: int
+
     def __init__(self, message: bytes) -> None:
         """Initialize C3 message response."""
         super().__init__(bytearray(message))

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -1021,7 +1021,11 @@ class TestC3UnitParaIdentification:
         return MessageC3Response(bytes(header + body))
 
     def test_software_versions_are_read_from_their_offsets(self) -> None:
-        """Test IDU and ODU versions come from raw bytes 93 and 94."""
+        """Test IDU and ODU versions come from body offsets 93 and 94.
+
+        The offsets are relative to data_offset, which is 1 for an X10
+        response, so the values below are written at body indices 94 and 95.
+        """
         response = self._build_response({93: 0, 94: 12, 95: 30, 96: 0})
         assert hasattr(response, "idu_software_version")
         assert hasattr(response, "odu_software_version")

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -19,6 +19,7 @@ from midealan.devices.c3.message import (
     MessageSetDisinfect,
     MessageSetECO,
     MessageSetSilent,
+    _parse_ascii_tail,
 )
 from midealan.message import ListTypes, MessageType
 
@@ -899,3 +900,185 @@ class TestC3UnitParaOutdoorTelemetryOffsets:
         response = self._build_response(values)
         assert hasattr(response, attribute)
         assert getattr(response, attribute) == expected
+
+
+# Real ASCII tail captured from a Hyundai HYHC-V30W/D2RN8 (Midea MHC-V30W/D2RN8,
+# device type 0xC3, protocol 3, Wi-Fi module 171H120F). In the capture the block
+# sits at bytes 160..191, preceded by a run of "-" padding and followed by NUL.
+CAPTURED_TAIL = b"0000C3310171H120F24114100123MNJ2"
+
+
+def _tail_block(serial: bytes = CAPTURED_TAIL, dashes: int = 24) -> bytes:
+    """Build a dash-padded, NUL-terminated ASCII tail block."""
+    return b"-" * dashes + serial + b"\x00" * 4
+
+
+class TestParseAsciiTail:
+    """Unit tests for the dash-padded ASCII tail scanner."""
+
+    def test_captured_tail_is_decoded(self) -> None:
+        """Test the real captured serial is returned verbatim."""
+        body = bytearray(32) + bytearray(_tail_block())
+        assert _parse_ascii_tail(body, 1) == CAPTURED_TAIL.decode()
+
+    def test_tail_is_located_by_dash_run_not_fixed_offset(self) -> None:
+        """Test the block is found wherever the dash run starts."""
+        near = bytearray(8) + bytearray(_tail_block())
+        far = bytearray(120) + bytearray(_tail_block())
+        assert _parse_ascii_tail(near, 1) == CAPTURED_TAIL.decode()
+        assert _parse_ascii_tail(far, 1) == CAPTURED_TAIL.decode()
+
+    def test_missing_dash_run_returns_none(self) -> None:
+        """Test a body without the padding run yields no identifier."""
+        assert _parse_ascii_tail(bytearray(200), 1) is None
+
+    def test_short_dash_run_is_not_treated_as_padding(self) -> None:
+        """Test fewer than 20 dashes does not trigger a match."""
+        body = bytearray(16) + bytearray(b"-" * 8 + CAPTURED_TAIL + b"\x00")
+        assert _parse_ascii_tail(body, 1) is None
+
+    def test_empty_tail_returns_none(self) -> None:
+        """Test padding immediately followed by NUL yields no identifier."""
+        body = bytearray(16) + bytearray(b"-" * 24 + b"\x00" * 8)
+        assert _parse_ascii_tail(body, 1) is None
+
+    def test_non_ascii_tail_returns_none(self) -> None:
+        """Test a tail with non-ASCII bytes is rejected instead of raising."""
+        body = bytearray(16) + bytearray(b"-" * 24 + b"\xff\xfe\xfd" + b"\x00")
+        assert _parse_ascii_tail(body, 1) is None
+
+    def test_unprintable_tail_returns_none(self) -> None:
+        """Test a control-character tail is rejected."""
+        body = bytearray(16) + bytearray(b"-" * 24 + b"AB\x07CD" + b"\x00")
+        assert _parse_ascii_tail(body, 1) is None
+
+    def test_scan_starts_at_data_offset(self) -> None:
+        """Test padding before data_offset is ignored."""
+        body = bytearray(b"-" * 24 + b"IGNORED" + b"\x00") + bytearray(_tail_block())
+        assert _parse_ascii_tail(body, 32) == CAPTURED_TAIL.decode()
+
+
+class TestC3UnitParaIdentification:
+    """Firmware versions and the Wi-Fi module serial in the X10 body.
+
+    The IDU / ODU software version bytes map to Modbus registers 130 and 1042
+    and were cross-checked against the wired HMI, which displays them as
+    "V<n>". Frames that stop before those offsets must keep parsing.
+    """
+
+    HEADER = bytearray(
+        [0xAA, 0x00, 0xC3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, MessageType.query],
+    )
+
+    @staticmethod
+    def _build_response(
+        values: dict[int, int] | None = None,
+        *,
+        with_tail: bool = True,
+        size: int = 200,
+    ) -> MessageC3Response:
+        """Build an X10 query response, optionally carrying an ASCII tail."""
+        body = bytearray(size)
+        body[0] = ListTypes.X10
+        for index, value in (values or {}).items():
+            body[index] = value
+        if with_tail:
+            block = _tail_block()
+            body[120 : 120 + len(block)] = block
+        header = TestC3UnitParaIdentification.HEADER
+        return MessageC3Response(bytes(header + body))
+
+    def test_software_versions_are_read_from_their_offsets(self) -> None:
+        """Test IDU and ODU versions come from raw bytes 93 and 94."""
+        response = self._build_response({93: 0, 94: 12, 95: 30, 96: 0})
+        assert hasattr(response, "idu_software_version")
+        assert hasattr(response, "odu_software_version")
+        assert response.idu_software_version == 12
+        assert response.odu_software_version == 30
+
+    def test_software_versions_are_formatted_for_display(self) -> None:
+        """Test the string form matches the "V<n>" shown on the HMI."""
+        response = self._build_response({94: 12, 95: 30})
+        assert hasattr(response, "idu_software_version_str")
+        assert hasattr(response, "odu_software_version_str")
+        assert response.idu_software_version_str == "V12"
+        assert response.odu_software_version_str == "V30"
+
+    def test_short_body_leaves_versions_unset(self) -> None:
+        """Test a frame stopping before the version bytes still parses."""
+        body = bytearray(88)  # body type + 86 data bytes + CRC
+        body[0] = ListTypes.X10
+        response = MessageC3Response(bytes(self.HEADER + body))
+        assert hasattr(response, "idu_software_version")
+        assert response.idu_software_version is None
+        assert response.odu_software_version is None
+        assert response.idu_software_version_str is None
+        assert response.odu_software_version_str is None
+
+    def test_wifi_module_serial_is_exposed(self) -> None:
+        """Test the ASCII tail is surfaced as the Wi-Fi module serial."""
+        response = self._build_response()
+        assert hasattr(response, "wifi_module_serial")
+        assert response.wifi_module_serial == CAPTURED_TAIL.decode()
+
+    def test_wifi_module_serial_is_none_without_tail(self) -> None:
+        """Test a frame with no ASCII tail reports no serial."""
+        response = self._build_response(with_tail=False)
+        assert hasattr(response, "wifi_module_serial")
+        assert response.wifi_module_serial is None
+
+    def test_identification_does_not_disturb_existing_fields(self) -> None:
+        """Test the added parsing leaves earlier X10 offsets untouched."""
+        response = self._build_response({5: 9, 58: 2, 59: 44})
+        assert response.fg_capacity_need == 9
+        assert response.current_unit_capacity == 556
+
+
+class TestC3EnergyAsciiTail:
+    """The notify1 0x04 energy body also carries the ASCII tail."""
+
+    HEADER = bytearray(
+        [0xAA, 0x00, 0xC3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, MessageType.notify1],
+    )
+
+    @staticmethod
+    def _build_response(*, with_tail: bool = True) -> MessageC3Response:
+        """Build a notify1 0x04 response, optionally carrying an ASCII tail."""
+        body = bytearray(200)
+        body[0] = ListTypes.X04
+        if with_tail:
+            block = _tail_block()
+            body[100 : 100 + len(block)] = block
+        return MessageC3Response(bytes(TestC3EnergyAsciiTail.HEADER + body))
+
+    def test_wifi_module_serial_is_exposed(self) -> None:
+        """Test the notify body surfaces the same identifier."""
+        response = self._build_response()
+        assert response.body_type == ListTypes.X04
+        assert hasattr(response, "wifi_module_serial")
+        assert response.wifi_module_serial == CAPTURED_TAIL.decode()
+
+    def test_wifi_module_serial_is_none_without_tail(self) -> None:
+        """Test a notify frame with no tail reports no serial."""
+        response = self._build_response(with_tail=False)
+        assert response.wifi_module_serial is None
+
+    def test_energy_counters_still_parse(self) -> None:
+        """Test the added parsing does not disturb the energy counters."""
+        header = bytearray(TestC3EnergyAsciiTail.HEADER)
+        body = bytearray(200)
+        body[0] = ListTypes.X04
+        for index, value in {
+            2: 0x01,
+            3: 0x02,
+            4: 0x03,
+            5: 0x04,
+            6: 0x0A,
+            7: 0x0B,
+            8: 0x0C,
+            9: 0x0D,
+        }.items():
+            body[index] = value
+        response = MessageC3Response(bytes(header + body))
+        assert response.total_energy_consumption == 0x01020304
+        assert response.total_produced_energy == 0x0A0B0C0D

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -19,7 +19,7 @@ from midealan.devices.c3.message import (
     MessageSetDisinfect,
     MessageSetECO,
     MessageSetSilent,
-    _parse_ascii_tail,
+    _parse_sn_block,
 )
 from midealan.message import ListTypes, MessageType
 
@@ -902,64 +902,95 @@ class TestC3UnitParaOutdoorTelemetryOffsets:
         assert getattr(response, attribute) == expected
 
 
-# Real ASCII tail captured from a Hyundai HYHC-V30W/D2RN8 (Midea MHC-V30W/D2RN8,
-# device type 0xC3, protocol 3, Wi-Fi module 171H120F). In the capture the block
-# sits at bytes 160..191, preceded by a run of "-" padding and followed by NUL.
-CAPTURED_TAIL = b"0000C3310171H120F24114100123MNJ2"
+# Real HMI serial captured from a Hyundai HYHC-V30W/D2RN8 (Midea
+# MHC-V30W/D2RN8, device type 0xC3, protocol 3, Wi-Fi module 171H120F). The
+# lua splits the frame tail into three fixed 32-byte blocks: iduSNCode at
+# _bodyBytes[96..127], oduSNCode at [128..159] and hmiSNCode at [160..191].
+# On this unit the first two are dash-filled and the value below fills the
+# HMI block exactly. The offsets are pinned here on purpose: a change to
+# SN_BLOCK_LENGTH or HMI_SN_BLOCK_OFFSET must break these tests.
+CAPTURED_HMI_SN = b"0000C3310171H120F24114100123MNJ2"
+SN_BLOCK_LEN = 32
+HMI_SN_OFFSET = 159
 
 
-def _tail_block(serial: bytes = CAPTURED_TAIL, dashes: int = 24) -> bytes:
-    """Build a dash-padded, NUL-terminated ASCII tail block."""
-    return b"-" * dashes + serial + b"\x00" * 4
+def _sn_block(serial: bytes = CAPTURED_HMI_SN) -> bytes:
+    """Build one fixed-width serial-number block.
+
+    A serial shorter than the block is NUL-terminated and dash-padded, which
+    is how the unit fills a partially used slot.
+    """
+    if len(serial) >= SN_BLOCK_LEN:
+        return serial[:SN_BLOCK_LEN]
+    return serial + b"\x00" + b"-" * (SN_BLOCK_LEN - len(serial) - 1)
 
 
-class TestParseAsciiTail:
-    """Unit tests for the dash-padded ASCII tail scanner."""
+def _body_with_sn(
+    block: bytes,
+    *,
+    data_offset: int = 1,
+    size: int = 200,
+) -> bytearray:
+    """Place a serial-number block at its fixed offset in a message body."""
+    body = bytearray(size)
+    start = data_offset + HMI_SN_OFFSET
+    body[start : start + len(block)] = block
+    return body
 
-    def test_captured_tail_is_decoded(self) -> None:
-        """Test the real captured serial is returned verbatim."""
-        body = bytearray(32) + bytearray(_tail_block())
-        assert _parse_ascii_tail(body, 1) == CAPTURED_TAIL.decode()
 
-    def test_tail_is_located_by_dash_run_not_fixed_offset(self) -> None:
-        """Test the block is found wherever the dash run starts."""
-        near = bytearray(8) + bytearray(_tail_block())
-        far = bytearray(120) + bytearray(_tail_block())
-        assert _parse_ascii_tail(near, 1) == CAPTURED_TAIL.decode()
-        assert _parse_ascii_tail(far, 1) == CAPTURED_TAIL.decode()
+class TestParseSnBlock:
+    """Unit tests for the fixed-offset serial-number block decoder."""
 
-    def test_missing_dash_run_returns_none(self) -> None:
-        """Test a body without the padding run yields no identifier."""
-        assert _parse_ascii_tail(bytearray(200), 1) is None
+    def test_captured_serial_is_decoded(self) -> None:
+        """Test the real captured HMI serial is returned verbatim."""
+        body = _body_with_sn(_sn_block())
+        assert _parse_sn_block(body, 1, HMI_SN_OFFSET) == CAPTURED_HMI_SN.decode()
 
-    def test_short_dash_run_is_not_treated_as_padding(self) -> None:
-        """Test fewer than 20 dashes does not trigger a match."""
-        body = bytearray(16) + bytearray(b"-" * 8 + CAPTURED_TAIL + b"\x00")
-        assert _parse_ascii_tail(body, 1) is None
+    def test_block_is_read_relative_to_data_offset(self) -> None:
+        """Test a decoy at another offset is not picked up."""
+        body = _body_with_sn(_sn_block(), data_offset=33, size=240)
+        decoy = _sn_block(b"DECOY")
+        body[1 + HMI_SN_OFFSET : 1 + HMI_SN_OFFSET + SN_BLOCK_LEN] = decoy
+        assert _parse_sn_block(body, 33, HMI_SN_OFFSET) == CAPTURED_HMI_SN.decode()
+        assert _parse_sn_block(body, 1, HMI_SN_OFFSET) == "DECOY"
 
-    def test_empty_tail_returns_none(self) -> None:
-        """Test padding immediately followed by NUL yields no identifier."""
-        body = bytearray(16) + bytearray(b"-" * 24 + b"\x00" * 8)
-        assert _parse_ascii_tail(body, 1) is None
+    def test_nul_terminated_short_serial_is_decoded(self) -> None:
+        """Test a serial shorter than the block stops at the terminator."""
+        body = _body_with_sn(_sn_block(b"SHORT1"))
+        assert _parse_sn_block(body, 1, HMI_SN_OFFSET) == "SHORT1"
 
-    def test_non_ascii_tail_returns_none(self) -> None:
-        """Test a tail with non-ASCII bytes is rejected instead of raising."""
-        body = bytearray(16) + bytearray(b"-" * 24 + b"\xff\xfe\xfd" + b"\x00")
-        assert _parse_ascii_tail(body, 1) is None
+    def test_all_dash_block_returns_none(self) -> None:
+        """Test an unpopulated, dash-filled slot yields no identifier."""
+        body = _body_with_sn(b"-" * SN_BLOCK_LEN)
+        assert _parse_sn_block(body, 1, HMI_SN_OFFSET) is None
 
-    def test_unprintable_tail_returns_none(self) -> None:
-        """Test a control-character tail is rejected."""
-        body = bytearray(16) + bytearray(b"-" * 24 + b"AB\x07CD" + b"\x00")
-        assert _parse_ascii_tail(body, 1) is None
+    def test_leading_nul_block_returns_none(self) -> None:
+        """Test a block terminated at its first byte yields no identifier."""
+        body = _body_with_sn(b"\x00" * SN_BLOCK_LEN)
+        assert _parse_sn_block(body, 1, HMI_SN_OFFSET) is None
 
-    def test_scan_starts_at_data_offset(self) -> None:
-        """Test padding before data_offset is ignored."""
-        body = bytearray(b"-" * 24 + b"IGNORED" + b"\x00") + bytearray(_tail_block())
-        assert _parse_ascii_tail(body, 32) == CAPTURED_TAIL.decode()
+    def test_short_body_returns_none(self) -> None:
+        """Test a frame ending inside the block is rejected, not truncated.
+
+        The previous scanner returned whatever printable bytes it had when it
+        ran off the end of the buffer; a partial block must yield None.
+        """
+        body = _body_with_sn(_sn_block())[:180]
+        assert _parse_sn_block(body, 1, HMI_SN_OFFSET) is None
+
+    def test_non_ascii_block_returns_none(self) -> None:
+        """Test non-ASCII bytes are rejected instead of raising."""
+        body = _body_with_sn(b"\xff\xfe\xfd" + b"-" * (SN_BLOCK_LEN - 3))
+        assert _parse_sn_block(body, 1, HMI_SN_OFFSET) is None
+
+    def test_unprintable_block_returns_none(self) -> None:
+        """Test a control character in the block is rejected."""
+        body = _body_with_sn(b"AB\x07CD" + b"-" * (SN_BLOCK_LEN - 5))
+        assert _parse_sn_block(body, 1, HMI_SN_OFFSET) is None
 
 
 class TestC3UnitParaIdentification:
-    """Firmware versions and the Wi-Fi module serial in the X10 body.
+    """Firmware versions and the HMI serial number in the X10 body.
 
     The IDU / ODU software version bytes map to Modbus registers 130 and 1042
     and were cross-checked against the wired HMI, which displays them as
@@ -974,17 +1005,18 @@ class TestC3UnitParaIdentification:
     def _build_response(
         values: dict[int, int] | None = None,
         *,
-        with_tail: bool = True,
+        with_sn: bool = True,
         size: int = 200,
     ) -> MessageC3Response:
-        """Build an X10 query response, optionally carrying an ASCII tail."""
+        """Build an X10 query response, optionally carrying the SN block."""
         body = bytearray(size)
         body[0] = ListTypes.X10
         for index, value in (values or {}).items():
             body[index] = value
-        if with_tail:
-            block = _tail_block()
-            body[120 : 120 + len(block)] = block
+        if with_sn:
+            block = _sn_block()
+            start = 1 + HMI_SN_OFFSET
+            body[start : start + len(block)] = block
         header = TestC3UnitParaIdentification.HEADER
         return MessageC3Response(bytes(header + body))
 
@@ -1015,17 +1047,17 @@ class TestC3UnitParaIdentification:
         assert response.idu_software_version_str is None
         assert response.odu_software_version_str is None
 
-    def test_wifi_module_serial_is_exposed(self) -> None:
-        """Test the ASCII tail is surfaced as the Wi-Fi module serial."""
+    def test_hmi_sn_code_is_exposed(self) -> None:
+        """Test the SN block is surfaced as the HMI serial number."""
         response = self._build_response()
-        assert hasattr(response, "wifi_module_serial")
-        assert response.wifi_module_serial == CAPTURED_TAIL.decode()
+        assert hasattr(response, "hmi_sn_code")
+        assert response.hmi_sn_code == CAPTURED_HMI_SN.decode()
 
-    def test_wifi_module_serial_is_none_without_tail(self) -> None:
-        """Test a frame with no ASCII tail reports no serial."""
-        response = self._build_response(with_tail=False)
-        assert hasattr(response, "wifi_module_serial")
-        assert response.wifi_module_serial is None
+    def test_hmi_sn_code_is_none_without_block(self) -> None:
+        """Test a frame with an unpopulated block reports no serial."""
+        response = self._build_response(with_sn=False)
+        assert hasattr(response, "hmi_sn_code")
+        assert response.hmi_sn_code is None
 
     def test_identification_does_not_disturb_existing_fields(self) -> None:
         """Test the added parsing leaves earlier X10 offsets untouched."""
@@ -1034,38 +1066,43 @@ class TestC3UnitParaIdentification:
         assert response.current_unit_capacity == 556
 
 
-class TestC3EnergyAsciiTail:
-    """The notify1 0x04 energy body also carries the ASCII tail."""
+class TestC3EnergyBodyHasNoSnBlock:
+    """The notify1 0x04 energy body must not report a serial number.
+
+    Real X04 frames are 175 bytes and stop before the serial-number blocks,
+    so decoding them there only ever produced None. The parsing was removed;
+    these tests keep it from coming back.
+    """
 
     HEADER = bytearray(
         [0xAA, 0x00, 0xC3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, MessageType.notify1],
     )
 
     @staticmethod
-    def _build_response(*, with_tail: bool = True) -> MessageC3Response:
-        """Build a notify1 0x04 response, optionally carrying an ASCII tail."""
+    def _build_response(*, with_sn: bool = False) -> MessageC3Response:
+        """Build a notify1 0x04 response, optionally carrying an SN block."""
         body = bytearray(200)
         body[0] = ListTypes.X04
-        if with_tail:
-            block = _tail_block()
-            body[100 : 100 + len(block)] = block
-        return MessageC3Response(bytes(TestC3EnergyAsciiTail.HEADER + body))
+        if with_sn:
+            block = _sn_block()
+            start = 1 + HMI_SN_OFFSET
+            body[start : start + len(block)] = block
+        return MessageC3Response(bytes(TestC3EnergyBodyHasNoSnBlock.HEADER + body))
 
-    def test_wifi_module_serial_is_exposed(self) -> None:
-        """Test the notify body surfaces the same identifier."""
+    def test_energy_body_does_not_expose_a_serial(self) -> None:
+        """Test the notify body exposes no serial attribute."""
         response = self._build_response()
         assert response.body_type == ListTypes.X04
-        assert hasattr(response, "wifi_module_serial")
-        assert response.wifi_module_serial == CAPTURED_TAIL.decode()
+        assert not hasattr(response, "hmi_sn_code")
 
-    def test_wifi_module_serial_is_none_without_tail(self) -> None:
-        """Test a notify frame with no tail reports no serial."""
-        response = self._build_response(with_tail=False)
-        assert response.wifi_module_serial is None
+    def test_serial_bytes_in_the_frame_are_still_ignored(self) -> None:
+        """Test an oversized notify frame is not mined for a serial."""
+        response = self._build_response(with_sn=True)
+        assert not hasattr(response, "hmi_sn_code")
 
     def test_energy_counters_still_parse(self) -> None:
         """Test the added parsing does not disturb the energy counters."""
-        header = bytearray(TestC3EnergyAsciiTail.HEADER)
+        header = bytearray(TestC3EnergyBodyHasNoSnBlock.HEADER)
         body = bytearray(200)
         body[0] = ListTypes.X04
         for index, value in {

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -978,6 +978,40 @@ class TestParseSnBlock:
         body = _body_with_sn(_sn_block())[:180]
         assert _parse_sn_block(body, 1, HMI_SN_OFFSET) is None
 
+    def test_dash_padded_block_without_terminator_returns_none(self) -> None:
+        """Test a padded block with no NUL terminator is rejected.
+
+        A short value followed by dash padding but never NUL-terminated is
+        not a valid record -- the terminator is what marks the value as
+        complete. Flagged by CodeRabbit on 89809e1.
+        """
+        block = b"SHORT1" + b"-" * (SN_BLOCK_LEN - 6)
+        body = _body_with_sn(block)
+        assert _parse_sn_block(body, 1, HMI_SN_OFFSET) is None
+
+    def test_bytes_after_terminator_returns_none(self) -> None:
+        """Test non-padding bytes after the NUL terminator are rejected.
+
+        Only dash padding may follow the terminator. A stray byte there
+        means the block cannot be trusted, even though the bytes before the
+        terminator look like a plausible serial. Flagged by CodeRabbit on
+        89809e1.
+        """
+        block = b"SHORT1\x00\x07" + b"-" * (SN_BLOCK_LEN - 8)
+        body = _body_with_sn(block)
+        assert _parse_sn_block(body, 1, HMI_SN_OFFSET) is None
+
+    def test_full_length_serial_without_terminator_is_decoded(self) -> None:
+        """Test a serial that exactly fills the block needs no terminator.
+
+        A 32-byte value with no dash padding and no NUL is not a partial
+        record -- it simply has nothing left to pad. It must still decode.
+        """
+        block = CAPTURED_HMI_SN
+        assert len(block) == SN_BLOCK_LEN
+        body = _body_with_sn(block)
+        assert _parse_sn_block(body, 1, HMI_SN_OFFSET) == CAPTURED_HMI_SN.decode()
+
     def test_non_ascii_block_returns_none(self) -> None:
         """Test non-ASCII bytes are rejected instead of raising."""
         body = _body_with_sn(b"\xff\xfe\xfd" + b"-" * (SN_BLOCK_LEN - 3))

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -954,6 +954,24 @@ class TestParseSnBlock:
         assert _parse_sn_block(body, 33, HMI_SN_OFFSET) == CAPTURED_HMI_SN.decode()
         assert _parse_sn_block(body, 1, HMI_SN_OFFSET) == "DECOY"
 
+    def test_padding_only_block_is_rejected(self) -> None:
+        """A block holding nothing but a terminator and padding decodes to None."""
+        block = b"\x00" + b"-" * (SN_BLOCK_LEN - 1)
+        body = _body_with_sn(block)
+        assert _parse_sn_block(body, 1, HMI_SN_OFFSET) is None
+
+    def test_non_ascii_block_is_rejected(self) -> None:
+        """Bytes outside ASCII make the record untrustworthy, not a mojibake serial."""
+        block = b"\xff\xfe\x00" + b"-" * (SN_BLOCK_LEN - 3)
+        body = _body_with_sn(block)
+        assert _parse_sn_block(body, 1, HMI_SN_OFFSET) is None
+
+    def test_non_printable_ascii_block_is_rejected(self) -> None:
+        """Valid ASCII is still rejected when it carries a control character."""
+        block = b"AB\x01CD\x00" + b"-" * (SN_BLOCK_LEN - 6)
+        body = _body_with_sn(block)
+        assert _parse_sn_block(body, 1, HMI_SN_OFFSET) is None
+
     def test_nul_terminated_short_serial_is_decoded(self) -> None:
         """Test a serial shorter than the block stops at the terminator."""
         body = _body_with_sn(_sn_block(b"SHORT1"))


### PR DESCRIPTION
Second of the four pieces split out of #46, per @kmich's request to land them
one at a time so each can be verified against the 208-frame capture separately.
Follows #80 (error-code table).

### What this adds

C3 telemetry frames carry an ASCII block appended after the main payload —
a run of `-` padding, then a printable identifier, then NUL. On the capture
used here the block sits at bytes 160..191 and reads
`0000C3310171H120F24114100123MNJ2`.

- `_parse_ascii_tail()` in `midealan/devices/c3/message.py` decodes it. The
  block is located by scanning for the dash run rather than by a fixed
  offset, because the position moves between firmware revisions. Bodies with
  no padding run, an empty tail, non-ASCII bytes, or control characters
  return `None` rather than raising.
- `wifi_module_serial` is exposed from both `C3EnergyBody` (notify1 `0x04`)
  and `C3UnitParaBody` (`X10`).
- `idu_software_version` / `odu_software_version` are read from raw offsets
  93 and 94 of the `X10` body (Modbus reg 130 / reg 1042) and exposed as
  `idu_software_version_str` / `odu_software_version_str` formatted `V<n>`,
  matching what the wired HMI displays. Frames that stop before those
  offsets leave all four fields `None` — the existing short-body path is
  unaffected.
- Three matching `DeviceAttributes` entries with `None` defaults in
  `midealan/devices/c3/__init__.py`. No change to `process_message` was
  needed; it picks the new attributes up through the existing
  `hasattr`/`getattr` loop.

### Not included

`build_info` from the original #46 branch is intentionally left out. It was
only ever a raw duplicate of the tail kept "for future decoding", was never
registered in `DeviceAttributes`, and so never reached Home Assistant. It can
be added later if a concrete use appears.

### Verification

- 14 new tests in `tests/devices/c3/message_c3_test.py`: eight direct tests
  of the scanner (captured serial, offset independence, and each rejection
  path) and six integration tests covering firmware versions, short bodies,
  and both message bodies. Each also asserts that neighbouring fields
  (`fg_capacity_need`, `current_unit_capacity`, the 32-bit energy counters)
  still decode, so a regression cannot pass unnoticed.
- Full suite: 1983 passed.
- `ruff check`, `ruff format`, `mypy`, and `pylint --rcfile=pylintrc` all
  clean on the changed files.

Scoped to C3 only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Device details now expose the HMI serial number when available.
  - Added IDU and ODU software version fields for compatible device telemetry.
  - Added human-readable descriptions for recognized device error codes, including clear handling of unknown errors.
- **Updates**
  - Serial numbers are decoded from a fixed device data block for improved consistency.
  - Serial information is no longer reported from energy-notification telemetry.
- **Bug Fixes**
  - Improved validation of serial-number data, including terminators, padding, and complete values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->