### PR TITLE
refactor(ac): nest B5 fan flags into capabilities fan_speeds map

### DIFF
--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -23,7 +23,9 @@ _LOGGER = logging.getLogger(__name__)
 # limit map, keyed "cool"/"auto"/"heat" with "min"/"max" floats plus a
 # "decimals" bool. The mode tag yields a supported-modes map, keyed
 # "heat"/"cool"/"dry"/"auto" with bool values. The wind_swing tag yields a
-# supported-swing map, keyed "horizontal"/"vertical" with bool values.
+# supported-swing map, keyed "horizontal"/"vertical" with bool values. The
+# wind_speed tag yields a supported-fan-speed map, keyed
+# "silent"/"low"/"medium"/"high"/"auto"/"custom" with bool values.
 CapabilityValue = bool | int | dict[str, dict[str, float] | bool]
 
 A1_MIN_BODY_LENGTH = 18
@@ -1411,22 +1413,15 @@ class CapabilityBody(NewProtocolMessageBody):
 
         if CapabilityTag.wind_speed in params:
             value = params[CapabilityTag.wind_speed][0]
-            caps["fan_silent"] = (
-                value == B5_FAN_CUSTOM_VALUE or value in B5_FAN_SILENT_VALUES
-            )
-            caps["fan_low"] = (
-                value == B5_FAN_CUSTOM_VALUE or value in B5_FAN_LOW_HIGH_VALUES
-            )
-            caps["fan_medium"] = (
-                value == B5_FAN_CUSTOM_VALUE or value in B5_FAN_MEDIUM_VALUES
-            )
-            caps["fan_high"] = (
-                value == B5_FAN_CUSTOM_VALUE or value in B5_FAN_LOW_HIGH_VALUES
-            )
-            caps["fan_auto"] = (
-                value == B5_FAN_CUSTOM_VALUE or value in B5_FAN_AUTO_VALUES
-            )
-            caps["fan_custom"] = value == B5_FAN_CUSTOM_VALUE
+            custom = value == B5_FAN_CUSTOM_VALUE
+            caps["fan_speeds"] = {
+                "silent": custom or value in B5_FAN_SILENT_VALUES,
+                "low": custom or value in B5_FAN_LOW_HIGH_VALUES,
+                "medium": custom or value in B5_FAN_MEDIUM_VALUES,
+                "high": custom or value in B5_FAN_LOW_HIGH_VALUES,
+                "auto": custom or value in B5_FAN_AUTO_VALUES,
+                "custom": custom,
+            }
 
         if CapabilityTag.eco in params:
             caps["eco"] = params[CapabilityTag.eco][0] in B5_ECO_VALUES

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -433,12 +433,16 @@ class TestNewProtocolQuery:
     def test_new_protocol_query_body_ignores_unknown_capability_keys(self) -> None:
         """Test capability keys that name no CapabilityTag member are skipped.
 
-        Manually-parsed capability keys (heat_mode, fan_low, ...) are not tag
-        names and must not raise or be appended to the query.
+        Manually-parsed capability keys (modes, swing_modes, fan_speeds, ...)
+        are not tag names and must not raise or be appended to the query.
         """
         msg = PropertiesQuery(
             protocol_version=ProtocolVersion.V1,
-            capabilities={"heat_mode": True, "fan_low": True, "cool_mode": True},
+            capabilities={
+                "modes": {"heat": True, "cool": True},
+                "swing_modes": {"horizontal": True},
+                "fan_speeds": {"low": True},
+            },
         )
         params_count = msg.body[1]
         assert params_count == len(PropertiesQuery._default_properties)
@@ -1225,12 +1229,14 @@ class TestMessageACResponse:
                 "horizontal": True,
                 "vertical": True,
             },
-            "fan_silent": False,
-            "fan_low": True,
-            "fan_medium": True,
-            "fan_high": True,
-            "fan_auto": True,
-            "fan_custom": False,
+            "fan_speeds": {
+                "silent": False,
+                "low": True,
+                "medium": True,
+                "high": True,
+                "auto": True,
+                "custom": False,
+            },
             "eco": True,
             "anion": True,
             "turbo_cool": True,
@@ -1364,12 +1370,14 @@ class TestMessageACResponse:
 
         assert hasattr(response, "capabilities")
         assert response.capabilities == {
-            "fan_silent": True,
-            "fan_low": True,
-            "fan_medium": True,
-            "fan_high": True,
-            "fan_auto": True,
-            "fan_custom": True,
+            "fan_speeds": {
+                "silent": True,
+                "low": True,
+                "medium": True,
+                "high": True,
+                "auto": True,
+                "custom": True,
+            },
         }
 
     def test_message_query_b5_value_9_fan_supports_silent_low_high_auto(
@@ -1385,12 +1393,14 @@ class TestMessageACResponse:
 
         assert hasattr(response, "capabilities")
         assert response.capabilities == {
-            "fan_silent": True,
-            "fan_low": True,
-            "fan_medium": False,
-            "fan_high": True,
-            "fan_auto": True,
-            "fan_custom": False,
+            "fan_speeds": {
+                "silent": True,
+                "low": True,
+                "medium": False,
+                "high": True,
+                "auto": True,
+                "custom": False,
+            },
         }
 
     def test_message_query_b5_warns_unknown_tag(


### PR DESCRIPTION
## Summary

Third of three stacked PRs continuing the capability-map refactor from #87. **Based on #89** (swing map) — review/merge that first.

Collapse the six flat fan capability keys into a single nested map:

- `fan_silent`, `fan_low`, `fan_medium`, `fan_high`, `fan_auto`, `fan_custom` → `caps["fan_speeds"] = {"silent", "low", "medium", "high", "auto", "custom"}`

The group name conveys "fan", so the sub-keys drop the `fan_` prefix. The group itself is named `fan_speeds` (not `fan_modes`) to match the wind_speed source tag.

## Stacked PRs

1. #88 — modes → `caps["modes"]`
2. #89 — swing → `caps["swing_modes"]`
3. **this PR** — fan → `caps["fan_speeds"]`

## Tested

- `uv run python -m pytest tests/` — 1970 pass
- `uv run prek run --all-files` — all pass
- AC parsing lines remain at 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)