### PR TITLE
refactor(ac): store B5 temperature limits in capabilities map

### DIFF
--- a/midealan/devices/ac/__init__.py
+++ b/midealan/devices/ac/__init__.py
@@ -14,6 +14,7 @@ from midealan.message import ListTypes
 from .message import (
     CapabilitiesAdditionalQuery,
     CapabilitiesQuery,
+    CapabilityValue,
     GroupOneQuery,
     GroupSevenQuery,
     GroupTwoQuery,
@@ -52,6 +53,12 @@ ACQuery = (
 
 # AC mode constants
 DRY_MODE = 3
+
+# Maps the reported mode value to the capabilities["temperature"] range key.
+# auto=1, cool=2, dry=3, heat=4, fan=5; dry and fan reuse the cool range.
+TEMPERATURE_LIMIT_MODE_KEYS = {1: "auto", 2: "cool", 3: "cool", 4: "heat", 5: "cool"}
+# Fallback range key for an unknown mode (e.g. 0 when the unit is off).
+TEMPERATURE_LIMIT_DEFAULT_KEY = "cool"
 
 
 class DeviceAttributes(StrEnum):
@@ -328,15 +335,14 @@ class MideaACDevice(MideaDevice):
         self._used_subprotocol: bool = self._model_capabilities.uses_bb_protocol
         self._bb_sn8_flag: bool = False
         self._bb_timer: bool = False
-        # per-mode setpoint limits from the B5 capability, keyed by mode value
-        self._temperature_limits: dict[int, tuple[float, float]] | None = None
         # decoded B5 capability flags (accumulated across B5 frames). Values are
-        # mostly booleans, but some (e.g. rate_select level count) are ints.
-        self._capabilities: dict[str, bool | int] = {}
+        # mostly booleans, but some are ints (e.g. rate_select level count) or a
+        # nested per-mode setpoint-limit map (the "temperature" key).
+        self._capabilities: dict[str, CapabilityValue] = {}
         # user-provided capability overrides from customize. Merged over the
         # B5-parsed values (see the capabilities property), so a user can force
         # a feature the B5 query missed, or disable one it reported in error.
-        self._customize_capabilities: dict[str, bool | int] = {}
+        self._customize_capabilities: dict[str, CapabilityValue] = {}
         # B5 capability query control. Both queries run once, like the appliance
         # query: on success the flag is cleared so it is never re-sent (the reply
         # never changes); on timeout the device layer records it in
@@ -396,7 +402,7 @@ class MideaACDevice(MideaDevice):
         2-gear map (50/75/100), 2 or 3 select the 5-gear map. Anything else
         (including 0/unsupported) yields an empty map so no options are offered.
         """
-        _levels: int = self.capabilities.get("rate_select", 0)
+        _levels = cast("int", self.capabilities.get("rate_select", 0))
         if _levels in (2, 3):
             return MideaACDevice._rate_select_level5
         if _levels == 1:
@@ -605,8 +611,10 @@ class MideaACDevice(MideaDevice):
             if update_self_clean:
                 self._attributes[DeviceAttributes.self_clean] = active
                 new_status[DeviceAttributes.self_clean.value] = active
-        new_status.update(self._refresh_temperature_limits(message))
+        # Merge capabilities first so a B5 frame's temperature limits are in the
+        # merged map before the setpoint limits are resolved from it.
         new_status.update(self._update_capabilities(message))
+        new_status.update(self._refresh_temperature_limits())
         return new_status
 
     @staticmethod
@@ -680,7 +688,7 @@ class MideaACDevice(MideaDevice):
         return {"capabilities": self.capabilities}
 
     @property
-    def capabilities(self) -> dict[str, bool | int]:
+    def capabilities(self) -> dict[str, CapabilityValue]:
         """Return the effective capability flags for the device.
 
         This is the B5-parsed capability map overlaid with the user's customize
@@ -692,24 +700,29 @@ class MideaACDevice(MideaDevice):
     def _capability_temperature_limits(self) -> tuple[float, float] | None:
         """Return the capability setpoint limits for the current mode, if any.
 
-        An unknown mode (e.g. 0 when off) falls back to the cool range.
+        Reads the per-mode limits from the merged ``capabilities`` map (the
+        nested ``temperature`` entry). An unknown mode (e.g. 0 when off) falls
+        back to the cool range.
         """
-        if self._temperature_limits is None:
+        temperature = self.capabilities.get("temperature")
+        if not isinstance(temperature, dict):
             return None
         mode = self._attributes[DeviceAttributes.mode]
-        return self._temperature_limits.get(mode, self._temperature_limits[2])
+        range_key = TEMPERATURE_LIMIT_MODE_KEYS.get(
+            mode,
+            TEMPERATURE_LIMIT_DEFAULT_KEY,
+        )
+        limits = temperature[range_key]
+        if not isinstance(limits, dict):
+            return None
+        return (limits["min"], limits["max"])
 
-    def _refresh_temperature_limits(
-        self,
-        message: MessageACResponse | None = None,
-    ) -> dict[str, Any]:
+    def _refresh_temperature_limits(self) -> dict[str, Any]:
         """Resolve min/max setpoint limits.
 
         Priority: customize option > capability response > None (the consumer
         then falls back to its own default range).
         """
-        if message is not None and hasattr(message, "temperature_limits"):
-            self._temperature_limits = message.temperature_limits
         capability_limits = self._capability_temperature_limits()
         minimum = self._customize_min_temperature
         if minimum is None and capability_limits is not None:

--- a/midealan/devices/ac/__init__.py
+++ b/midealan/devices/ac/__init__.py
@@ -712,8 +712,11 @@ class MideaACDevice(MideaDevice):
             mode,
             TEMPERATURE_LIMIT_DEFAULT_KEY,
         )
-        limits = temperature[range_key]
+        limits = temperature.get(range_key)
         if not isinstance(limits, dict):
+            return None
+        # Validate that both min and max keys exist before indexing
+        if "min" not in limits or "max" not in limits:
             return None
         return (limits["min"], limits["max"])
 

--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -18,6 +18,11 @@ from midealan.message import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# A decoded B5 capability value. Most tags decode to a bool/int flag, but the
+# temperature tag decodes to a nested per-mode setpoint-limit map
+# ({"cool"|"auto"|"heat": {"min": float, "max": float}, "decimals": bool}).
+CapabilityValue = bool | int | dict[str, dict[str, float] | bool]
+
 A1_MIN_BODY_LENGTH = 18
 
 BB_AC_MODES = [0, 3, 1, 2, 4, 5]
@@ -123,6 +128,19 @@ B5_IECO_END_VALUES = frozenset({1, 2, 3, 8})
 IECO_SET_PADDING = 10
 B5_TURBO_HEAT_VALUES = frozenset({1, 3})
 B5_DISPLAY_VALUES = frozenset({1, 2, 100})
+# Temperature capability (0x0225). The value holds per-mode setpoint limits in
+# 0.5 C units: six raw bytes are cool then auto then heat, each a min then a
+# max, followed by a decimals flag byte.
+B5_TEMPERATURE_HALF_DEGREE = 2
+B5_TEMPERATURE_COOL_MIN_INDEX = 0
+B5_TEMPERATURE_COOL_MAX_INDEX = 1
+B5_TEMPERATURE_AUTO_MIN_INDEX = 2
+B5_TEMPERATURE_AUTO_MAX_INDEX = 3
+B5_TEMPERATURE_HEAT_MIN_INDEX = 4
+B5_TEMPERATURE_HEAT_MAX_INDEX = 5
+B5_TEMPERATURE_DECIMALS_INDEX_LONG = 6
+B5_TEMPERATURE_DECIMALS_INDEX_SHORT = 2
+B5_TEMPERATURE_DECIMALS_SIZE_THRESHOLD = 6
 
 # A B5 capability body ends with a trailing [flag, message_id, crc] block. The
 # device sets the flag byte non-zero to signal that a second (additional)
@@ -519,7 +537,7 @@ class PropertiesQuery(MessageACBase):
         self,
         protocol_version: int,
         *,
-        capabilities: dict[str, bool | int] | None = None,
+        capabilities: dict[str, CapabilityValue] | None = None,
     ) -> None:
         """Initialize AC message new protocol query.
 
@@ -1299,17 +1317,6 @@ class CapabilityBody(NewProtocolMessageBody):
         super().__init__(body)
 
         params = self.parse()
-        # Parse temperature capability for min/max setpoint limits
-        if CapabilityTag.temperature in params:
-            temp_data = params[CapabilityTag.temperature]
-            # per-mode setpoint limits in 0.5 C units. the six raw bytes are
-            # cool then auto then heat, each a min then a max, plus a flag byte.
-            # keyed by mode value: auto is 1, cool 2, dry 3, heat 4, fan 5
-            # (dry and fan reuse the cool range).
-            cool = (temp_data[0] / 2, temp_data[1] / 2)
-            auto = (temp_data[2] / 2, temp_data[3] / 2)
-            heat = (temp_data[4] / 2, temp_data[5] / 2)
-            self.temperature_limits = {1: auto, 2: cool, 3: cool, 4: heat, 5: cool}
         self._parse_capabilities(params)
         self.additional_capabilities = self._detect_additional_capabilities()
 
@@ -1336,7 +1343,43 @@ class CapabilityBody(NewProtocolMessageBody):
 
         Logs warnings for unknown tags not in CapabilityTag enum.
         """
-        caps: dict[str, bool | int] = {}
+        caps: dict[str, CapabilityValue] = {}
+
+        # Temperature capability carries per-mode setpoint limits rather than a
+        # flag. Decode the six raw half-degree bytes (cool/auto/heat, each a
+        # min then a max) into a nested map keyed by mode name so the device
+        # layer can resolve the min/max for the active mode. Dry and fan reuse
+        # the cool range, so they are not stored separately. The decimals flag
+        # indicates whether the device supports 0.5°C increments.
+        if CapabilityTag.temperature in params:
+            temp_data = params[CapabilityTag.temperature]
+            size = len(temp_data)
+            decimals_index = (
+                B5_TEMPERATURE_DECIMALS_INDEX_LONG
+                if size > B5_TEMPERATURE_DECIMALS_SIZE_THRESHOLD
+                else B5_TEMPERATURE_DECIMALS_INDEX_SHORT
+            )
+            caps["temperature"] = {
+                "cool": {
+                    "min": temp_data[B5_TEMPERATURE_COOL_MIN_INDEX]
+                    / B5_TEMPERATURE_HALF_DEGREE,
+                    "max": temp_data[B5_TEMPERATURE_COOL_MAX_INDEX]
+                    / B5_TEMPERATURE_HALF_DEGREE,
+                },
+                "auto": {
+                    "min": temp_data[B5_TEMPERATURE_AUTO_MIN_INDEX]
+                    / B5_TEMPERATURE_HALF_DEGREE,
+                    "max": temp_data[B5_TEMPERATURE_AUTO_MAX_INDEX]
+                    / B5_TEMPERATURE_HALF_DEGREE,
+                },
+                "heat": {
+                    "min": temp_data[B5_TEMPERATURE_HEAT_MIN_INDEX]
+                    / B5_TEMPERATURE_HALF_DEGREE,
+                    "max": temp_data[B5_TEMPERATURE_HEAT_MAX_INDEX]
+                    / B5_TEMPERATURE_HALF_DEGREE,
+                },
+                "decimals": temp_data[decimals_index] != 0,
+            }
 
         # Manual parsing for tags with complex/special logic
         if CapabilityTag.mode in params:
@@ -1407,6 +1450,7 @@ class CapabilityBody(NewProtocolMessageBody):
         # Tags with special parsing logic (handled above).
         manually_parsed_tags = frozenset(
             {
+                CapabilityTag.temperature,
                 CapabilityTag.mode,
                 CapabilityTag.wind_swing,
                 CapabilityTag.wind_speed,
@@ -1443,7 +1487,7 @@ class CapabilityBody(NewProtocolMessageBody):
             # value (0 -> falsy, >=1 -> truthy).
             caps[tag_name] = raw[0] if len(raw) > 0 else 0
 
-        self.capabilities = caps
+        self.capabilities: dict[str, CapabilityValue] = caps
 
 
 class StateBody(XMessageBody):

--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -1353,33 +1353,41 @@ class CapabilityBody(NewProtocolMessageBody):
         # indicates whether the device supports 0.5°C increments.
         if CapabilityTag.temperature in params:
             temp_data = params[CapabilityTag.temperature]
-            size = len(temp_data)
-            decimals_index = (
-                B5_TEMPERATURE_DECIMALS_INDEX_LONG
-                if size > B5_TEMPERATURE_DECIMALS_SIZE_THRESHOLD
-                else B5_TEMPERATURE_DECIMALS_INDEX_SHORT
-            )
-            caps["temperature"] = {
-                "cool": {
-                    "min": temp_data[B5_TEMPERATURE_COOL_MIN_INDEX]
-                    / B5_TEMPERATURE_HALF_DEGREE,
-                    "max": temp_data[B5_TEMPERATURE_COOL_MAX_INDEX]
-                    / B5_TEMPERATURE_HALF_DEGREE,
-                },
-                "auto": {
-                    "min": temp_data[B5_TEMPERATURE_AUTO_MIN_INDEX]
-                    / B5_TEMPERATURE_HALF_DEGREE,
-                    "max": temp_data[B5_TEMPERATURE_AUTO_MAX_INDEX]
-                    / B5_TEMPERATURE_HALF_DEGREE,
-                },
-                "heat": {
-                    "min": temp_data[B5_TEMPERATURE_HEAT_MIN_INDEX]
-                    / B5_TEMPERATURE_HALF_DEGREE,
-                    "max": temp_data[B5_TEMPERATURE_HEAT_MAX_INDEX]
-                    / B5_TEMPERATURE_HALF_DEGREE,
-                },
-                "decimals": temp_data[decimals_index] != 0,
-            }
+            # Skip temperature capability if data is too short to safely decode
+            # all range and decimals fields (requires indices 0-5, plus decimals)
+            if len(temp_data) < B5_TEMPERATURE_HEAT_MAX_INDEX + 1:
+                _LOGGER.warning(
+                    "Temperature capability data too short (%d bytes), skipping",
+                    len(temp_data),
+                )
+            else:
+                size = len(temp_data)
+                decimals_index = (
+                    B5_TEMPERATURE_DECIMALS_INDEX_LONG
+                    if size > B5_TEMPERATURE_DECIMALS_SIZE_THRESHOLD
+                    else B5_TEMPERATURE_DECIMALS_INDEX_SHORT
+                )
+                caps["temperature"] = {
+                    "cool": {
+                        "min": temp_data[B5_TEMPERATURE_COOL_MIN_INDEX]
+                        / B5_TEMPERATURE_HALF_DEGREE,
+                        "max": temp_data[B5_TEMPERATURE_COOL_MAX_INDEX]
+                        / B5_TEMPERATURE_HALF_DEGREE,
+                    },
+                    "auto": {
+                        "min": temp_data[B5_TEMPERATURE_AUTO_MIN_INDEX]
+                        / B5_TEMPERATURE_HALF_DEGREE,
+                        "max": temp_data[B5_TEMPERATURE_AUTO_MAX_INDEX]
+                        / B5_TEMPERATURE_HALF_DEGREE,
+                    },
+                    "heat": {
+                        "min": temp_data[B5_TEMPERATURE_HEAT_MIN_INDEX]
+                        / B5_TEMPERATURE_HALF_DEGREE,
+                        "max": temp_data[B5_TEMPERATURE_HEAT_MAX_INDEX]
+                        / B5_TEMPERATURE_HALF_DEGREE,
+                    },
+                    "decimals": temp_data[decimals_index] != 0,
+                }
 
         # Manual parsing for tags with complex/special logic
         if CapabilityTag.mode in params:

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -312,6 +312,28 @@ class TestMideaACDevice:
         assert self.device.attributes[DeviceAttributes.min_temperature] == 17
         assert self.device.attributes[DeviceAttributes.max_temperature] == 28
 
+    def test_capability_temperature_limits_missing_range(self) -> None:
+        """Test capability limits fall back when the mode range is absent.
+
+        The nested ``temperature`` map may lack the entry for the current mode
+        (e.g. a malformed B5 payload). The resolver must return None instead of
+        raising, so the consumer keeps its own default range.
+        """
+        self.device._attributes[DeviceAttributes.mode] = 2  # -> "cool"
+        # temperature dict is present but has no "cool" key.
+        self.device._capabilities["temperature"] = {"heat": {"min": 16, "max": 30}}
+        assert self.device._capability_temperature_limits() is None
+
+    def test_capability_temperature_limits_missing_min_max(self) -> None:
+        """Test capability limits return None when min/max keys are missing.
+
+        A range entry that is a dict but lacks the ``min``/``max`` keys must not
+        raise a KeyError; the resolver returns None instead.
+        """
+        self.device._attributes[DeviceAttributes.mode] = 2  # -> "cool"
+        self.device._capabilities["temperature"] = {"cool": {"min": 16}}
+        assert self.device._capability_temperature_limits() is None
+
     def test_build_query(self) -> None:
         """Test build query."""
         self.device._used_subprotocol = True

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -1202,7 +1202,7 @@ class TestMessageACResponse:
         body += bytearray([0x1E, 0x02, 0x01, 1])  # anion
         body += bytearray([0x17, 0x02, 0x01, 1])  # filter_remind
         body += bytearray([0x1A, 0x02, 0x01, 1])  # strong_wind
-        body += bytearray([0x25, 0x02, 0x07, 34, 60, 34, 60, 34, 60, 0])  # temperature
+        body += bytearray([0x25, 0x02, 0x07, 34, 60, 34, 60, 34, 60, 1])  # temperature
         # screen_display_capability
         body += bytearray([0x24, 0x02, 0x01, 1])
         body += bytearray([0x2C, 0x02, 0x01, 1])  # sound
@@ -1210,16 +1210,8 @@ class TestMessageACResponse:
         body += bytearray(1)  # trailing checksum byte (stripped by MessageResponse)
 
         response = MessageACResponse(self.header + body)
-        # Temperature limits are extracted into temperature_limits attribute
-        assert hasattr(response, "temperature_limits")
-        assert response.temperature_limits == {
-            1: (17.0, 30.0),
-            2: (17.0, 30.0),
-            3: (17.0, 30.0),
-            4: (17.0, 30.0),
-            5: (17.0, 30.0),
-        }
-        # All capability tags are parsed into capabilities dict
+        # All capability tags are parsed into capabilities dict, including the
+        # temperature capability as a nested per-mode setpoint-limit map.
         assert hasattr(response, "capabilities")
         assert response.capabilities == {
             # Manually parsed capabilities with special logic
@@ -1242,11 +1234,37 @@ class TestMessageACResponse:
             "display_control": True,
             # Presence-based capability (raw value ignored)
             "sound": True,
+            # Per-mode setpoint limits (0.5 C units): 34/2=17.0, 60/2=30.0.
+            # Decimals flag (index 6 for size=7) indicates 0.5 C support.
+            "temperature": {
+                "cool": {"min": 17.0, "max": 30.0},
+                "auto": {"min": 17.0, "max": 30.0},
+                "heat": {"min": 17.0, "max": 30.0},
+                "decimals": True,
+            },
             # Auto-parsed tags (raw value from first byte)
             "filter_remind": 1,
-            "temperature": 34,
             "humidity": 1,
         }
+
+    def test_message_query_b5_temperature_decimals_short_size(self) -> None:
+        """Test temperature decimals parsing with short size (<=6 bytes)."""
+        self.header[9] = 0x03
+        body = bytearray([0xB5, 0x01])  # Body type, params count
+        # Temperature with 6 bytes: cool/auto/heat min/max only, no trailing byte
+        # Decimals flag is at index 2 (auto min) when size <= 6
+        body += bytearray([0x25, 0x02, 0x06, 34, 60, 1, 60, 34, 60])  # temperature
+        body += bytearray(1)  # trailing checksum byte
+
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "capabilities")
+        assert "temperature" in response.capabilities
+        temp = response.capabilities["temperature"]
+        assert isinstance(temp, dict)
+        # Index 2 (third byte = 1) is the decimals flag when size = 6
+        assert temp["decimals"] is True
+        assert temp["cool"]["min"] == 17.0
+        assert temp["cool"]["max"] == 30.0
 
     def test_message_query_b5_detects_additional_capabilities(self) -> None:
         """Test the basic B5 frame's trailing flag arms the additional query.

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -1266,6 +1266,19 @@ class TestMessageACResponse:
         assert temp["cool"]["min"] == 17.0
         assert temp["cool"]["max"] == 30.0
 
+    def test_message_query_b5_temperature_too_short(self) -> None:
+        """Test temperature capability is skipped when data is too short."""
+        self.header[9] = 0x03
+        body = bytearray([0xB5, 0x01])  # Body type, params count
+        # Temperature with only 5 bytes: missing heat max index (needs 6 minimum)
+        body += bytearray([0x25, 0x02, 0x05, 34, 60, 1, 60, 34])
+        body += bytearray(1)  # trailing checksum byte
+
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "capabilities")
+        # Temperature capability should be skipped due to insufficient data
+        assert "temperature" not in response.capabilities
+
     def test_message_query_b5_detects_additional_capabilities(self) -> None:
         """Test the basic B5 frame's trailing flag arms the additional query.
 


### PR DESCRIPTION
## Summary

Refactors how the AC B5 temperature capability (`0x0225`) is decoded and stored.

Previously the six raw setpoint-limit bytes were parsed inline in
`CapabilityBody.__init__` into a `temperature_limits` attribute keyed by mode
value. This moves the decoding into `_parse_capabilities` and stores it as a
nested entry inside the regular `capabilities` map:

```python
capabilities["temperature"] = {
    "cool": {"min": 17.0, "max": 30.0},
    "auto": {"min": 17.0, "max": 30.0},
    "heat": {"min": 17.0, "max": 30.0},
    "decimals": True,  # indicates 0.5°C increment support
}
```

The limits are in degrees Celsius (raw half-degree bytes divided by 2). Dry and
fan modes reuse the cool range, so only cool/auto/heat are stored.

The `decimals` flag indicates whether the device supports 0.5°C temperature
increments. It is parsed from index 6 (when temperature data size > 6) or index 2
(when size ≤ 6), following the msmart reference implementation.

The device layer now resolves the active mode's min/max target temperature from
the merged `capabilities` map instead of a separate attribute. In
`process_message`, capabilities are merged before the setpoint limits are
resolved, so a B5 frame's temperature limits are available in the same status
update.

## Behavior

The `min_temperature` / `max_temperature` feature is unchanged: customize
overrides still win over the capability-reported values, and an unknown mode
(e.g. `0` when off) still falls back to the cool range.

## Testing

- `uv run python -m pytest ./tests/` — 1967 passed
- Full `prek run --all-files` (ruff, ruff format, mypy, pylint, commitlint) — all pass
- Coverage: no statement misses in the changed AC modules; the added parsing
  and lookup branches are exercised by existing B5 tests and new decimals tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for controlling and monitoring additional oven, microwave, water heater, and air-conditioner device models.
  - Air-conditioner capabilities now include temperature limits by operating mode and decimal-temperature support.
  - Improved decoding of device status, including power, mode, temperature, timers, sensors, and other settings.

- **Documentation**
  - Added a comprehensive catalog of supported air-conditioner protocol tags and query behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->