### PR TITLE
refactor(ac): nest B5 mode flags into capabilities modes map

### DIFF
--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -18,9 +18,11 @@ from midealan.message import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# A decoded B5 capability value. Most tags decode to a bool/int flag, but the
-# temperature tag decodes to a nested per-mode setpoint-limit map
-# ({"cool"|"auto"|"heat": {"min": float, "max": float}, "decimals": bool}).
+# A decoded B5 capability value. Most tags decode to a bool/int flag, but some
+# tags decode to a nested map. The temperature tag yields a per-mode setpoint
+# limit map, keyed "cool"/"auto"/"heat" with "min"/"max" floats plus a
+# "decimals" bool. The mode tag yields a supported-modes map, keyed
+# "heat"/"cool"/"dry"/"auto" with bool values.
 CapabilityValue = bool | int | dict[str, dict[str, float] | bool]
 
 A1_MIN_BODY_LENGTH = 18
@@ -1392,10 +1394,12 @@ class CapabilityBody(NewProtocolMessageBody):
         # Manual parsing for tags with complex/special logic
         if CapabilityTag.mode in params:
             value = params[CapabilityTag.mode][0]
-            caps["heat_mode"] = value in B5_HEAT_MODE_VALUES
-            caps["cool_mode"] = value not in B5_NO_COOL_MODE_VALUES
-            caps["dry_mode"] = value in B5_DRY_MODE_VALUES
-            caps["auto_mode"] = value in B5_AUTO_MODE_VALUES
+            caps["modes"] = {
+                "heat": value in B5_HEAT_MODE_VALUES,
+                "cool": value not in B5_NO_COOL_MODE_VALUES,
+                "dry": value in B5_DRY_MODE_VALUES,
+                "auto": value in B5_AUTO_MODE_VALUES,
+            }
 
         if CapabilityTag.wind_swing in params:
             value = params[CapabilityTag.wind_swing][0]

--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -22,7 +22,10 @@ _LOGGER = logging.getLogger(__name__)
 # tags decode to a nested map. The temperature tag yields a per-mode setpoint
 # limit map, keyed "cool"/"auto"/"heat" with "min"/"max" floats plus a
 # "decimals" bool. The mode tag yields a supported-modes map, keyed
-# "heat"/"cool"/"dry"/"auto" with bool values.
+# "heat"/"cool"/"dry"/"auto" with bool values. The wind_swing tag yields a
+# supported-swing map, keyed "horizontal"/"vertical" with bool values. The
+# wind_speed tag yields a supported-fan-speed map, keyed
+# "silent"/"low"/"medium"/"high"/"auto"/"custom" with bool values.
 CapabilityValue = bool | int | dict[str, dict[str, float] | bool]
 
 A1_MIN_BODY_LENGTH = 18
@@ -1403,27 +1406,22 @@ class CapabilityBody(NewProtocolMessageBody):
 
         if CapabilityTag.wind_swing in params:
             value = params[CapabilityTag.wind_swing][0]
-            caps["swing_horizontal"] = value in B5_SWING_HORIZONTAL_VALUES
-            caps["swing_vertical"] = value < B5_LOW_VALUE_MAX
+            caps["swing_modes"] = {
+                "horizontal": value in B5_SWING_HORIZONTAL_VALUES,
+                "vertical": value < B5_LOW_VALUE_MAX,
+            }
 
         if CapabilityTag.wind_speed in params:
             value = params[CapabilityTag.wind_speed][0]
-            caps["fan_silent"] = (
-                value == B5_FAN_CUSTOM_VALUE or value in B5_FAN_SILENT_VALUES
-            )
-            caps["fan_low"] = (
-                value == B5_FAN_CUSTOM_VALUE or value in B5_FAN_LOW_HIGH_VALUES
-            )
-            caps["fan_medium"] = (
-                value == B5_FAN_CUSTOM_VALUE or value in B5_FAN_MEDIUM_VALUES
-            )
-            caps["fan_high"] = (
-                value == B5_FAN_CUSTOM_VALUE or value in B5_FAN_LOW_HIGH_VALUES
-            )
-            caps["fan_auto"] = (
-                value == B5_FAN_CUSTOM_VALUE or value in B5_FAN_AUTO_VALUES
-            )
-            caps["fan_custom"] = value == B5_FAN_CUSTOM_VALUE
+            custom = value == B5_FAN_CUSTOM_VALUE
+            caps["fan_speeds"] = {
+                "silent": custom or value in B5_FAN_SILENT_VALUES,
+                "low": custom or value in B5_FAN_LOW_HIGH_VALUES,
+                "medium": custom or value in B5_FAN_MEDIUM_VALUES,
+                "high": custom or value in B5_FAN_LOW_HIGH_VALUES,
+                "auto": custom or value in B5_FAN_AUTO_VALUES,
+                "custom": custom,
+            }
 
         if CapabilityTag.eco in params:
             caps["eco"] = params[CapabilityTag.eco][0] in B5_ECO_VALUES

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -748,10 +748,12 @@ class TestMideaACDevice:
         self.device.process_message(self._response(body))
 
         assert self.device.capabilities == {
-            "heat_mode": True,
-            "cool_mode": True,
-            "dry_mode": False,
-            "auto_mode": True,
+            "modes": {
+                "heat": True,
+                "cool": True,
+                "dry": False,
+                "auto": True,
+            },
             "eco": True,
             "anion": True,
         }
@@ -772,7 +774,7 @@ class TestMideaACDevice:
         status = self.device.process_message(self._response(body))
 
         assert "capabilities" in status
-        assert status["capabilities"]["heat_mode"] is True
+        assert status["capabilities"]["modes"]["heat"] is True
         assert status["capabilities"] == self.device.capabilities
         # It is a copy, not the internal dict, so listeners cannot corrupt it.
         assert status["capabilities"] is not self.device.capabilities
@@ -875,7 +877,9 @@ class TestMideaACDevice:
         # Both frames merged into a single capability dict. rate_select carries
         # the raw B5 b5_electricity level count (4 in this frame), not a bool.
         assert self.device.capabilities["rate_select"] == 4
-        assert self.device.capabilities["cool_mode"] is True
+        modes = self.device.capabilities["modes"]
+        assert isinstance(modes, dict)
+        assert modes["cool"] is True
 
     def test_process_message(self) -> None:
         """Test process message."""

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -433,12 +433,16 @@ class TestNewProtocolQuery:
     def test_new_protocol_query_body_ignores_unknown_capability_keys(self) -> None:
         """Test capability keys that name no CapabilityTag member are skipped.
 
-        Manually-parsed capability keys (heat_mode, fan_low, ...) are not tag
-        names and must not raise or be appended to the query.
+        Manually-parsed capability keys (modes, swing_modes, fan_speeds, ...)
+        are not tag names and must not raise or be appended to the query.
         """
         msg = PropertiesQuery(
             protocol_version=ProtocolVersion.V1,
-            capabilities={"heat_mode": True, "fan_low": True, "cool_mode": True},
+            capabilities={
+                "modes": {"heat": True, "cool": True},
+                "swing_modes": {"horizontal": True},
+                "fan_speeds": {"low": True},
+            },
         )
         params_count = msg.body[1]
         assert params_count == len(PropertiesQuery._default_properties)
@@ -1221,14 +1225,18 @@ class TestMessageACResponse:
                 "dry": False,
                 "auto": True,
             },
-            "swing_horizontal": True,
-            "swing_vertical": True,
-            "fan_silent": False,
-            "fan_low": True,
-            "fan_medium": True,
-            "fan_high": True,
-            "fan_auto": True,
-            "fan_custom": False,
+            "swing_modes": {
+                "horizontal": True,
+                "vertical": True,
+            },
+            "fan_speeds": {
+                "silent": False,
+                "low": True,
+                "medium": True,
+                "high": True,
+                "auto": True,
+                "custom": False,
+            },
             "eco": True,
             "anion": True,
             "turbo_cool": True,
@@ -1362,12 +1370,14 @@ class TestMessageACResponse:
 
         assert hasattr(response, "capabilities")
         assert response.capabilities == {
-            "fan_silent": True,
-            "fan_low": True,
-            "fan_medium": True,
-            "fan_high": True,
-            "fan_auto": True,
-            "fan_custom": True,
+            "fan_speeds": {
+                "silent": True,
+                "low": True,
+                "medium": True,
+                "high": True,
+                "auto": True,
+                "custom": True,
+            },
         }
 
     def test_message_query_b5_value_9_fan_supports_silent_low_high_auto(
@@ -1383,12 +1393,14 @@ class TestMessageACResponse:
 
         assert hasattr(response, "capabilities")
         assert response.capabilities == {
-            "fan_silent": True,
-            "fan_low": True,
-            "fan_medium": False,
-            "fan_high": True,
-            "fan_auto": True,
-            "fan_custom": False,
+            "fan_speeds": {
+                "silent": True,
+                "low": True,
+                "medium": False,
+                "high": True,
+                "auto": True,
+                "custom": False,
+            },
         }
 
     def test_message_query_b5_warns_unknown_tag(

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -1215,10 +1215,12 @@ class TestMessageACResponse:
         assert hasattr(response, "capabilities")
         assert response.capabilities == {
             # Manually parsed capabilities with special logic
-            "heat_mode": True,
-            "cool_mode": True,
-            "dry_mode": False,
-            "auto_mode": True,
+            "modes": {
+                "heat": True,
+                "cool": True,
+                "dry": False,
+                "auto": True,
+            },
             "swing_horizontal": True,
             "swing_vertical": True,
             "fan_silent": False,
@@ -1407,7 +1409,7 @@ class TestMessageACResponse:
 
         # Known tag should parse
         assert hasattr(response, "capabilities")
-        assert "heat_mode" in response.capabilities
+        assert "modes" in response.capabilities
         # Unknown tag should trigger warning
         assert any(
             "Unknown capability tag" in record.message and "0x0299" in record.message


### PR DESCRIPTION
## Summary

First of three stacked PRs continuing the capability-map refactor from #87 (which collapsed the temperature flags into a single nested `caps["temperature"]` map).

Collapse the four flat mode capability keys into a single nested map:

- `heat_mode`, `cool_mode`, `dry_mode`, `auto_mode` → `caps["modes"] = {"heat", "cool", "dry", "auto"}`

The group name already conveys "mode", so the sub-keys drop the `_mode` suffix.

## Stacked PRs

1. **this PR** — modes → `caps["modes"]`
2. swing → `caps["swing_modes"]` (based on this branch)
3. fan → `caps["fan_speeds"]` (based on #2)

## Tested

- `uv run python -m pytest tests/` — all pass
- `uv run prek run --all-files` — ruff, format, mypy, pylint, commitlint all pass
- AC parsing lines remain at 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AC capability information now presents operating modes, swing settings, and fan speeds in grouped mappings.
  * Temperature limits can be represented for specific operating modes.
* **Bug Fixes**
  * Improved handling and reporting of structured AC capability data.
* **Tests**
  * Updated AC capability and status coverage to reflect the grouped capability format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->