### PR TITLE
fix(cd): add known model to new protocol list

### DIFF
--- a/midealan/devices/cd/__init__.py
+++ b/midealan/devices/cd/__init__.py
@@ -300,6 +300,7 @@ class MideaCDDevice(MideaDevice):
                 # an unverified RSJ000CB assumption; subtype alone cannot
                 # distinguish models with different protocol versions.
                 check_device = self.model in {
+                    "RSJ000CB",
                     "RSJRAC01",
                     "RSJRAC06",
                     "RSJRAC07",


### PR DESCRIPTION
fix issue https://github.com/wuwentao/midea_ac_lan/issues/1049

in old code:
```
# auto mode, use subtype to set value as old or new
            if return_value == LuaProtocol.auto:
                # new protocol, [subtype0, model RSJRAC01] [subtype186, model RSJ000CB]
                # old protocol. current subtype is unknown, to be done.
                check_device = (
                    self.subtype == CDSubType.T186 or self.model == "RSJRAC01",
                )
                return_value = LuaProtocol.new if check_device else LuaProtocol.old
```
[subtype186, model RSJ000CB]
curent code not process RSJ000CB and also missed subtype186

just add `RSJ000CB` to device model list and ignore subtype 186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated automatic Lua protocol selection for the RSJ000CB device model.
  * Other device models continue using their existing protocol behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->