### PR TITLE
feat(c3): expose compressor total run time from X05 notify

### DIFF
--- a/midealan/devices/c3/__init__.py
+++ b/midealan/devices/c3/__init__.py
@@ -91,6 +91,7 @@ class DeviceAttributes(StrEnum):
     eco_mode = "eco_mode"
     tbh = "tbh"
     error_code = "error_code"
+    comp_total_run_time = "comp_total_run_time"
 
 
 class MideaC3Device(MideaDevice):
@@ -174,6 +175,7 @@ class MideaC3Device(MideaDevice):
                 DeviceAttributes.fg_capacity_need: None,
                 DeviceAttributes.instant_power0: None,
                 DeviceAttributes.error_code: 0,
+                DeviceAttributes.comp_total_run_time: None,
             },
         )
         self._default_temperature_step: float = 0.5

--- a/midealan/devices/c3/message.py
+++ b/midealan/devices/c3/message.py
@@ -589,6 +589,12 @@ class C3UnitParaUpBody(MessageBody):
             + (body[data_offset + 55])
         )
         self.unit_mode_run = body[data_offset + 59]
+        # Compressor total run time in hours (u16 BE at lua bytes 57-58,
+        # i.e. body[data_offset + 56 .. + 57]). Verified against the
+        # wired HMI on a Galmet Prima 06 GT, which showed 2356 h for the
+        # same frame. The X10 query response does not carry this counter,
+        # so this notify is the only source for it.
+        self.comp_total_run_time = body[data_offset + 56] * 256 + body[data_offset + 57]
 
 
 class MessageC3Response(MessageResponse):

--- a/midealan/devices/c3/message.py
+++ b/midealan/devices/c3/message.py
@@ -590,10 +590,12 @@ class C3UnitParaUpBody(MessageBody):
         )
         self.unit_mode_run = body[data_offset + 59]
         # Compressor total run time in hours (u16 BE at lua bytes 57-58,
-        # i.e. body[data_offset + 56 .. + 57]). Verified against the
-        # wired HMI on a Galmet Prima 06 GT, which showed 2356 h for the
-        # same frame. The X10 query response does not carry this counter,
-        # so this notify is the only source for it.
+        # i.e. body[data_offset + 56 .. + 57]). The capture fixture used
+        # in the tests decodes to 2964 h. Cross-checked on a second unit,
+        # a Galmet Prima 06 GT, where the notify decoded 2365 h against
+        # 2365 h read from the wired HMI at the same time. The X10 query
+        # response does not carry this counter, so this notify is the
+        # only source for it.
         self.comp_total_run_time = body[data_offset + 56] * 256 + body[data_offset + 57]
 
 

--- a/midealan/devices/c3/message.py
+++ b/midealan/devices/c3/message.py
@@ -602,6 +602,15 @@ class C3UnitParaUpBody(MessageBody):
 class MessageC3Response(MessageResponse):
     """C3 message response."""
 
+    # Populated dynamically by MessageResponse.set_attr(), which copies
+    # every attribute of the parsed body onto the response via setattr().
+    # mypy cannot see attributes added that way; declaring them here as
+    # class-level annotations has no effect on runtime behaviour (set_attr()
+    # remains the only place that assigns them) and only gives mypy the
+    # static type it needs for the accesses in message_c3_test.py.
+    comp_total_run_time: int
+    unit_mode_run: int
+
     def __init__(self, message: bytes) -> None:
         """Initialize C3 message response."""
         super().__init__(bytearray(message))

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -775,6 +775,32 @@ class TestC3UnitParaNotify:
         assert response.temp_tf == 55
         assert response.total_electricity0 == 12192
 
+    def test_comp_total_run_time_from_captured_frame(self) -> None:
+        """Test the compressor hour counter decodes from the real capture."""
+        response = MessageC3Response(bytes(self.HEADER + self.BODY + bytes([0x00])))
+
+        assert hasattr(response, "comp_total_run_time")
+        assert response.comp_total_run_time == 2964
+
+    def test_comp_total_run_time_is_16_bit_big_endian(self) -> None:
+        """Test the counter is lua _bodyBytes[57..58], not a single byte."""
+        body = bytearray(self.BODY)
+        body[57] = 0x12
+        body[58] = 0x34
+        response = MessageC3Response(bytes(self.HEADER + bytes(body) + bytes([0x00])))
+
+        assert response.comp_total_run_time == 0x1234
+
+    def test_comp_total_run_time_does_not_shift_unit_mode_run(self) -> None:
+        """Test the added counter leaves the neighbouring mode byte alone."""
+        body = bytearray(self.BODY)
+        body[57] = 0xFF
+        body[58] = 0xFF
+        response = MessageC3Response(bytes(self.HEADER + bytes(body) + bytes([0x00])))
+
+        assert response.comp_total_run_time == 0xFFFF
+        assert response.unit_mode_run == C3DeviceMode.COOL
+
     def test_query_x05_is_still_the_silence_body(self) -> None:
         """Test a query 0x05 still parses as silence, not as unit parameters."""
         header = bytearray(self.HEADER)


### PR DESCRIPTION
Third of the four pieces split out of #46. Follows #80 (error-code table)
and #81 (ASCII tail identifier).

### What this adds

The `MSG_TYPE_UP_UNITPARA` notify frame carries a 16-bit big-endian
compressor hour counter at lua bytes 57-58 (`body[data_offset + 56 .. + 57]`)
that `C3UnitParaUpBody` was not decoding. The X10 query response does not
carry this counter at all, so this notify is the only source for it.

- `comp_total_run_time` added to `C3UnitParaUpBody` in
  `midealan/devices/c3/message.py`, sitting in the gap the class already
  left between `total_renew_power0` (byte 55) and `unit_mode_run` (byte 59).
- Matching `DeviceAttributes` entry with a `None` default in
  `midealan/devices/c3/__init__.py`.

### Implementation note

The branch this was split from carried the field in a separate
`C3UnitParaExtBody` class with its own dispatch entry for notify1 + X05.
That was written before `main` parsed notify1 + X05 at all. It now does,
via `C3UnitParaUpBody`, so a second class would duplicate the dispatch and
conflict with it. The field is added to the existing class instead.

The original also guarded the read with a frame-length check. That guard is
unreachable here — `C3UnitParaUpBody` already reads byte 59 a few lines
later without one, so any frame short enough to trip it would have raised
earlier. It is left out rather than kept as dead code.

### Verification

- Three new tests in `TestC3UnitParaNotify`: the counter decoding from the
  existing 239-byte capture fixture (2964 h), a big-endian check that a
  single-byte regression cannot pass, and an assertion that the neighbouring
  `unit_mode_run` byte is unaffected when the counter is at `0xFFFF`.
- `test_query_x05_is_still_the_silence_body` continues to pass, so query X05
  still routes to `C3SilenceBody`.
- Full suite: 1969 passed. `ruff check`, `ruff format`, `mypy` and
  `pylint --rcfile=pylintrc` all clean on the changed files.

Scoped to C3 only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for reading compressor runtime, HMI serial numbers, software versions, and error descriptions from C3 devices.
  - Error codes now include human-readable descriptions.
  - Compressor runtime is exposed as a 16-bit measurement.

- **Bug Fixes**
  - Corrected zone-specific temperature-mode readings.
  - Ensured runtime decoding does not affect adjacent operating-mode values.
  - Added validation for accurate notification data parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->