### PR TITLE
refactor(ac): unify capabilities format to arrays

### DIFF
--- a/midealan/devices/ac/__init__.py
+++ b/midealan/devices/ac/__init__.py
@@ -1121,7 +1121,18 @@ class MideaACDevice(MideaDevice):
                                 ]
                             elif isinstance(value, list):
                                 # New array format: ["heat", "cool"]
-                                normalized_caps[key] = value
+                                # Validate all elements are strings
+                                if all(isinstance(item, str) for item in value):
+                                    normalized_caps[key] = value
+                                else:
+                                    # Invalid array elements, skip with warning
+                                    _LOGGER.warning(
+                                        "[%s] Invalid capability array for %s: "
+                                        "contains non-string elements",
+                                        self.device_id,
+                                        key,
+                                    )
+                                    continue
                             else:
                                 # Invalid format, skip with warning
                                 _LOGGER.warning(

--- a/midealan/devices/ac/__init__.py
+++ b/midealan/devices/ac/__init__.py
@@ -1108,7 +1108,33 @@ class MideaACDevice(MideaDevice):
                 # missed (or disable one it wrongly reported). Values follow the
                 # capabilities map: truthy enables the tag, falsy disables it.
                 if params and isinstance(params.get("capabilities"), dict):
-                    self._customize_capabilities = params["capabilities"]
+                    caps_input = params["capabilities"]
+                    # Normalize capabilities: convert legacy dict format to array
+                    normalized_caps: dict[str, Any] = {}
+                    for key, value in caps_input.items():
+                        if key in ("modes", "fan_speeds", "swing_modes"):
+                            if isinstance(value, dict):
+                                # Legacy dict format: {"heat": true, "cool": true}
+                                # Convert to array: ["heat", "cool"]
+                                normalized_caps[key] = [
+                                    k for k, v in value.items() if v
+                                ]
+                            elif isinstance(value, list):
+                                # New array format: ["heat", "cool"]
+                                normalized_caps[key] = value
+                            else:
+                                # Invalid format, skip with warning
+                                _LOGGER.warning(
+                                    "[%s] Invalid capability format for %s: %s",
+                                    self.device_id,
+                                    key,
+                                    type(value).__name__,
+                                )
+                                continue
+                        else:
+                            # Other capabilities remain as-is
+                            normalized_caps[key] = value
+                    self._customize_capabilities = normalized_caps
             except Exception:
                 _LOGGER.exception("[%s] Set customize error", self.device_id)
             self.update_all({"temperature_step": self._temperature_step})

--- a/midealan/devices/ac/message.py
+++ b/midealan/devices/ac/message.py
@@ -26,7 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 # supported-swing map, keyed "horizontal"/"vertical" with bool values. The
 # wind_speed tag yields a supported-fan-speed map, keyed
 # "silent"/"low"/"medium"/"high"/"auto"/"custom" with bool values.
-CapabilityValue = bool | int | dict[str, dict[str, float] | bool]
+CapabilityValue = bool | int | list[str] | dict[str, dict[str, float] | bool]
 
 A1_MIN_BODY_LENGTH = 18
 
@@ -1339,7 +1339,10 @@ class CapabilityBody(NewProtocolMessageBody):
             return False
         return bool(remaining[-B5_ADDITIONAL_CAPABILITIES_TRAILER_LENGTH])
 
-    def _parse_capabilities(self, params: dict[int, bytearray]) -> None:
+    def _parse_capabilities(  # noqa: C901
+        self,
+        params: dict[int, bytearray],
+    ) -> None:
         """Decode capability values into feature flags.
 
         Parse capabilities using two strategies:
@@ -1397,31 +1400,43 @@ class CapabilityBody(NewProtocolMessageBody):
         # Manual parsing for tags with complex/special logic
         if CapabilityTag.mode in params:
             value = params[CapabilityTag.mode][0]
-            caps["modes"] = {
-                "heat": value in B5_HEAT_MODE_VALUES,
-                "cool": value not in B5_NO_COOL_MODE_VALUES,
-                "dry": value in B5_DRY_MODE_VALUES,
-                "auto": value in B5_AUTO_MODE_VALUES,
-            }
+            modes = []
+            if value in B5_HEAT_MODE_VALUES:
+                modes.append("heat")
+            if value not in B5_NO_COOL_MODE_VALUES:
+                modes.append("cool")
+            if value in B5_DRY_MODE_VALUES:
+                modes.append("dry")
+            if value in B5_AUTO_MODE_VALUES:
+                modes.append("auto")
+            caps["modes"] = modes
 
         if CapabilityTag.wind_swing in params:
             value = params[CapabilityTag.wind_swing][0]
-            caps["swing_modes"] = {
-                "horizontal": value in B5_SWING_HORIZONTAL_VALUES,
-                "vertical": value < B5_LOW_VALUE_MAX,
-            }
+            swing_modes = []
+            if value in B5_SWING_HORIZONTAL_VALUES:
+                swing_modes.append("horizontal")
+            if value < B5_LOW_VALUE_MAX:
+                swing_modes.append("vertical")
+            caps["swing_modes"] = swing_modes
 
         if CapabilityTag.wind_speed in params:
             value = params[CapabilityTag.wind_speed][0]
             custom = value == B5_FAN_CUSTOM_VALUE
-            caps["fan_speeds"] = {
-                "silent": custom or value in B5_FAN_SILENT_VALUES,
-                "low": custom or value in B5_FAN_LOW_HIGH_VALUES,
-                "medium": custom or value in B5_FAN_MEDIUM_VALUES,
-                "high": custom or value in B5_FAN_LOW_HIGH_VALUES,
-                "auto": custom or value in B5_FAN_AUTO_VALUES,
-                "custom": custom,
-            }
+            fan_speeds = []
+            if custom or value in B5_FAN_SILENT_VALUES:
+                fan_speeds.append("silent")
+            if custom or value in B5_FAN_LOW_HIGH_VALUES:
+                fan_speeds.append("low")
+            if custom or value in B5_FAN_MEDIUM_VALUES:
+                fan_speeds.append("medium")
+            if custom or value in B5_FAN_LOW_HIGH_VALUES:
+                fan_speeds.append("high")
+            if custom or value in B5_FAN_AUTO_VALUES:
+                fan_speeds.append("auto")
+            if custom:
+                fan_speeds.append("custom")
+            caps["fan_speeds"] = fan_speeds
 
         if CapabilityTag.eco in params:
             caps["eco"] = params[CapabilityTag.eco][0] in B5_ECO_VALUES

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -748,12 +748,7 @@ class TestMideaACDevice:
         self.device.process_message(self._response(body))
 
         assert self.device.capabilities == {
-            "modes": {
-                "heat": True,
-                "cool": True,
-                "dry": False,
-                "auto": True,
-            },
+            "modes": ["heat", "cool", "auto"],
             "eco": True,
             "anion": True,
         }
@@ -774,7 +769,7 @@ class TestMideaACDevice:
         status = self.device.process_message(self._response(body))
 
         assert "capabilities" in status
-        assert status["capabilities"]["modes"]["heat"] is True
+        assert "heat" in status["capabilities"]["modes"]
         assert status["capabilities"] == self.device.capabilities
         # It is a copy, not the internal dict, so listeners cannot corrupt it.
         assert status["capabilities"] is not self.device.capabilities
@@ -878,8 +873,8 @@ class TestMideaACDevice:
         # the raw B5 b5_electricity level count (4 in this frame), not a bool.
         assert self.device.capabilities["rate_select"] == 4
         modes = self.device.capabilities["modes"]
-        assert isinstance(modes, dict)
-        assert modes["cool"] is True
+        assert isinstance(modes, list)
+        assert "cool" in modes
 
     def test_process_message(self) -> None:
         """Test process message."""

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -1354,3 +1354,87 @@ class TestMideaACDevice:
     def test_invalid_customize_format(self) -> None:
         """Test invalid customize format."""
         self.device.set_customize("{")
+
+    def test_customize_capabilities_legacy_dict_format(self) -> None:
+        """Test customize with legacy dict format converts to array format."""
+        customize_str = """{
+            "capabilities": {
+                "modes": {"heat": true, "cool": true, "dry": false, "auto": true},
+                "fan_speeds": {
+                    "silent": false, "low": true, "medium": true, "high": true
+                },
+                "swing_modes": {"vertical": true, "horizontal": false, "both": true}
+            }
+        }"""
+        self.device.set_customize(customize_str)
+
+        # Legacy dict format should be converted to array format
+        assert self.device.capabilities["modes"] == ["heat", "cool", "auto"]
+        assert self.device.capabilities["fan_speeds"] == ["low", "medium", "high"]
+        assert self.device.capabilities["swing_modes"] == ["vertical", "both"]
+
+    def test_customize_capabilities_array_format(self) -> None:
+        """Test customize with array format works directly."""
+        customize_str = """{
+            "capabilities": {
+                "modes": ["heat", "cool"],
+                "fan_speeds": ["low", "high", "auto"],
+                "swing_modes": ["vertical"]
+            }
+        }"""
+        self.device.set_customize(customize_str)
+
+        # Array format should be used as-is
+        assert self.device.capabilities["modes"] == ["heat", "cool"]
+        assert self.device.capabilities["fan_speeds"] == ["low", "high", "auto"]
+        assert self.device.capabilities["swing_modes"] == ["vertical"]
+
+    def test_customize_capabilities_invalid_format_skipped(self) -> None:
+        """Test customize with invalid format is skipped with warning."""
+        customize_str = """{
+            "capabilities": {
+                "modes": "invalid_string_not_dict_or_list",
+                "fan_speeds": 123,
+                "other_capability": true
+            }
+        }"""
+        self.device.set_customize(customize_str)
+
+        # Invalid formats should be skipped and not set
+        assert "modes" not in self.device._customize_capabilities
+        assert "fan_speeds" not in self.device._customize_capabilities
+        # Other valid capabilities should still be set
+        assert self.device._customize_capabilities.get("other_capability") is True
+
+    def test_customize_capabilities_mixed_valid_invalid(self) -> None:
+        """Test customize with mix of valid and invalid capability formats."""
+        customize_str = """{
+            "capabilities": {
+                "modes": ["heat", "cool"],
+                "fan_speeds": "invalid",
+                "other_capability": true
+            }
+        }"""
+        self.device.set_customize(customize_str)
+
+        # Valid formats should be applied
+        assert self.device.capabilities["modes"] == ["heat", "cool"]
+        # Other capabilities should remain as-is
+        assert self.device.capabilities["other_capability"] is True
+
+    def test_customize_capabilities_array_with_non_string_elements(self) -> None:
+        """Test customize rejects arrays containing non-string elements."""
+        customize_str = """{
+            "capabilities": {
+                "modes": ["heat", 123, "cool"],
+                "fan_speeds": [1, 2, 3],
+                "other_capability": true
+            }
+        }"""
+        self.device.set_customize(customize_str)
+
+        # Arrays with non-string elements should be rejected and not set
+        assert "modes" not in self.device._customize_capabilities
+        assert "fan_speeds" not in self.device._customize_capabilities
+        # Other valid capabilities should still be set
+        assert self.device._customize_capabilities.get("other_capability") is True

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -439,9 +439,9 @@ class TestNewProtocolQuery:
         msg = PropertiesQuery(
             protocol_version=ProtocolVersion.V1,
             capabilities={
-                "modes": {"heat": True, "cool": True},
-                "swing_modes": {"horizontal": True},
-                "fan_speeds": {"low": True},
+                "modes": ["heat", "cool"],
+                "swing_modes": ["horizontal"],
+                "fan_speeds": ["low"],
             },
         )
         params_count = msg.body[1]
@@ -1219,24 +1219,9 @@ class TestMessageACResponse:
         assert hasattr(response, "capabilities")
         assert response.capabilities == {
             # Manually parsed capabilities with special logic
-            "modes": {
-                "heat": True,
-                "cool": True,
-                "dry": False,
-                "auto": True,
-            },
-            "swing_modes": {
-                "horizontal": True,
-                "vertical": True,
-            },
-            "fan_speeds": {
-                "silent": False,
-                "low": True,
-                "medium": True,
-                "high": True,
-                "auto": True,
-                "custom": False,
-            },
+            "modes": ["heat", "cool", "auto"],
+            "swing_modes": ["horizontal", "vertical"],
+            "fan_speeds": ["low", "medium", "high", "auto"],
             "eco": True,
             "anion": True,
             "turbo_cool": True,
@@ -1370,14 +1355,7 @@ class TestMessageACResponse:
 
         assert hasattr(response, "capabilities")
         assert response.capabilities == {
-            "fan_speeds": {
-                "silent": True,
-                "low": True,
-                "medium": True,
-                "high": True,
-                "auto": True,
-                "custom": True,
-            },
+            "fan_speeds": ["silent", "low", "medium", "high", "auto", "custom"],
         }
 
     def test_message_query_b5_value_9_fan_supports_silent_low_high_auto(
@@ -1393,14 +1371,7 @@ class TestMessageACResponse:
 
         assert hasattr(response, "capabilities")
         assert response.capabilities == {
-            "fan_speeds": {
-                "silent": True,
-                "low": True,
-                "medium": False,
-                "high": True,
-                "auto": True,
-                "custom": False,
-            },
+            "fan_speeds": ["silent", "low", "high", "auto"],
         }
 
     def test_message_query_b5_warns_unknown_tag(

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -1399,6 +1399,68 @@ class TestMessageACResponse:
             for record in caplog.records
         )
 
+    def test_message_query_b5_mode_excludes_unsupported_modes(self) -> None:
+        """Test B5 mode capability excludes modes based on value."""
+        self.header[9] = 0x03
+        body = bytearray([0xB5, 0x01])  # Body type, 1 param
+        # Value 3: no heat (not in B5_HEAT_MODE_VALUES),
+        # has cool (not in B5_NO_COOL_MODE_VALUES),
+        # no dry (not in B5_DRY_MODE_VALUES),
+        # no auto (not in B5_AUTO_MODE_VALUES)
+        body += bytearray([0x14, 0x02, 0x01, 3])  # mode tag with value 3
+        body += bytearray(1)  # trailing checksum byte
+
+        response = MessageACResponse(self.header + body)
+
+        assert hasattr(response, "capabilities")
+        assert response.capabilities["modes"] == ["cool"]
+
+    def test_message_query_b5_mode_excludes_cool_when_in_no_cool_values(
+        self,
+    ) -> None:
+        """Test B5 mode capability excludes cool for no-cool values."""
+        self.header[9] = 0x03
+        body = bytearray([0xB5, 0x01])  # Body type, 1 param
+        # Value 10: has heat (in B5_HEAT_MODE_VALUES),
+        # no cool (in B5_NO_COOL_MODE_VALUES),
+        # no dry (not in B5_DRY_MODE_VALUES),
+        # no auto (not in B5_AUTO_MODE_VALUES)
+        body += bytearray([0x14, 0x02, 0x01, 10])  # mode tag with value 10
+        body += bytearray(1)  # trailing checksum byte
+
+        response = MessageACResponse(self.header + body)
+
+        assert hasattr(response, "capabilities")
+        assert response.capabilities["modes"] == ["heat"]
+
+    def test_message_query_b5_swing_excludes_unsupported_directions(self) -> None:
+        """Test B5 swing capability excludes directions based on value."""
+        self.header[9] = 0x03
+        body = bytearray([0xB5, 0x01])  # Body type, 1 param
+        # Value 2: no horizontal (not in B5_SWING_HORIZONTAL_VALUES),
+        # no vertical (value >= B5_LOW_VALUE_MAX which is 2)
+        body += bytearray([0x15, 0x02, 0x01, 2])  # wind_swing tag with value 2
+        body += bytearray(1)  # trailing checksum byte
+
+        response = MessageACResponse(self.header + body)
+
+        assert hasattr(response, "capabilities")
+        assert response.capabilities["swing_modes"] == []
+
+    def test_message_query_b5_fan_speed_excludes_unsupported_speeds(self) -> None:
+        """Test B5 fan speed capability excludes speeds based on value."""
+        self.header[9] = 0x03
+        body = bytearray([0xB5, 0x01])  # Body type, 1 param
+        # Value 8: not custom, no silent, no low/high, no medium, no auto
+        # (8 is not in any of the B5_FAN_* sets)
+        body += bytearray([0x10, 0x02, 0x01, 8])  # wind_speed tag with value 8
+        body += bytearray(1)  # trailing checksum byte
+
+        response = MessageACResponse(self.header + body)
+
+        assert hasattr(response, "capabilities")
+        assert response.capabilities["fan_speeds"] == []
+
     @pytest.mark.parametrize(
         ("raw_value", "expected"),
         [(0x03, True), (0x00, False)],


### PR DESCRIPTION
## Summary

This PR unifies the capabilities format for AC devices by converting , , and  from dict format to array format.

## Changes

### Before
```python
capabilities["modes"] = {"heat": True, "cool": True, "dry": False}
capabilities["fan_speeds"] = {"low": True, "high": True, "medium": False}
capabilities["swing_modes"] = {"horizontal": True, "vertical": False}
```

### After
```python
capabilities["modes"] = ["heat", "cool"]
capabilities["fan_speeds"] = ["low", "high"]
capabilities["swing_modes"] = ["horizontal"]
```

## Backward Compatibility

The `set_customize()` method now automatically converts legacy dict format to the new array format, ensuring existing customize configurations continue to work:

```python
# Both formats are accepted in customize:
{"capabilities": {"modes": {"heat": true}}}  # Legacy dict format
{"capabilities": {"modes": ["heat"]}}        # New array format
```

## Implementation Details

- Updated `CapabilityBody._parse_capabilities()` to generate arrays instead of dicts
- Updated `MideaACDevice.set_customize()` to normalize legacy dict format to arrays
- Updated `CapabilityValue` type to include `list[str]`
- Updated all test assertions to use array membership checks

## Testing

- ✅ All 197 AC tests pass
- ✅ Type checking passes (mypy)
- ✅ Linting passes (ruff, pylint)
- ✅ Format checking passes

## Related

This is **Phase 0** of the AC refactoring plan, establishing a consistent format foundation for future enhancements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Air conditioner capability data now consistently represents supported modes, swing directions, and fan speeds as lists of available options.
  * Unsupported options are excluded from reported capabilities.
  * Legacy capability formats continue to be normalized, while invalid overrides are skipped with a warning.
  * Valid capability settings continue to apply even when other supplied values are invalid.
* **Tests**
  * Updated capability handling checks to reflect list-based values and supported-option membership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->