### PR TITLE
feat(c3): decode reg 129 load output bitmap

### DIFF
--- a/midealan/devices/c3/__init__.py
+++ b/midealan/devices/c3/__init__.py
@@ -91,6 +91,16 @@ class DeviceAttributes(StrEnum):
     eco_mode = "eco_mode"
     tbh = "tbh"
     error_code = "error_code"
+    ibh1_on = "ibh1_on"
+    ibh2_on = "ibh2_on"
+    load_output_tbh = "load_output_tbh"
+    pump_i_running = "pump_i_running"
+    sv1_open = "sv1_open"
+    sv2_open = "sv2_open"
+    pump_o_running = "pump_o_running"
+    pump_d_running = "pump_d_running"
+    pump_c_running = "pump_c_running"
+    raw_b31 = "raw_b31"
 
 
 class MideaC3Device(MideaDevice):
@@ -174,6 +184,16 @@ class MideaC3Device(MideaDevice):
                 DeviceAttributes.fg_capacity_need: None,
                 DeviceAttributes.instant_power0: None,
                 DeviceAttributes.error_code: 0,
+                DeviceAttributes.ibh1_on: None,
+                DeviceAttributes.ibh2_on: None,
+                DeviceAttributes.load_output_tbh: None,
+                DeviceAttributes.pump_i_running: None,
+                DeviceAttributes.sv1_open: None,
+                DeviceAttributes.sv2_open: None,
+                DeviceAttributes.pump_o_running: None,
+                DeviceAttributes.pump_d_running: None,
+                DeviceAttributes.pump_c_running: None,
+                DeviceAttributes.raw_b31: None,
             },
         )
         self._default_temperature_step: float = 0.5

--- a/midealan/devices/c3/__init__.py
+++ b/midealan/devices/c3/__init__.py
@@ -100,7 +100,20 @@ class DeviceAttributes(StrEnum):
     pump_o_running = "pump_o_running"
     pump_d_running = "pump_d_running"
     pump_c_running = "pump_c_running"
-    raw_b31 = "raw_b31"
+    sv3_open = "sv3_open"
+    crankcase_heater_on = "crankcase_heater_on"
+    pump_s_running = "pump_s_running"
+    alarm_on = "alarm_on"
+    run_valve_on = "run_valve_on"
+    aux_heat_on = "aux_heat_on"
+    defrost_valve_on = "defrost_valve_on"
+    fact_req_solar_on = "fact_req_solar_on"
+    fact_req_ther_cool_on = "fact_req_ther_cool_on"
+    cool_run = "cool_run"
+    heat_run = "heat_run"
+    dhw_run = "dhw_run"
+    fact_req_ther_heat_on = "fact_req_ther_heat_on"
+    edge_version_type = "edge_version_type"
 
 
 class MideaC3Device(MideaDevice):
@@ -193,7 +206,20 @@ class MideaC3Device(MideaDevice):
                 DeviceAttributes.pump_o_running: None,
                 DeviceAttributes.pump_d_running: None,
                 DeviceAttributes.pump_c_running: None,
-                DeviceAttributes.raw_b31: None,
+                DeviceAttributes.sv3_open: None,
+                DeviceAttributes.crankcase_heater_on: None,
+                DeviceAttributes.pump_s_running: None,
+                DeviceAttributes.alarm_on: None,
+                DeviceAttributes.run_valve_on: None,
+                DeviceAttributes.aux_heat_on: None,
+                DeviceAttributes.defrost_valve_on: None,
+                DeviceAttributes.fact_req_solar_on: None,
+                DeviceAttributes.fact_req_ther_cool_on: None,
+                DeviceAttributes.cool_run: None,
+                DeviceAttributes.heat_run: None,
+                DeviceAttributes.dhw_run: None,
+                DeviceAttributes.fact_req_ther_heat_on: None,
+                DeviceAttributes.edge_version_type: None,
             },
         )
         self._default_temperature_step: float = 0.5

--- a/midealan/devices/c3/message.py
+++ b/midealan/devices/c3/message.py
@@ -459,11 +459,29 @@ class C3UnitParaBody(MessageBody):
         self.pump_o_running = bool(load_output & 0x40)
         self.pump_d_running = bool(load_output & 0x80)
         self.pump_c_running = bool(load_output_hi & 0x01)
-        # Diagnostic: bit-field-shaped byte whose register is not yet
-        # identified. Observed values 0/32/64/96 across 443 frames, with
-        # only bit5 and bit6 varying. Exposed raw so its bits can be
-        # correlated against scenario events before being named.
-        self.raw_b31 = body[data_offset + 30]
+        # Remaining bits of register 129 (Modbus doc V4.7 BIT9-BIT15).
+        # BIT13 and BIT15 are documented as reserved, but the 171H120F lua
+        # reads them as fgRunValveOn and fgDefValveOn and they are live on
+        # real units, so both are decoded. BIT10 is "Crankcase heater" in
+        # the doc and fgHeat4ValveOn in the lua; the doc name is used.
+        self.sv3_open = bool(load_output_hi & 0x02)
+        self.crankcase_heater_on = bool(load_output_hi & 0x04)
+        self.pump_s_running = bool(load_output_hi & 0x08)
+        self.alarm_on = bool(load_output_hi & 0x10)
+        self.run_valve_on = bool(load_output_hi & 0x20)
+        self.aux_heat_on = bool(load_output_hi & 0x40)
+        self.defrost_valve_on = bool(load_output_hi & 0x80)
+        # Run-state byte. Not part of the Modbus register map; the bit
+        # names come from the 171H120F lua, which fills bits 1-7. Bit 0 is
+        # unnamed there and is left undecoded.
+        run_state = body[data_offset + 30]
+        self.fact_req_solar_on = bool(run_state & 0x02)
+        self.fact_req_ther_cool_on = bool(run_state & 0x04)
+        self.cool_run = bool(run_state & 0x08)
+        self.heat_run = bool(run_state & 0x10)
+        self.dhw_run = bool(run_state & 0x20)
+        self.fact_req_ther_heat_on = bool(run_state & 0x40)
+        self.edge_version_type = bool(run_state & 0x80)
         self.temp_t1 = body[data_offset + 33]
         self.temp_tw2 = body[data_offset + 34]
         self.temp_t2 = body[data_offset + 35]

--- a/midealan/devices/c3/message.py
+++ b/midealan/devices/c3/message.py
@@ -439,6 +439,31 @@ class C3UnitParaBody(MessageBody):
         self.odu_model = body[data_offset + 21]
         # self.unit_online_num  body[data_offset + 22]
         # self.current_code  body[data_offset + 23]
+        # LOAD_OUTPUT bitmap. Authoritative source: Midea Modbus doc
+        # V4.7, register 129 (Load output, 16-bit). Cross-checked
+        # against the wired HMI during a pump test.
+        #   BIT0 = electric heater IBH1     BIT4 = SV1
+        #   BIT1 = electric heater IBH2     BIT5 = SV2
+        #   BIT2 = electric heater TBH      BIT6 = external pump Pump_o
+        #   BIT3 = internal pump Pump_i     BIT7 = DHW pump Pump_d
+        # BIT8 (mixed water loop pump Pump_c, zone 2) lives in the
+        # adjacent byte; BIT9-BIT15 are reserved per the Modbus doc.
+        load_output = body[data_offset + 32]
+        load_output_hi = body[data_offset + 31]
+        self.ibh1_on = bool(load_output & 0x01)
+        self.ibh2_on = bool(load_output & 0x02)
+        self.load_output_tbh = bool(load_output & 0x04)
+        self.pump_i_running = bool(load_output & 0x08)
+        self.sv1_open = bool(load_output & 0x10)
+        self.sv2_open = bool(load_output & 0x20)
+        self.pump_o_running = bool(load_output & 0x40)
+        self.pump_d_running = bool(load_output & 0x80)
+        self.pump_c_running = bool(load_output_hi & 0x01)
+        # Diagnostic: bit-field-shaped byte whose register is not yet
+        # identified. Observed values 0/32/64/96 across 443 frames, with
+        # only bit5 and bit6 varying. Exposed raw so its bits can be
+        # correlated against scenario events before being named.
+        self.raw_b31 = body[data_offset + 30]
         self.temp_t1 = body[data_offset + 33]
         self.temp_tw2 = body[data_offset + 34]
         self.temp_t2 = body[data_offset + 35]

--- a/midealan/devices/c3/message.py
+++ b/midealan/devices/c3/message.py
@@ -637,6 +637,30 @@ class C3UnitParaUpBody(MessageBody):
 class MessageC3Response(MessageResponse):
     """C3 message response."""
 
+    # Populated dynamically by MessageResponse.set_attr(), which copies
+    # every attribute of the parsed body onto the response via setattr().
+    # mypy cannot see attributes added that way; declaring them here as
+    # class-level annotations has no effect on runtime behaviour (set_attr()
+    # remains the only place that assigns them) and only gives mypy the
+    # static type it needs for the accesses in message_c3_test.py.
+    temp_t1: int
+    ibh1_on: bool
+    pump_i_running: bool
+    sv1_open: bool
+    pump_d_running: bool
+    pump_c_running: bool
+    sv2_open: bool
+    load_output_tbh: bool
+    run_valve_on: bool
+    dhw_run: bool
+    fact_req_ther_heat_on: bool
+    sv3_open: bool
+    alarm_on: bool
+    aux_heat_on: bool
+    defrost_valve_on: bool
+    cool_run: bool
+    heat_run: bool
+
     def __init__(self, message: bytes) -> None:
         """Initialize C3 message response."""
         super().__init__(bytearray(message))

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -1,5 +1,7 @@
 """Test c3 message."""
 
+from typing import ClassVar
+
 import pytest
 
 from midealan.const import ProtocolVersion
@@ -948,13 +950,6 @@ class TestC3UnitParaLoadOutput:
         assert response.pump_c_running is False
         assert response.ibh1_on is False
 
-    def test_raw_b31_is_exposed_verbatim(self) -> None:
-        """Test the unmapped diagnostic byte is surfaced unchanged."""
-        response = self._build_response({31: 96})
-
-        assert hasattr(response, "raw_b31")
-        assert response.raw_b31 == 96
-
     def test_bitmap_does_not_disturb_neighbouring_fields(self) -> None:
         """Test the added reads leave the surrounding X10 offsets alone."""
         response = self._build_response({31: 96, 32: 0x01, 33: 0xFF, 34: 21})
@@ -1015,3 +1010,148 @@ class TestC3UnitParaOutdoorTelemetryOffsets:
         response = self._build_response(values)
         assert hasattr(response, attribute)
         assert getattr(response, attribute) == expected
+
+
+class TestC3LoadOutputHighByte:
+    """Register 129 high byte and the adjacent lua run-state byte.
+
+    The X10 body carries register 129 (Load output) across two bytes. The
+    low byte at ``body[data_offset + 32]`` is covered by
+    ``TestC3LoadOutputBitmap``; this covers the high byte at
+    ``body[data_offset + 31]`` (Modbus doc V4.7 BIT8-BIT15) and the
+    run-state byte at ``body[data_offset + 30]``.
+
+    The run-state byte is not in the Modbus map. Its bit names come from
+    the 171H120F lua, which fills bits 1-7 and leaves bit 0 unnamed.
+
+    The frame below is a real X10 response from a Galmet Prima 06 GT
+    captured while the compressor was running at 17 Hz during a DHW
+    cycle. Byte 31 reads 32 (run valve) and byte 30 reads 96 (DHW run
+    plus the heating request), which is what the wired HMI showed.
+    """
+
+    HEADER = bytearray(
+        [0xAA, 0x00, 0xC3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, MessageType.query],
+    )
+
+    BODY = bytes.fromhex(
+        "1011032302030015151f2f2f7f000000000100eb01e0060100000000040087"
+        "60201c2e191d1e30197f7f14074e08341b022401251bffff00570000ec0000"
+        "00000000340000392e00002ab0000016f100002ab000cd0000000017770000"
+        "000e402d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d"
+        "2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d"
+        "2d2d2d2d2d3030303043333331303137314831323046323431313431303031"
+        "32334d4e4a320000000000000000",
+    )
+
+    HIGH_BYTE_BITS: ClassVar[list[tuple[int, str]]] = [
+        (0x01, "pump_c_running"),
+        (0x02, "sv3_open"),
+        (0x04, "crankcase_heater_on"),
+        (0x08, "pump_s_running"),
+        (0x10, "alarm_on"),
+        (0x20, "run_valve_on"),
+        (0x40, "aux_heat_on"),
+        (0x80, "defrost_valve_on"),
+    ]
+
+    RUN_STATE_BITS: ClassVar[list[tuple[int, str]]] = [
+        (0x02, "fact_req_solar_on"),
+        (0x04, "fact_req_ther_cool_on"),
+        (0x08, "cool_run"),
+        (0x10, "heat_run"),
+        (0x20, "dhw_run"),
+        (0x40, "fact_req_ther_heat_on"),
+        (0x80, "edge_version_type"),
+    ]
+
+    # BODY indices. The X10 response has data_offset = 1, so the register
+    # 129 high byte at body[data_offset + 31] is BODY[32] and the lua
+    # run-state byte at body[data_offset + 30] is BODY[31].
+    HIGH_BYTE_INDEX = 32
+    RUN_STATE_INDEX = 31
+
+    def _response(self, index: int, value: int) -> MessageC3Response:
+        """Build a response with one body byte overridden."""
+        body = bytearray(self.BODY)
+        body[index] = value
+        return MessageC3Response(bytes(self.HEADER + bytes(body) + bytes([0x00])))
+
+    @pytest.mark.parametrize(("mask", "attribute"), HIGH_BYTE_BITS)
+    def test_high_byte_bit_drives_one_flag(self, mask: int, attribute: str) -> None:
+        """Test each register 129 high bit sets its flag and no other."""
+        response = self._response(self.HIGH_BYTE_INDEX, mask)
+
+        assert getattr(response, attribute) is True
+
+        for other_mask, other_attribute in self.HIGH_BYTE_BITS:
+            if other_mask != mask:
+                assert getattr(response, other_attribute) is False
+
+    @pytest.mark.parametrize(("mask", "attribute"), RUN_STATE_BITS)
+    def test_run_state_bit_drives_one_flag(self, mask: int, attribute: str) -> None:
+        """Test each lua run-state bit sets its flag and no other."""
+        response = self._response(self.RUN_STATE_INDEX, mask)
+
+        assert getattr(response, attribute) is True
+
+        for other_mask, other_attribute in self.RUN_STATE_BITS:
+            if other_mask != mask:
+                assert getattr(response, other_attribute) is False
+
+    def test_all_high_byte_flags_clear_when_byte_is_zero(self) -> None:
+        """Test a zero high byte leaves every register 129 flag off."""
+        response = self._response(self.HIGH_BYTE_INDEX, 0x00)
+
+        for _, attribute in self.HIGH_BYTE_BITS:
+            assert getattr(response, attribute) is False
+
+    def test_all_run_state_flags_clear_when_byte_is_zero(self) -> None:
+        """Test a zero run-state byte leaves every lua flag off."""
+        response = self._response(self.RUN_STATE_INDEX, 0x00)
+
+        for _, attribute in self.RUN_STATE_BITS:
+            assert getattr(response, attribute) is False
+
+    def test_run_state_bit0_is_not_decoded(self) -> None:
+        """Test the unnamed lua bit 0 drives none of the run-state flags."""
+        response = self._response(self.RUN_STATE_INDEX, 0x01)
+
+        for _, attribute in self.RUN_STATE_BITS:
+            assert getattr(response, attribute) is False
+
+    def test_captured_compressor_run(self) -> None:
+        """Test the captured frame decodes the state the HMI showed.
+
+        The high byte is 32 and the run-state byte is 96 on this frame:
+        the run valve is open with the compressor at 17 Hz, and the unit
+        is in DHW with the heating request set. Across the 229 captured
+        frames the high byte bit 5 was set in all 66 frames with a running
+        compressor and in none of the 163 with it stopped.
+        """
+        response = MessageC3Response(
+            bytes(self.HEADER + self.BODY + bytes([0x00])),
+        )
+
+        assert response.run_valve_on is True
+        assert response.dhw_run is True
+        assert response.fact_req_ther_heat_on is True
+
+        assert response.sv3_open is False
+        assert response.alarm_on is False
+        assert response.aux_heat_on is False
+        assert response.defrost_valve_on is False
+        assert response.cool_run is False
+        assert response.heat_run is False
+
+    def test_neighbouring_fields_still_decode(self) -> None:
+        """Test the bytes either side of the pair are untouched."""
+        response = MessageC3Response(
+            bytes(self.HEADER + self.BODY + bytes([0x00])),
+        )
+
+        assert response.load_output_tbh is True
+        assert response.pump_i_running is True
+        assert response.sv1_open is True
+        assert response.ibh1_on is False
+        assert response.temp_t1 == 46

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -847,6 +847,122 @@ class TestC3UnitParaLuaOffsets:
         assert response.total_renew_power0 == 0
 
 
+class TestC3UnitParaLoadOutput:
+    """The LOAD_OUTPUT bitmap in the X10 body.
+
+    Authoritative source: Midea Modbus doc V4.7, register 129 (Load output).
+    The low byte sits at body[data_offset + 32] and carries BIT0..BIT7; BIT8
+    (mixed water loop pump, zone 2) is the low bit of the adjacent byte at
+    body[data_offset + 31]. Cross-checked against the wired HMI during a
+    pump test.
+    """
+
+    HEADER = bytearray(
+        [0xAA, 0x00, 0xC3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, MessageType.query],
+    )
+
+    @staticmethod
+    def _build_response(values: dict[int, int]) -> MessageC3Response:
+        """Build an X10 query response with the given body bytes set."""
+        body = bytearray(96)
+        body[0] = ListTypes.X10
+        for index, value in values.items():
+            body[index] = value
+        return MessageC3Response(bytes(TestC3UnitParaLoadOutput.HEADER + body))
+
+    @pytest.mark.parametrize(
+        ("attribute", "mask"),
+        [
+            ("ibh1_on", 0x01),
+            ("ibh2_on", 0x02),
+            ("load_output_tbh", 0x04),
+            ("pump_i_running", 0x08),
+            ("sv1_open", 0x10),
+            ("sv2_open", 0x20),
+            ("pump_o_running", 0x40),
+            ("pump_d_running", 0x80),
+        ],
+    )
+    def test_each_low_byte_bit_maps_to_its_flag(
+        self,
+        attribute: str,
+        mask: int,
+    ) -> None:
+        """Test every documented low-byte bit drives exactly one flag."""
+        response = self._build_response({33: mask})
+
+        assert hasattr(response, attribute)
+        assert getattr(response, attribute) is True
+        others = [
+            "ibh1_on",
+            "ibh2_on",
+            "load_output_tbh",
+            "pump_i_running",
+            "sv1_open",
+            "sv2_open",
+            "pump_o_running",
+            "pump_d_running",
+        ]
+        for other in others:
+            if other != attribute:
+                assert getattr(response, other) is False
+
+    def test_all_flags_clear_when_byte_is_zero(self) -> None:
+        """Test an idle unit reports every load output off."""
+        response = self._build_response({33: 0x00})
+
+        assert response.ibh1_on is False
+        assert response.pump_i_running is False
+        assert response.sv1_open is False
+        assert response.pump_d_running is False
+        assert response.pump_c_running is False
+
+    def test_combined_flags_from_pump_test(self) -> None:
+        """Test the pump-test combination decodes as observed on the HMI."""
+        # Internal pump + SV1 running, everything else off.
+        response = self._build_response({33: 0x18})
+
+        assert response.pump_i_running is True
+        assert response.sv1_open is True
+        assert response.ibh1_on is False
+        assert response.sv2_open is False
+
+    def test_pump_c_comes_from_the_adjacent_byte(self) -> None:
+        """Test BIT8 is read from the byte before the low byte."""
+        response = self._build_response({32: 0x01, 33: 0x00})
+
+        assert response.pump_c_running is True
+        assert response.pump_i_running is False
+
+    def test_low_byte_does_not_leak_into_pump_c(self) -> None:
+        """Test a fully set low byte leaves BIT8 clear."""
+        response = self._build_response({33: 0xFF})
+
+        assert response.pump_d_running is True
+        assert response.pump_c_running is False
+
+    def test_reserved_high_bits_are_not_exposed(self) -> None:
+        """Test bits 9-15 do not affect any decoded flag."""
+        response = self._build_response({32: 0xFE, 33: 0x00})
+
+        assert response.pump_c_running is False
+        assert response.ibh1_on is False
+
+    def test_raw_b31_is_exposed_verbatim(self) -> None:
+        """Test the unmapped diagnostic byte is surfaced unchanged."""
+        response = self._build_response({31: 96})
+
+        assert hasattr(response, "raw_b31")
+        assert response.raw_b31 == 96
+
+    def test_bitmap_does_not_disturb_neighbouring_fields(self) -> None:
+        """Test the added reads leave the surrounding X10 offsets alone."""
+        response = self._build_response({31: 96, 32: 0x01, 33: 0xFF, 34: 21})
+
+        assert response.temp_t1 == 21
+        assert response.pump_d_running is True
+
+
 class TestC3UnitParaOutdoorTelemetryOffsets:
     """Pin the X10 body offsets for the outdoor-unit telemetry fields.
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><p>Last of the four pieces split out of #46. Follows #80 (error-code table), #81 (HMI serial and firmware versions) and #82 (compressor run time).</p>
<h3>What this adds</h3>
<p>Register 129 (Load output) spans two bytes of the X10 body, and neither was fully decoded. The run-state byte immediately before them was not decoded at all.</p>
<p><strong>Low byte</strong> — <code>body[data_offset + 32]</code>, Modbus BIT0-BIT7:</p>

bit | attribute | load output
-- | -- | --
0 | ibh1_on | Electric heater IBH1
1 | ibh2_on | Electric heater IBH2
2 | load_output_tbh | Electric heater TBH
3 | pump_i_running | Internal circulation pump
4 | sv1_open | SV1
5 | sv2_open | SV2
6 | pump_o_running | External circulation pump
7 | pump_d_running | DHW circulation pump


<p>This replaces <code>raw_b31</code>, which the first revision shipped undecoded.</p>
<h3>Not included</h3>
<p><code>ibh1_on</code>, <code>ibh2_on</code>, <code>load_output_tbh</code>, <code>sv1_open</code>, <code>sv2_open</code> and <code>pump_d_running</code> are decoded but unverified against hardware. All six sit at 0 across both available captures, which cover heating and DHW without backup heat. @kmich has offered to confirm them from a DHW cycle and a heating run with backup heat; that can follow separately.</p>
<p>Bit 0 of the run-state byte is left undecoded. The lua names bits 1-7 and leaves that one blank.</p>
<h3>Verification</h3>
<p>Against 229 X10 frames from a Galmet Prima 06 GT:</p>
<ul>
<li>High byte bit 5 (<code>run_valve_on</code>) is set in all 66 frames with a running compressor and in none of the 163 with it stopped, flipping on the same poll the compressor starts and again when it stops.</li>
<li>Run-state bit 5 (<code>dhw_run</code>) rises and falls with the tank heating from 48 to 53 °C. Bit 6 holds throughout the heating run.</li>
<li>Every other high-byte bit reads 0 across all 229 frames, consistent with a monobloc with no solar loop, no backup heat and no faults.</li>
</ul>
<p>Tests: a parametrised case per bit of both bytes asserting it drives its own flag and leaves the others clear, all-off cases for each byte, a check that the unnamed run-state bit 0 drives nothing, decoding of a captured frame taken during a DHW cycle at 17 Hz, and a guard that the neighbouring low-byte flags and <code>temp_t1</code> still decode.</p>
<p>Full suite: 2000 passed. <code>ruff check</code>, <code>ruff format</code>, <code>mypy</code> and <code>pylint --rcfile=pylintrc</code> all clean.</p>
<p>Scoped to C3 only.</p>
</body></html><!--EndFragment-->
</body>
</html>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detailed device status indicators for pumps, valves, heating, cooling, hot water, defrost, alarms, and auxiliary heat.
  - Added decoding for indoor/outdoor software versions and HMI serial numbers.
  - Added compressor total runtime reporting.
  - Added human-readable descriptions for recognized and unknown error codes.
  - Added operating-state and equipment-demand telemetry for more comprehensive device monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->