### PR TITLE
feat(ac): add HA mode mapping utilities (Phase 2)

### DIFF
--- a/midealan/devices/ac/__init__.py
+++ b/midealan/devices/ac/__init__.py
@@ -60,6 +60,15 @@ TEMPERATURE_LIMIT_MODE_KEYS = {1: "auto", 2: "cool", 3: "cool", 4: "heat", 5: "c
 # Fallback range key for an unknown mode (e.g. 0 when the unit is off).
 TEMPERATURE_LIMIT_DEFAULT_KEY = "cool"
 
+# HA fan mode mapping (Phase 2)
+# The device auto fan mode is the fixed value 102; discrete speeds map to
+# named HA fan modes by upper-bound range.
+FAN_SPEED_AUTO = 102
+FAN_SPEED_SILENT = 20
+FAN_SPEED_LOW = 40
+FAN_SPEED_MEDIUM = 60
+FAN_SPEED_HIGH = 80
+
 
 class DeviceAttributes(StrEnum):
     """Midea AC device attributes."""
@@ -896,6 +905,254 @@ class MideaACDevice(MideaDevice):
 
         # Priority 3: default basic set (for devices without B5 support)
         return ["none", "comfort", "eco", "boost", "sleep"]
+
+    # HA Mode Mapping Methods (Phase 2)
+
+    @property
+    def current_hvac_mode(self) -> str:
+        """Return current HVAC mode as Home Assistant string.
+
+        Maps device power + mode to HA hvac_mode:
+        - power=off → "off"
+        - power=on + mode=1 → "auto"
+        - power=on + mode=2 → "cool"
+        - power=on + mode=3 → "dry"
+        - power=on + mode=4 → "heat"
+        - power=on + mode=5 → "fan_only"
+
+        Returns:
+            HA hvac_mode string: "off", "auto", "cool", "heat", "dry", "fan_only"
+
+        """
+        if not self._attributes[DeviceAttributes.power]:
+            return "off"
+
+        mode = self._attributes[DeviceAttributes.mode]
+        mode_map = {
+            1: "auto",
+            2: "cool",
+            3: "dry",
+            4: "heat",
+            5: "fan_only",
+        }
+        return mode_map.get(mode, "auto")
+
+    def set_hvac_mode(self, hvac_mode: str) -> None:
+        """Set HVAC mode from Home Assistant string.
+
+        Converts HA hvac_mode to device attributes and applies them.
+
+        Args:
+            hvac_mode: HA hvac_mode string from supported_hvac_modes
+
+        Raises:
+            ValueError: if hvac_mode not in supported_hvac_modes
+
+        """
+        if hvac_mode not in self.supported_hvac_modes:
+            msg = f"Unsupported hvac_mode: {hvac_mode}"
+            raise ValueError(msg)
+
+        if hvac_mode == "off":
+            self.set_attribute(DeviceAttributes.power, False)
+            return
+
+        # Map HA mode to device mode value
+        mode_map = {
+            "auto": 1,
+            "cool": 2,
+            "dry": 3,
+            "heat": 4,
+            "fan_only": 5,
+        }
+        device_mode = mode_map[hvac_mode]
+
+        # Turn on power if needed, then set mode
+        if not self._attributes[DeviceAttributes.power]:
+            self.set_attribute(DeviceAttributes.power, True)
+        self.set_attribute(DeviceAttributes.mode, device_mode)
+
+    @property
+    def current_fan_mode(self) -> str:
+        """Return current fan mode as Home Assistant string.
+
+        Maps device fan_speed to HA fan mode using ranges:
+        - 102 → "auto" (auto fan speed)
+        - 0-19 → "silent"
+        - 20-39 → "low"
+        - 40-59 → "medium"
+        - 60-79 → "high"
+        - 80+ → "auto"
+
+        For "custom" fixed speed mode, returns "custom".
+
+        Returns:
+            HA fan_mode string
+
+        """
+        fan_speed = self._attributes[DeviceAttributes.fan_speed]
+
+        # 102 is the standard auto fan mode
+        if fan_speed == FAN_SPEED_AUTO:
+            return "auto"
+
+        # Map fan_speed ranges to HA modes
+        if fan_speed < FAN_SPEED_SILENT:
+            return "silent"
+        if fan_speed < FAN_SPEED_LOW:
+            return "low"
+        if fan_speed < FAN_SPEED_MEDIUM:
+            return "medium"
+        if fan_speed < FAN_SPEED_HIGH:
+            return "high"
+
+        # 80-100 or other values → "auto"
+        return "auto"
+
+    def set_fan_mode(self, fan_mode: str) -> None:
+        """Set fan mode from Home Assistant string.
+
+        Converts HA fan mode to device fan_speed value.
+
+        Args:
+            fan_mode: HA fan_mode string from supported_fan_modes
+
+        Raises:
+            ValueError: if fan_mode not in supported_fan_modes
+
+        """
+        if fan_mode not in self.supported_fan_modes:
+            msg = f"Unsupported fan_mode: {fan_mode}"
+            raise ValueError(msg)
+
+        # Map HA fan mode to device fan_speed value
+        fan_speed_map = {
+            "auto": FAN_SPEED_AUTO,
+            "silent": FAN_SPEED_SILENT,
+            "low": FAN_SPEED_LOW,
+            "medium": FAN_SPEED_MEDIUM,
+            "high": FAN_SPEED_HIGH,
+            "custom": FAN_SPEED_AUTO,
+        }
+        fan_speed = fan_speed_map[fan_mode]
+        self.set_attribute(DeviceAttributes.fan_speed, fan_speed)
+
+    @property
+    def current_swing_mode(self) -> str:
+        """Return current swing mode as Home Assistant string.
+
+        Maps device swing flags to HA swing mode:
+        - vertical=False, horizontal=False → "off"
+        - vertical=True, horizontal=False → "vertical"
+        - vertical=False, horizontal=True → "horizontal"
+        - vertical=True, horizontal=True → "both"
+
+        Returns:
+            HA swing_mode string
+
+        """
+        vertical = self._attributes[DeviceAttributes.swing_vertical]
+        horizontal = self._attributes[DeviceAttributes.swing_horizontal]
+
+        if vertical and horizontal:
+            return "both"
+        if vertical:
+            return "vertical"
+        if horizontal:
+            return "horizontal"
+        return "off"
+
+    def set_swing_mode(self, swing_mode: str) -> None:
+        """Set swing mode from Home Assistant string.
+
+        Converts HA swing mode to device swing flags.
+
+        Args:
+            swing_mode: HA swing_mode string from supported_swing_modes
+
+        Raises:
+            ValueError: if swing_mode not in supported_swing_modes
+
+        """
+        if swing_mode not in self.supported_swing_modes:
+            msg = f"Unsupported swing_mode: {swing_mode}"
+            raise ValueError(msg)
+
+        # Map HA swing mode to device swing flags
+        swing_map = {
+            "off": (False, False),
+            "vertical": (True, False),
+            "horizontal": (False, True),
+            "both": (True, True),
+        }
+        vertical, horizontal = swing_map[swing_mode]
+        self.set_attribute(DeviceAttributes.swing_vertical, vertical)
+        self.set_attribute(DeviceAttributes.swing_horizontal, horizontal)
+
+    @property
+    def current_preset_mode(self) -> str:
+        """Return current preset mode as Home Assistant string.
+
+        Maps device preset flags to HA preset mode with priority order:
+        - boost_mode=True → "boost"
+        - eco_mode=True → "eco"
+        - ieco=True → "ieco"
+        - sleep_mode=True → "sleep"
+        - comfort_mode=True → "comfort"
+        - else → "none"
+
+        Returns:
+            HA preset_mode string
+
+        """
+        # Check presets in priority order
+        if self._attributes.get(DeviceAttributes.boost_mode):
+            return "boost"
+        if self._attributes.get(DeviceAttributes.eco_mode):
+            return "eco"
+        if self._attributes.get(DeviceAttributes.ieco):
+            return "ieco"
+        if self._attributes.get(DeviceAttributes.sleep_mode):
+            return "sleep"
+        if self._attributes.get(DeviceAttributes.comfort_mode):
+            return "comfort"
+        return "none"
+
+    def set_preset_mode(self, preset_mode: str) -> None:
+        """Set preset mode from Home Assistant string.
+
+        Converts HA preset mode to device preset flags.
+        Turns off all other presets (mutually exclusive).
+
+        Args:
+            preset_mode: HA preset_mode string from supported_preset_modes
+
+        Raises:
+            ValueError: if preset_mode not in supported_preset_modes
+
+        """
+        if preset_mode not in self.supported_preset_modes:
+            msg = f"Unsupported preset_mode: {preset_mode}"
+            raise ValueError(msg)
+
+        # Map HA preset to device attribute
+        # set_attribute() already handles mutual exclusivity for presets
+        preset_attr_map = {
+            "none": None,
+            "boost": DeviceAttributes.boost_mode,
+            "eco": DeviceAttributes.eco_mode,
+            "ieco": DeviceAttributes.ieco,
+            "sleep": DeviceAttributes.sleep_mode,
+            "comfort": DeviceAttributes.comfort_mode,
+        }
+
+        attr = preset_attr_map[preset_mode]
+        if attr is None:
+            # Turn off all presets by setting any preset to False
+            # The set_attribute logic will turn off all others
+            self.set_attribute(DeviceAttributes.eco_mode, False)
+        else:
+            self.set_attribute(attr, True)
 
     def _capability_temperature_limits(self) -> tuple[float, float] | None:
         """Return the capability setpoint limits for the current mode, if any.

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -1814,3 +1814,357 @@ class TestHASupportProperties:
         # falls through to default basic set
         expected = ["none", "comfort", "eco", "boost", "sleep"]
         assert self.device.supported_preset_modes == expected
+
+
+class TestHAModeMapping:
+    """Test Home Assistant mode mapping methods (Phase 2)."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_device(self) -> None:
+        """Set up test device with known state."""
+        self.device = MideaACDevice(
+            name="Test AC",
+            device_id=123456789012345,
+            ip_address="192.168.1.100",
+            port=6444,
+            token="AA" * 40,
+            key="BB" * 16,
+            device_protocol=ProtocolVersion.V3,
+            model="test_model",
+            subtype=0,
+            customize="",
+        )
+        # Set device to known initial state
+        self.device._attributes[DeviceAttributes.power] = True
+        self.device._attributes[DeviceAttributes.mode] = 2  # cool
+        self.device._attributes[DeviceAttributes.fan_speed] = 102  # auto
+        self.device._attributes[DeviceAttributes.swing_vertical] = False
+        self.device._attributes[DeviceAttributes.swing_horizontal] = False
+        self.device._attributes[DeviceAttributes.boost_mode] = False
+        self.device._attributes[DeviceAttributes.eco_mode] = False
+        self.device._attributes[DeviceAttributes.ieco] = False
+        self.device._attributes[DeviceAttributes.sleep_mode] = False
+        self.device._attributes[DeviceAttributes.comfort_mode] = False
+
+    # current_hvac_mode getter tests
+
+    def test_current_hvac_mode_off(self) -> None:
+        """Test current_hvac_mode when power is off."""
+        self.device._attributes[DeviceAttributes.power] = False
+        assert self.device.current_hvac_mode == "off"
+
+    def test_current_hvac_mode_auto(self) -> None:
+        """Test current_hvac_mode for auto mode."""
+        self.device._attributes[DeviceAttributes.mode] = 1
+        assert self.device.current_hvac_mode == "auto"
+
+    def test_current_hvac_mode_cool(self) -> None:
+        """Test current_hvac_mode for cool mode."""
+        self.device._attributes[DeviceAttributes.mode] = 2
+        assert self.device.current_hvac_mode == "cool"
+
+    def test_current_hvac_mode_dry(self) -> None:
+        """Test current_hvac_mode for dry mode."""
+        self.device._attributes[DeviceAttributes.mode] = 3
+        assert self.device.current_hvac_mode == "dry"
+
+    def test_current_hvac_mode_heat(self) -> None:
+        """Test current_hvac_mode for heat mode."""
+        self.device._attributes[DeviceAttributes.mode] = 4
+        assert self.device.current_hvac_mode == "heat"
+
+    def test_current_hvac_mode_fan_only(self) -> None:
+        """Test current_hvac_mode for fan_only mode."""
+        self.device._attributes[DeviceAttributes.mode] = 5
+        assert self.device.current_hvac_mode == "fan_only"
+
+    def test_current_hvac_mode_unknown(self) -> None:
+        """Test current_hvac_mode defaults to auto for unknown mode."""
+        self.device._attributes[DeviceAttributes.mode] = 99
+        assert self.device.current_hvac_mode == "auto"
+
+    # set_hvac_mode tests
+
+    def test_set_hvac_mode_off(self) -> None:
+        """Test set_hvac_mode to off sends power=False."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_hvac_mode("off")
+            message = mock_send.call_args[0][0]
+            assert message.power is False
+
+    def test_set_hvac_mode_auto(self) -> None:
+        """Test set_hvac_mode to auto sends mode=1.
+
+        Starts from power=off to cover the power-on branch.
+        """
+        self.device._attributes[DeviceAttributes.power] = False
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_hvac_mode("auto")
+            # First call powers on the device
+            first_message = mock_send.call_args_list[0][0][0]
+            assert first_message.power is True
+            # Last call sets the mode
+            last_message = mock_send.call_args[0][0]
+            assert last_message.mode == 1
+
+    def test_set_hvac_mode_cool(self) -> None:
+        """Test set_hvac_mode to cool sends mode=2."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_hvac_mode("cool")
+            message = mock_send.call_args[0][0]
+            assert message.mode == 2
+
+    def test_set_hvac_mode_heat(self) -> None:
+        """Test set_hvac_mode to heat sends mode=4."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_hvac_mode("heat")
+            message = mock_send.call_args[0][0]
+            assert message.mode == 4
+
+    def test_set_hvac_mode_dry(self) -> None:
+        """Test set_hvac_mode to dry sends mode=3."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_hvac_mode("dry")
+            message = mock_send.call_args[0][0]
+            assert message.mode == 3
+
+    def test_set_hvac_mode_fan_only(self) -> None:
+        """Test set_hvac_mode to fan_only sends mode=5."""
+        # fan_only requires explicit enable in customize
+        self.device._customize_capabilities = {"fan_only": True}
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_hvac_mode("fan_only")
+            message = mock_send.call_args[0][0]
+            assert message.mode == 5
+
+    def test_set_hvac_mode_invalid(self) -> None:
+        """Test set_hvac_mode raises ValueError for invalid mode."""
+        with pytest.raises(ValueError, match="Unsupported hvac_mode"):
+            self.device.set_hvac_mode("invalid_mode")
+
+    # current_fan_mode getter tests
+
+    def test_current_fan_mode_auto(self) -> None:
+        """Test current_fan_mode for auto (102)."""
+        self.device._attributes[DeviceAttributes.fan_speed] = 102
+        assert self.device.current_fan_mode == "auto"
+
+    def test_current_fan_mode_silent(self) -> None:
+        """Test current_fan_mode for silent range."""
+        self.device._attributes[DeviceAttributes.fan_speed] = 10
+        assert self.device.current_fan_mode == "silent"
+
+    def test_current_fan_mode_low(self) -> None:
+        """Test current_fan_mode for low range."""
+        self.device._attributes[DeviceAttributes.fan_speed] = 30
+        assert self.device.current_fan_mode == "low"
+
+    def test_current_fan_mode_medium(self) -> None:
+        """Test current_fan_mode for medium range."""
+        self.device._attributes[DeviceAttributes.fan_speed] = 50
+        assert self.device.current_fan_mode == "medium"
+
+    def test_current_fan_mode_high(self) -> None:
+        """Test current_fan_mode for high range."""
+        self.device._attributes[DeviceAttributes.fan_speed] = 70
+        assert self.device.current_fan_mode == "high"
+
+    def test_current_fan_mode_high_range_upper(self) -> None:
+        """Test current_fan_mode for 80+ maps to auto."""
+        self.device._attributes[DeviceAttributes.fan_speed] = 85
+        assert self.device.current_fan_mode == "auto"
+
+    # set_fan_mode tests
+
+    def test_set_fan_mode_auto(self) -> None:
+        """Test set_fan_mode to auto sends fan_speed=102."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_fan_mode("auto")
+            message = mock_send.call_args[0][0]
+            assert message.fan_speed == 102
+
+    def test_set_fan_mode_silent(self) -> None:
+        """Test set_fan_mode to silent sends fan_speed=20."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_fan_mode("silent")
+            message = mock_send.call_args[0][0]
+            assert message.fan_speed == 20
+
+    def test_set_fan_mode_low(self) -> None:
+        """Test set_fan_mode to low sends fan_speed=40."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_fan_mode("low")
+            message = mock_send.call_args[0][0]
+            assert message.fan_speed == 40
+
+    def test_set_fan_mode_medium(self) -> None:
+        """Test set_fan_mode to medium sends fan_speed=60."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_fan_mode("medium")
+            message = mock_send.call_args[0][0]
+            assert message.fan_speed == 60
+
+    def test_set_fan_mode_high(self) -> None:
+        """Test set_fan_mode to high sends fan_speed=80."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_fan_mode("high")
+            message = mock_send.call_args[0][0]
+            assert message.fan_speed == 80
+
+    def test_set_fan_mode_custom(self) -> None:
+        """Test set_fan_mode to custom sends fan_speed=102."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_fan_mode("custom")
+            message = mock_send.call_args[0][0]
+            assert message.fan_speed == 102
+
+    def test_set_fan_mode_invalid(self) -> None:
+        """Test set_fan_mode raises ValueError for invalid mode."""
+        with pytest.raises(ValueError, match="Unsupported fan_mode"):
+            self.device.set_fan_mode("invalid_mode")
+
+    # current_swing_mode getter tests
+
+    def test_current_swing_mode_off(self) -> None:
+        """Test current_swing_mode when both off."""
+        assert self.device.current_swing_mode == "off"
+
+    def test_current_swing_mode_vertical(self) -> None:
+        """Test current_swing_mode for vertical only."""
+        self.device._attributes[DeviceAttributes.swing_vertical] = True
+        assert self.device.current_swing_mode == "vertical"
+
+    def test_current_swing_mode_horizontal(self) -> None:
+        """Test current_swing_mode for horizontal only."""
+        self.device._attributes[DeviceAttributes.swing_horizontal] = True
+        assert self.device.current_swing_mode == "horizontal"
+
+    def test_current_swing_mode_both(self) -> None:
+        """Test current_swing_mode for both directions."""
+        self.device._attributes[DeviceAttributes.swing_vertical] = True
+        self.device._attributes[DeviceAttributes.swing_horizontal] = True
+        assert self.device.current_swing_mode == "both"
+
+    # set_swing_mode tests
+
+    def test_set_swing_mode_off(self) -> None:
+        """Test set_swing_mode to off sends both False."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_swing_mode("off")
+            # Last call sets swing_horizontal
+            message = mock_send.call_args[0][0]
+            assert message.swing_horizontal is False
+
+    def test_set_swing_mode_vertical(self) -> None:
+        """Test set_swing_mode to vertical sends vertical=True."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_swing_mode("vertical")
+            # First call sets swing_vertical=True
+            first_message = mock_send.call_args_list[0][0][0]
+            assert first_message.swing_vertical is True
+
+    def test_set_swing_mode_horizontal(self) -> None:
+        """Test set_swing_mode to horizontal sends horizontal=True."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_swing_mode("horizontal")
+            # Last call sets swing_horizontal=True
+            message = mock_send.call_args[0][0]
+            assert message.swing_horizontal is True
+
+    def test_set_swing_mode_both(self) -> None:
+        """Test set_swing_mode to both sends both True."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_swing_mode("both")
+            first_message = mock_send.call_args_list[0][0][0]
+            last_message = mock_send.call_args[0][0]
+            assert first_message.swing_vertical is True
+            assert last_message.swing_horizontal is True
+
+    def test_set_swing_mode_invalid(self) -> None:
+        """Test set_swing_mode raises ValueError for invalid mode."""
+        with pytest.raises(ValueError, match="Unsupported swing_mode"):
+            self.device.set_swing_mode("invalid_mode")
+
+    # current_preset_mode getter tests
+
+    def test_current_preset_mode_none(self) -> None:
+        """Test current_preset_mode when no preset is active."""
+        assert self.device.current_preset_mode == "none"
+
+    def test_current_preset_mode_boost(self) -> None:
+        """Test current_preset_mode for boost (highest priority)."""
+        self.device._attributes[DeviceAttributes.boost_mode] = True
+        self.device._attributes[DeviceAttributes.eco_mode] = True
+        assert self.device.current_preset_mode == "boost"
+
+    def test_current_preset_mode_eco(self) -> None:
+        """Test current_preset_mode for eco."""
+        self.device._attributes[DeviceAttributes.eco_mode] = True
+        assert self.device.current_preset_mode == "eco"
+
+    def test_current_preset_mode_ieco(self) -> None:
+        """Test current_preset_mode for ieco."""
+        self.device._attributes[DeviceAttributes.ieco] = True
+        assert self.device.current_preset_mode == "ieco"
+
+    def test_current_preset_mode_sleep(self) -> None:
+        """Test current_preset_mode for sleep."""
+        self.device._attributes[DeviceAttributes.sleep_mode] = True
+        assert self.device.current_preset_mode == "sleep"
+
+    def test_current_preset_mode_comfort(self) -> None:
+        """Test current_preset_mode for comfort (lowest priority)."""
+        self.device._attributes[DeviceAttributes.comfort_mode] = True
+        assert self.device.current_preset_mode == "comfort"
+
+    # set_preset_mode tests
+
+    def test_set_preset_mode_none(self) -> None:
+        """Test set_preset_mode to none sends eco_mode=False."""
+        self.device._attributes[DeviceAttributes.eco_mode] = True
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_preset_mode("none")
+            message = mock_send.call_args[0][0]
+            assert message.eco_mode is False
+
+    def test_set_preset_mode_boost(self) -> None:
+        """Test set_preset_mode to boost sends boost_mode=True."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_preset_mode("boost")
+            message = mock_send.call_args[0][0]
+            assert message.boost_mode is True
+
+    def test_set_preset_mode_eco(self) -> None:
+        """Test set_preset_mode to eco sends eco_mode=True."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_preset_mode("eco")
+            message = mock_send.call_args[0][0]
+            assert message.eco_mode is True
+
+    def test_set_preset_mode_ieco(self) -> None:
+        """Test set_preset_mode to ieco sends ieco=True."""
+        # ieco is B5-only, requires it in capabilities
+        self.device._capabilities = {"modes": ["cool"], "ieco": True}
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_preset_mode("ieco")
+            message = mock_send.call_args[0][0]
+            assert message.ieco is True
+
+    def test_set_preset_mode_sleep(self) -> None:
+        """Test set_preset_mode to sleep sends sleep_mode=True."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_preset_mode("sleep")
+            message = mock_send.call_args[0][0]
+            assert message.sleep_mode is True
+
+    def test_set_preset_mode_comfort(self) -> None:
+        """Test set_preset_mode to comfort sends comfort_mode=True."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_preset_mode("comfort")
+            message = mock_send.call_args[0][0]
+            assert message.comfort_mode is True
+
+    def test_set_preset_mode_invalid(self) -> None:
+        """Test set_preset_mode raises ValueError for invalid mode."""
+        with pytest.raises(ValueError, match="Unsupported preset_mode"):
+            self.device.set_preset_mode("invalid_mode")


### PR DESCRIPTION
## Summary

Phase 2 of the Home Assistant integration support. Builds on the support-properties from Phase 1 (#92) by adding bidirectional mapping between HA climate modes and the AC device's attributes.

### Properties (device state → HA)
- `current_hvac_mode` — maps power + mode to HA `hvac_mode` strings
- `current_fan_mode` — maps device `fan_speed` to HA `fan_mode` strings
- `current_swing_mode` — maps swing flags to HA `swing_mode` strings
- `current_preset_mode` — maps preset flags to HA `preset_mode` strings

### Methods (HA → device)
- `set_hvac_mode()` — converts HA `hvac_mode` to power + mode attributes
- `set_fan_mode()` — converts HA `fan_mode` to device `fan_speed`
- `set_swing_mode()` — converts HA `swing_mode` to swing flags
- `set_preset_mode()` — converts HA `preset_mode` to preset flags

All setters validate input against the `supported_*_modes` helpers introduced in Phase 1 and raise `ValueError` on unsupported values.

## Implementation notes
- Fan speed ranges: `0-19` silent, `20-39` low, `40-59` medium, `60-79` high, `102` auto
- HVAC modes: `1` auto, `2` cool, `3` dry, `4` heat, `5` fan_only, `off` powers off
- Preset priority: boost > eco > ieco > sleep > comfort > none
- Swing modes derived from vertical/horizontal flag combinations
- New fan speed constants avoid magic numbers (PLR2004)

## Testing
- Added 49 tests covering all getters/setters, including invalid-input `ValueError` paths and message-construction verification for each `set_*`
- 150 AC device tests pass
- 100% coverage on new code
- ruff / mypy / pylint clean (pylint 10.00/10)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Home Assistant-compatible control and status mapping for HVAC modes, fan speeds, swing modes, and preset modes.
  - Added support for automatic, silent, low, medium, and high fan-speed settings.
  - Switching HVAC modes can automatically power on the device when needed.
  - Preset selections remain mutually exclusive where applicable.
  - Unsupported mode or setting requests are rejected with a clear validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->