### PR TITLE
feat(b1): expose oven programme number and target temperature

### DIFF
--- a/midealan/devices/b1/__init__.py
+++ b/midealan/devices/b1/__init__.py
@@ -22,6 +22,8 @@ class DeviceAttributes(StrEnum):
     tank_ejected = "tank_ejected"
     water_change_reminder = "water_change_reminder"
     water_shortage = "water_shortage"
+    mode = "mode"
+    target_temperature = "target_temperature"
 
 
 class MideaB1Device(MideaDevice):
@@ -54,6 +56,8 @@ class MideaB1Device(MideaDevice):
                 DeviceAttributes.tank_ejected: False,
                 DeviceAttributes.water_change_reminder: False,
                 DeviceAttributes.water_shortage: False,
+                DeviceAttributes.mode: None,
+                DeviceAttributes.target_temperature: None,
             },
         )
 
@@ -85,6 +89,14 @@ class MideaB1Device(MideaDevice):
                         )
                     else:
                         self._attributes[DeviceAttributes.status] = None
+                elif status in (
+                    DeviceAttributes.mode,
+                    DeviceAttributes.target_temperature,
+                ):
+                    # The oven zeroes both when no programme is selected.
+                    # Reported as None rather than 0, which would otherwise
+                    # read as programme number zero and a setpoint of 0 C.
+                    self._attributes[status] = value or None
                 else:
                     self._attributes[status] = value
                 new_status[str(status)] = self._attributes[status]

--- a/midealan/devices/b1/message.py
+++ b/midealan/devices/b1/message.py
@@ -9,6 +9,8 @@ from midealan.message import (
     MessageType,
 )
 
+X01_MODE_OFFSET = 7
+X01_TARGET_TEMPERATURE_OFFSET = 14
 X01_STATUS_OFFSET = 31
 X01_FLAGS_OFFSET = 32
 X01_MIN_BODY_LENGTH = X01_FLAGS_OFFSET + 1
@@ -113,6 +115,26 @@ class B1Message01Body(MessageBody):
     real showed ``door=True`` (open) with no inversion needed - everything
     else (status, time_remaining, temperature, tank/water flags) produced
     sane values matching the device's known idle state.
+
+    ``mode`` and ``target_temperature`` were added from a physical test on
+    the same oven, driving the appliance through a full session with a
+    pause after every action so each frame maps to exactly one action:
+
+    * switch on with top+bottom heat at 180 degrees - byte 7 goes 0 -> 83,
+      byte 14 goes 0 -> 180;
+    * change the setpoint to 220 degrees - byte 14 goes 180 -> 220, and
+      byte 7 does not move;
+    * switch to convection - byte 7 goes 83 -> 84 and byte 14 goes
+      220 -> 160 in the same frame, because each programme carries its own
+      default temperature;
+    * switch off - both go to 0.
+
+    Scrolling the programme dial afterwards produced further codes
+    (82, 87, 88, 94, 95, 99, 102, 103, 162, 164), each with its own
+    default setpoint, so byte 7 is a programme number rather than a
+    bit field. The codes are reported as-is: this is one appliance, and
+    guessing a name table from a single model would be worse than
+    passing the number through.
     """
 
     def __init__(self, body: bytearray) -> None:
@@ -150,6 +172,8 @@ class B1Message01Body(MessageBody):
             self.tank_ejected = (body[X01_FLAGS_OFFSET] & 0x04) > 0
             self.water_shortage = (body[X01_FLAGS_OFFSET] & 0x08) > 0
             self.water_change_reminder = (body[X01_FLAGS_OFFSET] & 0x10) > 0
+            self.mode = body[X01_MODE_OFFSET]
+            self.target_temperature = body[X01_TARGET_TEMPERATURE_OFFSET]
 
 
 class MessageB1Response(MessageResponse):

--- a/tests/devices/b1/device_b1_test.py
+++ b/tests/devices/b1/device_b1_test.py
@@ -26,6 +26,15 @@ class TestMideaB1Device:
         "0021"
     )
 
+    # Real-device X01 response captured from the same oven while running:
+    # top+bottom heat (programme 0x53) at a 180C setpoint, 30 minutes left
+    # on the timer, cavity at 33C on the way up.
+    X01_RESPONSE_711001CJ_WORKING_HEX = (
+        "010000000011005301001e000000b4ffff0000000000001e000021ffff"
+        "0000030004000000000000000000000ab803000200000000000080"
+        "000021"
+    )
+
     @pytest.fixture(autouse=True)
     def _setup_device(self) -> None:
         """Midea B1 Device setup."""
@@ -51,6 +60,8 @@ class TestMideaB1Device:
         assert self.device.attributes[DeviceAttributes.tank_ejected] is False
         assert self.device.attributes[DeviceAttributes.water_change_reminder] is False
         assert self.device.attributes[DeviceAttributes.water_shortage] is False
+        assert self.device.attributes[DeviceAttributes.mode] is None
+        assert self.device.attributes[DeviceAttributes.target_temperature] is None
 
     def test_build_query(self) -> None:
         """Test build query."""
@@ -188,6 +199,30 @@ class TestMideaB1Device:
         assert self.device.attributes[DeviceAttributes.water_shortage] is False
         assert self.device.attributes[DeviceAttributes.water_change_reminder] is False
         assert result[DeviceAttributes.status.value] == "Idle"
+        assert self.device.attributes[DeviceAttributes.mode] is None
+        assert self.device.attributes[DeviceAttributes.target_temperature] is None
+
+    def test_x01_response_mode_and_target_temperature(self) -> None:
+        """Test programme number and setpoint from a running-oven capture.
+
+        The idle capture has both bytes at zero, which is indistinguishable
+        from "not implemented", so this uses a second capture taken while
+        the oven was actually cooking. Both values were driven one at a
+        time on the physical appliance, with a pause after every action:
+        see ``B1Message01Body`` for the full sequence.
+        """
+        header = bytearray(
+            [0xAA, 0x00, DeviceType.B1] + [0x00] * 5 + [ProtocolVersion.V1],
+        ) + bytearray([MessageType.query])
+        body = bytearray.fromhex(self.X01_RESPONSE_711001CJ_WORKING_HEX)
+        result = self.device.process_message(bytes(header + body + bytearray(1)))
+        assert self.device.attributes[DeviceAttributes.mode] == 0x53
+        assert self.device.attributes[DeviceAttributes.target_temperature] == 180
+        assert self.device.attributes[DeviceAttributes.status] == "Working"
+        assert self.device.attributes[DeviceAttributes.time_remaining] == 30 * 60
+        assert self.device.attributes[DeviceAttributes.current_temperature] == 33
+        assert result[DeviceAttributes.mode.value] == 0x53
+        assert result[DeviceAttributes.target_temperature.value] == 180
 
 
 class TestMessageB1Base:


### PR DESCRIPTION
The X01 body of a B1 electric oven already carries the programme number and
the target temperature. They were simply not read: seven values were decoded
out of a sixty-byte body.

This adds `mode` (byte 7) and `target_temperature` (byte 14).

## How the offsets were established

On a real subtype-zero electric oven (model `711001CJ`, the same appliance the
existing X01 sample and its test came from), driving the appliance by hand with
a pause after every action, so that every captured frame maps to exactly one
action:

| action | what moved |
|---|---|
| switch on, top+bottom heat, 180 °C | byte 7: `0 → 83`, byte 14: `0 → 180` |
| change setpoint to 220 °C | byte 14 alone: `180 → 220` |
| switch to convection | bytes 7 and 14 **in the same frame**: `83 → 84`, `220 → 160` |
| switch off | both `→ 0` |

The third row is the interesting one: every programme carries its own default
temperature, and the appliance substitutes it when the programme changes.

Scrolling the programme dial through all thirteen programmes of this model
produced codes 82, 83, 84, 87, 88, 94, 95, 99, 102, 103, 162 and 164, each with
its own default setpoint and default duration - so byte 7 is a programme number,
not a bit field.

## Two deliberate choices

**No name table.** The codes come from a single model, and a guessed mapping
would be worse than passing the number through. Anyone who wants names can map
them where they know their own appliance.

**Zero is reported as `None`.** The oven zeroes both bytes when no programme is
selected; a bare `0` would read as "programme number zero" and "a setpoint of
0 °C".

## Tests

The existing real-device sample is an idle oven, where both bytes are zero and
therefore indistinguishable from "not implemented". Added a second capture taken
while the appliance was actually cooking, plus assertions on the initial and
idle states. `tests/devices/b1/` passes, 13 tests.

Control is untouched: `set_attribute` for B1 remains empty, this is read-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added oven status reporting for the selected mode and target temperature.
  * Unselected programs now report these values as unavailable rather than zero.

* **Tests**
  * Added coverage for idle and active oven states, including mode, target temperature, status, remaining time, and current temperature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->