### PR TITLE
fix: generate prettier-compatible manifest json format

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -82,7 +82,8 @@ jobs:
 
       - name: Update version in manifest
         run: |
-          echo '{".":'\ '"${{ inputs.version }}"}' > .release-please-manifest.json
+          # Use jq to produce prettier-compatible formatting (multi-line, 2-space indent)
+          jq -n --arg v "${{ inputs.version }}" '{".": $v}' > .release-please-manifest.json
 
       - name: Update version in Python code
         run: |


### PR DESCRIPTION
## Problem

The manual-release workflow generated `.release-please-manifest.json` as:
```
{".": "2026.9.1"}
```

But prettier (via prek/CI) expects inner spaces:
```diff
-{".": "2026.9.1"}
+{ ".": "2026.9.1" }
```

This caused all Python Build and Test jobs to fail on the release PR (#98).

## Fix

Replace the fragile `echo` construction with `jq`:
```bash
jq -n --arg v "${{ inputs.version }}" '{".": $v}' > .release-please-manifest.json
```

`jq` outputs standard multi-line, 2-space-indented JSON that:
- ✅ Passes the prettier prek check (verified locally with `prettier --check`)
- ✅ Matches the original manifest formatting on main

## Verification

Confirmed locally that jq output passes `npx prettier --tab-width 2 --check`.

---
🤖 Generated with Claude Code