### PR TITLE
feat(e3): add cloud usage report API and client

### DIFF
--- a/midealan/cloud.py
+++ b/midealan/cloud.py
@@ -13,9 +13,9 @@ from secrets import token_hex
 from typing import Any, cast
 
 import aiofiles
-from aiohttp import ClientConnectionError, ClientSession, ClientTimeout
+from aiohttp import ClientConnectionError, ClientError, ClientSession, ClientTimeout
 
-from midealan.exceptions import ElementMissing
+from midealan.exceptions import CloudAuthError, CloudError, ElementMissing
 
 from .security import (
     CloudSecurity,
@@ -25,6 +25,17 @@ from .security import (
 )
 
 SN8_MIN_SERIAL_LENGTH = 17
+
+# E3 gas water heaters report water and gas consumption only in the cloud: the
+# official app requests the dayReportV2 usage report through the per-cloud
+# proxy alias below, authenticated with the user access token (the LAN
+# token/key are rejected).
+DAY_REPORT_ALIAS = "/cfhrs/e3/v1/api"
+DAY_REPORT_MESSAGE = "dayReportV2"
+DAY_REPORT_TIMEOUT = ClientTimeout(20)
+# Codes the gateway answers when the access token is missing, rejected or not a
+# user token; callers log in again instead of retrying the same token.
+AUTH_ERROR_CODES = frozenset({40001, 40002, 44001})
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -153,6 +164,15 @@ def _redact_data(data: str) -> str:
         )
 
     return data
+
+
+def _day_report_error(code: object, message: object) -> CloudError:
+    """Return the error matching a dayReportV2 error payload."""
+    error_code = code if isinstance(code, int) else -1
+    text = f"{error_code}: {message}"
+    if error_code in AUTH_ERROR_CODES:
+        return CloudAuthError(text)
+    return CloudError(text)
 
 
 class MideaCloud:
@@ -316,6 +336,71 @@ class MideaCloud:
         ):
             return cast("dict", response[device_id])
         return None
+
+    def set_access_token(self, access_token: str) -> None:
+        """Use an externally obtained access token instead of logging in."""
+        self._access_token = access_token
+
+    async def get_day_report(self, appliance_id: int) -> dict[str, Any] | None:
+        """Get the dayReportV2 usage report of an appliance.
+
+        The report is served by the per-cloud proxy under
+        :data:`DAY_REPORT_ALIAS` and requires a user access token: the LAN
+        ``token``/``key`` are rejected with 40002.
+
+        Returns
+        -------
+        dict[str, Any] | None
+            The raw report result, or None when the cloud holds no report for
+            the appliance.
+
+        Raises
+        ------
+        CloudAuthError
+            If no access token is available or the cloud rejected it.
+        CloudError
+            If the cloud does not provide usage reports, could not be reached,
+            or answered with an error.
+
+        """
+        if not self._access_token:
+            msg = "No Midea cloud access token"
+            raise CloudAuthError(msg)
+        if "alias=" not in self._api_url:
+            msg = f"Cloud {self._api_url} does not provide usage reports"
+            raise CloudError(msg)
+        url = f"{self._api_url}{DAY_REPORT_ALIAS}"
+        headers = {
+            "content-type": "application/json; charset=utf-8",
+            "accessToken": self._access_token,
+        }
+        payload = {
+            "msg": DAY_REPORT_MESSAGE,
+            "params": {"applianceId": str(appliance_id)},
+        }
+        try:
+            async with self._api_lock:
+                response = await self._session.request(
+                    "POST",
+                    url,
+                    headers=headers,
+                    json=payload,
+                    timeout=DAY_REPORT_TIMEOUT,
+                )
+                data: Any = await response.json(content_type=None)
+        except (ClientError, TimeoutError, ValueError) as err:
+            msg = f"Midea cloud usage report request failed: {err}"
+            raise CloudError(msg) from err
+        if not isinstance(data, dict):
+            msg = f"Unexpected Midea cloud usage report response: {type(data).__name__}"
+            raise CloudError(msg)
+        error_code = data.get("code")
+        if error_code is not None:
+            raise _day_report_error(error_code, data.get("msg", ""))
+        if str(data.get("retCode")) != "0":
+            raise _day_report_error(0, data.get("desc", data.get("retCode")))
+        result = data.get("result")
+        return result if isinstance(result, dict) else None
 
     @staticmethod
     def _get_lua_download_metadata(

--- a/midealan/devices/e3/cloud_report.py
+++ b/midealan/devices/e3/cloud_report.py
@@ -1,0 +1,297 @@
+"""Midea E3 cloud usage report.
+
+The E3 local protocol does not report water or gas consumption; those values
+only exist in the Midea cloud, where the official app requests them with the
+``dayReportV2`` message (see :meth:`MideaCloud.get_day_report`). This module
+parses that report into an :class:`E3DayReport` and fetches it with an
+:class:`E3CloudReportClient`.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+from aiohttp import ClientSession
+
+from midealan.cloud import SUPPORTED_CLOUDS, MideaCloud, get_midea_cloud
+from midealan.exceptions import CloudAuthError, CloudError
+
+_LOGGER = logging.getLogger(__name__)
+
+# The daily values are the newest entry of the month-to-date series the report
+# carries: 31 days, or 7 on models that only report the last week.
+DAILY_SERIES_LENGTH = 31
+WEEK_SERIES_LENGTH = 7
+MONTHLY_SERIES_LENGTH = 12
+# A token issued by a fresh login is rejected for a couple of seconds until the
+# gateway propagates it, so an auth failure is retried once after this delay.
+AUTH_RETRY_DELAY = 3.0
+
+
+@dataclass(frozen=True, slots=True)
+class E3DayReport:
+    """Parsed dayReportV2 data for an E3 gas water heater.
+
+    ``*_daily`` is the most recent complete day, ``*_monthly`` the current
+    month to date and ``*_last_month`` the previous calendar month. Water is in
+    litres, gas in cubic metres and duration in minutes.
+    """
+
+    report_date: date
+    water_daily: float | None
+    gas_daily: float | None
+    duration_daily: float | None
+    water_monthly: float | None
+    gas_monthly: float | None
+    water_last_month: float | None
+    gas_last_month: float | None
+
+
+def parse_day_report(result: dict[str, Any]) -> E3DayReport:
+    """Parse a dayReportV2 ``result`` payload.
+
+    Returns
+    -------
+    E3DayReport
+        The parsed usage values.
+
+    """
+    return E3DayReport(
+        report_date=_parse_report_date(result.get("date")),
+        water_daily=_parse_daily(result, "hotwaterUsem", "hotwaterUse7"),
+        gas_daily=_parse_daily(result, "gasUsem", "gasUse7"),
+        duration_daily=_parse_daily(result, "durTimem", "durTime7"),
+        water_monthly=_parse_monthly(result, "hotwaterUsey")[0],
+        gas_monthly=_parse_monthly(result, "gasUsey")[0],
+        water_last_month=_parse_monthly(result, "hotwaterUsey")[1],
+        gas_last_month=_parse_monthly(result, "gasUsey")[1],
+    )
+
+
+def _parse_series(value: object, length: int) -> tuple[float, ...]:
+    """Parse a comma separated numeric series, keeping the newest entries.
+
+    Returns
+    -------
+    tuple[float, ...]
+        The newest ``length`` values, or an empty tuple when absent or invalid.
+
+    """
+    if not isinstance(value, str):
+        return ()
+    parts = value.split(",")
+    if len(parts) < length:
+        return ()
+    try:
+        return tuple(float(part) for part in parts[-length:])
+    except ValueError:
+        return ()
+
+
+def _parse_daily(
+    result: dict[str, Any],
+    monthly_key: str,
+    weekly_key: str,
+) -> float | None:
+    """Return the newest value of a daily series.
+
+    Falls back to the 7 day series of models that do not report the full month.
+
+    Returns
+    -------
+    float | None
+        The most recent value, or None when the report carries no series.
+
+    """
+    series = _parse_series(result.get(monthly_key), DAILY_SERIES_LENGTH)
+    if not series:
+        series = _parse_series(result.get(weekly_key), WEEK_SERIES_LENGTH)
+    return series[-1] if series else None
+
+
+def _parse_monthly(
+    result: dict[str, Any],
+    key: str,
+) -> tuple[float | None, float | None]:
+    """Return the current and previous value of a monthly series.
+
+    Returns
+    -------
+    tuple[float | None, float | None]
+        The current month to date and the previous calendar month.
+
+    """
+    series = _parse_series(result.get(key), MONTHLY_SERIES_LENGTH)
+    if not series:
+        return (None, None)
+    return (series[-1], series[-2] if len(series) > 1 else None)
+
+
+def _parse_report_date(value: object) -> date:
+    """Parse the report date, falling back to yesterday in local time.
+
+    Returns
+    -------
+    date
+        The date the report describes.
+
+    """
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value)
+        except ValueError:
+            pass
+    # Yesterday in local time: the report describes the user's day.
+    return datetime.now(tz=UTC).astimezone().date() - timedelta(days=1)
+
+
+class E3CloudReportClient:
+    """Fetch the Midea cloud usage report of E3 appliances.
+
+    Either an ``access_token`` (used as is) or an ``account``/``password`` pair
+    (used to log in and refresh the token when it expires) must be provided.
+    The report is written once a day by the cloud.
+    """
+
+    def __init__(
+        self,
+        cloud_name: str,
+        session: ClientSession,
+        *,
+        access_token: str = "",
+        account: str = "",
+        password: str = "",
+    ) -> None:
+        """Initialize the E3 cloud report client."""
+        if cloud_name not in SUPPORTED_CLOUDS:
+            msg = f"Unsupported cloud: {cloud_name}"
+            raise CloudError(msg)
+        self._cloud_name = cloud_name
+        self._session = session
+        self._access_token = access_token
+        self._account = account
+        self._password = password
+        self._cloud: MideaCloud | None = None
+
+    async def async_get_report(self, appliance_id: int) -> E3DayReport | None:
+        """Fetch and parse the usage report of an appliance.
+
+        Returns
+        -------
+        E3DayReport | None
+            The parsed report, or None when the cloud holds no report for the
+            appliance yet.
+
+        Raises
+        ------
+        CloudAuthError
+            If no credentials are stored or the cloud rejected them.
+        CloudError
+            If the cloud could not be reached or answered with an error.
+
+        """
+        try:
+            result = await self._async_fetch(appliance_id)
+        except CloudAuthError:
+            # A fresh token can be rejected until the gateway propagates it;
+            # drop the cached client and authenticate again.
+            self._cloud = None
+            result = await self._async_fetch(appliance_id)
+        return None if result is None else parse_day_report(result)
+
+    async def _async_fetch(self, appliance_id: int) -> dict[str, Any] | None:
+        """Fetch the raw report, logging in again when the token was rejected.
+
+        Returns
+        -------
+        dict[str, Any] | None
+            The raw report result, or None when the cloud holds no report.
+
+        """
+        cloud = await self._async_cloud()
+        if self._access_token:
+            # The stored token is used as is; the account, when there is one,
+            # only logs in after the token was rejected.
+            try:
+                return await cloud.get_day_report(appliance_id)
+            except CloudAuthError:
+                if not self._has_login():
+                    # A freshly stored token can need a moment to become valid
+                    # server side; retry the same token once after a delay.
+                    await asyncio.sleep(AUTH_RETRY_DELAY)
+                    return await cloud.get_day_report(appliance_id)
+                _LOGGER.debug(
+                    "Stored Midea cloud token was rejected for appliance %s, "
+                    "logging in again",
+                    appliance_id,
+                )
+                # From here on the account's token replaces the stored one.
+                self._access_token = ""
+                self._cloud = None
+                cloud = await self._async_cloud()
+        try:
+            return await cloud.get_day_report(appliance_id)
+        except CloudAuthError:
+            # A token issued by a fresh login is rejected until the gateway
+            # propagates it; retry the same token once after a short delay.
+            await asyncio.sleep(AUTH_RETRY_DELAY)
+            return await cloud.get_day_report(appliance_id)
+
+    async def _async_cloud(self) -> MideaCloud:
+        """Return the cloud client, creating it on first use.
+
+        The client is authenticated with the stored access token, or by logging
+        in with the stored account when no token is available.
+
+        Returns
+        -------
+        MideaCloud
+            The authenticated cloud client.
+
+        """
+        if self._cloud is None:
+            if self._access_token:
+                cloud = self._new_cloud()
+                cloud.set_access_token(self._access_token)
+                self._cloud = cloud
+            else:
+                self._cloud = await self._async_login_cloud()
+        return self._cloud
+
+    async def _async_login_cloud(self) -> MideaCloud:
+        """Create a cloud client logged in with the stored account.
+
+        Returns
+        -------
+        MideaCloud
+            The logged in cloud client.
+
+        Raises
+        ------
+        CloudAuthError
+            If no account is stored or the login failed.
+
+        """
+        if not self._has_login():
+            msg = "No Midea cloud access token or account stored"
+            raise CloudAuthError(msg)
+        cloud = self._new_cloud()
+        if not await cloud.login():
+            msg = "Midea cloud login failed"
+            raise CloudAuthError(msg)
+        return cloud
+
+    def _new_cloud(self) -> MideaCloud:
+        """Create a cloud client for the configured cloud."""
+        return get_midea_cloud(
+            self._cloud_name,
+            self._session,
+            self._account,
+            self._password,
+        )
+
+    def _has_login(self) -> bool:
+        """Whether account credentials allow a re-login."""
+        return bool(self._account and self._password)

--- a/midealan/exceptions.py
+++ b/midealan/exceptions.py
@@ -11,6 +11,14 @@ class CannotAuthenticate(MideaLanError):
     """Exception raised when credentials are incorrect."""
 
 
+class CloudError(MideaLanError):
+    """Exception raised when a Midea cloud request fails."""
+
+
+class CloudAuthError(CloudError):
+    """Exception raised when Midea cloud credentials are missing or rejected."""
+
+
 class CannotConnect(MideaLanError):
     """Exception raised when connection fails."""
 

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -23,7 +23,7 @@ from midealan.cloud import (
     get_midea_cloud,
     get_preset_account_cloud,
 )
-from midealan.exceptions import ElementMissing
+from midealan.exceptions import CloudAuthError, CloudError, ElementMissing
 
 # ``CloudSecurity.get_udp_id(100, method)``. Hard-coded on purpose: deriving them
 # with the same helper the implementation calls would not catch a request that
@@ -1512,3 +1512,116 @@ class CloudTest(IsolatedAsyncioTestCase):
 
         device = await cloud.get_device_info(99)
         assert device is None
+
+
+class DayReportTest(IsolatedAsyncioTestCase):
+    """Day report test case."""
+
+    @staticmethod
+    def _cloud(
+        session: Mock,
+        api_url: str = "https://mp-prod.smartmidea.net/mas/v5/app/proxy?alias=",
+    ) -> MideaCloud:
+        """Build a cloud client for the day report tests."""
+        return MideaCloud(
+            session=session,
+            security=Mock(),
+            app_id="appid",
+            app_key="appkey",
+            account="account",
+            password="password",
+            api_url=api_url,
+        )
+
+    @staticmethod
+    def _session(payload: object) -> Mock:
+        """Return a session whose single request answers with a payload."""
+        response = Mock()
+        response.json = AsyncMock(return_value=payload)
+        session = Mock()
+        session.request = AsyncMock(return_value=response)
+        return session
+
+    async def test_get_day_report(self) -> None:
+        """Request the usage report with the access token and proxy alias."""
+        session = self._session({"retCode": "0", "result": {"date": "2026-09-10"}})
+        cloud = self._cloud(session)
+        cloud.set_access_token("token")
+        result = await cloud.get_day_report(100)
+        assert result == {"date": "2026-09-10"}
+        call = session.request.await_args
+        assert call.args[0] == "POST"
+        assert call.args[1] == (
+            "https://mp-prod.smartmidea.net/mas/v5/app/proxy?alias=/cfhrs/e3/v1/api"
+        )
+        assert call.kwargs["headers"] == {
+            "content-type": "application/json; charset=utf-8",
+            "accessToken": "token",
+        }
+        assert call.kwargs["json"] == {
+            "msg": "dayReportV2",
+            "params": {"applianceId": "100"},
+        }
+
+    async def test_get_day_report_empty_result(self) -> None:
+        """Return None when the cloud holds no report for the appliance."""
+        session = self._session({"retCode": "0"})
+        cloud = self._cloud(session)
+        cloud.set_access_token("token")
+        assert await cloud.get_day_report(100) is None
+
+    async def test_get_day_report_auth_error(self) -> None:
+        """Map a rejected access token to CloudAuthError."""
+        session = self._session({"code": 40002, "msg": "token invalid"})
+        cloud = self._cloud(session)
+        cloud.set_access_token("token")
+        with pytest.raises(CloudAuthError):
+            await cloud.get_day_report(100)
+
+    async def test_get_day_report_gateway_error(self) -> None:
+        """Map a gateway error to CloudError."""
+        session = self._session({"code": 1234, "msg": "boom"})
+        cloud = self._cloud(session)
+        cloud.set_access_token("token")
+        with pytest.raises(CloudError):
+            await cloud.get_day_report(100)
+
+    async def test_get_day_report_failed_ret_code(self) -> None:
+        """Map a non-zero retCode to CloudError."""
+        session = self._session({"retCode": "1", "desc": "no report"})
+        cloud = self._cloud(session)
+        cloud.set_access_token("token")
+        with pytest.raises(CloudError):
+            await cloud.get_day_report(100)
+
+    async def test_get_day_report_invalid_response(self) -> None:
+        """Reject a response that is not a JSON object."""
+        session = self._session([])
+        cloud = self._cloud(session)
+        cloud.set_access_token("token")
+        with pytest.raises(CloudError):
+            await cloud.get_day_report(100)
+
+    async def test_get_day_report_request_failure(self) -> None:
+        """Map a connection failure to CloudError."""
+        session = Mock()
+        session.request = AsyncMock(side_effect=ClientConnectionError())
+        cloud = self._cloud(session)
+        cloud.set_access_token("token")
+        with pytest.raises(CloudError):
+            await cloud.get_day_report(100)
+
+    async def test_get_day_report_no_token(self) -> None:
+        """Reject a report request without an access token."""
+        with pytest.raises(CloudAuthError):
+            await self._cloud(Mock()).get_day_report(100)
+
+    async def test_get_day_report_no_alias(self) -> None:
+        """Reject a report request on a cloud without the proxy alias."""
+        cloud = self._cloud(
+            Mock(),
+            api_url="https://mapp.appsmb.com",  # codespell:ignore
+        )
+        cloud.set_access_token("token")
+        with pytest.raises(CloudError):
+            await cloud.get_day_report(100)

--- a/tests/devices/e3/cloud_report_test.py
+++ b/tests/devices/e3/cloud_report_test.py
@@ -1,0 +1,240 @@
+"""Test E3 cloud report."""
+
+from datetime import UTC, date, datetime
+from typing import Any
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from midealan.devices.e3.cloud_report import (
+    E3CloudReportClient,
+    parse_day_report,
+)
+from midealan.exceptions import CloudAuthError, CloudError
+
+DAILY_SERIES = ",".join(str(value) for value in range(1, 32))
+WEEK_SERIES = ",".join(str(value) for value in range(25, 32))
+MONTHLY_SERIES = ",".join(str(value) for value in range(1, 13))
+
+
+def _result(**overrides: object) -> dict[str, Any]:
+    """Build a dayReportV2 result payload with all series present."""
+    result: dict[str, Any] = {
+        "date": "2026-09-10",
+        "hotwaterUsem": DAILY_SERIES,
+        "gasUsem": DAILY_SERIES,
+        "durTimem": DAILY_SERIES,
+        "hotwaterUsey": MONTHLY_SERIES,
+        "gasUsey": MONTHLY_SERIES,
+    }
+    result.update(overrides)
+    return result
+
+
+class TestParseDayReport:
+    """Test parse_day_report."""
+
+    def test_parse_day_report(self) -> None:
+        """Parse the daily, monthly and previous month values."""
+        report = parse_day_report(_result())
+        assert report.report_date == date(2026, 9, 10)
+        assert report.water_daily == 31
+        assert report.gas_daily == 31
+        assert report.duration_daily == 31
+        assert report.water_monthly == 12
+        assert report.gas_monthly == 12
+        assert report.water_last_month == 11
+        assert report.gas_last_month == 11
+
+    def test_parse_day_report_weekly_fallback(self) -> None:
+        """Use the 7 day series when the 31 day one is missing."""
+        report = parse_day_report(
+            _result(
+                hotwaterUsem=None,
+                hotwaterUse7=WEEK_SERIES,
+                gasUsem="",
+                gasUse7=WEEK_SERIES,
+                durTimem="1,2",
+                durTime7=None,
+            ),
+        )
+        assert report.water_daily == 31
+        assert report.gas_daily == 31
+        assert report.duration_daily is None
+
+    def test_parse_day_report_missing_series(self) -> None:
+        """Report all values as None when the payload carries no series."""
+        report = parse_day_report({})
+        assert report.water_daily is None
+        assert report.gas_daily is None
+        assert report.duration_daily is None
+        assert report.water_monthly is None
+        assert report.gas_monthly is None
+        assert report.water_last_month is None
+        assert report.gas_last_month is None
+
+    def test_parse_day_report_short_monthly_series(self) -> None:
+        """Ignore a monthly series that does not cover 12 months."""
+        report = parse_day_report(_result(hotwaterUsey="1,2,3"))
+        assert report.water_monthly is None
+        assert report.water_last_month is None
+
+    def test_parse_day_report_invalid_date(self) -> None:
+        """Fall back to yesterday in local time when the date is invalid."""
+        fake_now = Mock()
+        fake_now.astimezone.return_value = datetime(2026, 9, 12, 12, 0, tzinfo=UTC)
+        with patch("midealan.devices.e3.cloud_report.datetime") as mock_datetime:
+            mock_datetime.now.return_value = fake_now
+            report = parse_day_report({"date": "not-a-date"})
+        assert report.report_date == date(2026, 9, 11)
+
+
+class E3CloudReportClientTest(IsolatedAsyncioTestCase):
+    """Test the E3 cloud report client."""
+
+    async def test_uses_stored_token(self) -> None:
+        """Use the stored access token as is, without logging in."""
+        cloud = Mock()
+        cloud.get_day_report = AsyncMock(return_value=_result())
+        session = Mock()
+        client = E3CloudReportClient("美的美居", session, access_token="token")
+        with patch(
+            "midealan.devices.e3.cloud_report.get_midea_cloud",
+            return_value=cloud,
+        ) as get_cloud:
+            report = await client.async_get_report(100)
+        get_cloud.assert_called_once_with("美的美居", session, "", "")
+        cloud.set_access_token.assert_called_once_with("token")
+        cloud.login.assert_not_called()
+        cloud.get_day_report.assert_awaited_once_with(100)
+        assert report is not None
+        assert report.water_daily == 31
+
+    async def test_retries_stored_token(self) -> None:
+        """Retry the stored token once when no account can log in."""
+        cloud = Mock()
+        cloud.get_day_report = AsyncMock(
+            side_effect=[CloudAuthError("40002"), _result()],
+        )
+        client = E3CloudReportClient("美的美居", Mock(), access_token="token")
+        with (
+            patch(
+                "midealan.devices.e3.cloud_report.get_midea_cloud",
+                return_value=cloud,
+            ),
+            patch("asyncio.sleep", AsyncMock()) as sleep,
+        ):
+            report = await client.async_get_report(100)
+        sleep.assert_awaited_once()
+        assert cloud.get_day_report.await_count == 2
+        assert report is not None
+
+    async def test_logs_in_after_rejected_token(self) -> None:
+        """Log in with the stored account when the stored token was rejected."""
+        token_cloud = Mock()
+        token_cloud.get_day_report = AsyncMock(
+            side_effect=CloudAuthError("40002"),
+        )
+        login_cloud = Mock()
+        login_cloud.login = AsyncMock(return_value=True)
+        login_cloud.get_day_report = AsyncMock(return_value=_result())
+        client = E3CloudReportClient(
+            "美的美居",
+            Mock(),
+            access_token="token",
+            account="user",
+            password="password",
+        )
+        with patch(
+            "midealan.devices.e3.cloud_report.get_midea_cloud",
+            side_effect=[token_cloud, login_cloud],
+        ):
+            report = await client.async_get_report(100)
+        token_cloud.set_access_token.assert_called_once_with("token")
+        token_cloud.login.assert_not_called()
+        login_cloud.set_access_token.assert_not_called()
+        login_cloud.login.assert_awaited_once()
+        assert report is not None
+
+    async def test_logs_in_without_token(self) -> None:
+        """Log in with the stored account when no token is stored."""
+        cloud = Mock()
+        cloud.login = AsyncMock(return_value=True)
+        cloud.get_day_report = AsyncMock(return_value=_result())
+        client = E3CloudReportClient(
+            "美的美居",
+            Mock(),
+            account="user",
+            password="password",
+        )
+        with patch(
+            "midealan.devices.e3.cloud_report.get_midea_cloud",
+            return_value=cloud,
+        ):
+            report = await client.async_get_report(100)
+        cloud.login.assert_awaited_once()
+        assert report is not None
+
+    async def test_reauthenticates_when_fresh_token_is_rejected(self) -> None:
+        """Log in again when even a fresh login token was rejected."""
+        first = Mock()
+        first.login = AsyncMock(return_value=True)
+        first.get_day_report = AsyncMock(side_effect=CloudAuthError("40002"))
+        second = Mock()
+        second.login = AsyncMock(return_value=True)
+        second.get_day_report = AsyncMock(return_value=_result())
+        client = E3CloudReportClient(
+            "美的美居",
+            Mock(),
+            account="user",
+            password="password",
+        )
+        with (
+            patch(
+                "midealan.devices.e3.cloud_report.get_midea_cloud",
+                side_effect=[first, second],
+            ),
+            patch("asyncio.sleep", AsyncMock()),
+        ):
+            report = await client.async_get_report(100)
+        first.login.assert_awaited_once()
+        assert first.get_day_report.await_count == 2
+        second.login.assert_awaited_once()
+        assert report is not None
+
+    async def test_login_failure(self) -> None:
+        """Raise CloudAuthError when the account login fails."""
+        cloud = Mock()
+        cloud.login = AsyncMock(return_value=False)
+        client = E3CloudReportClient(
+            "美的美居",
+            Mock(),
+            account="user",
+            password="password",
+        )
+        with (
+            patch(
+                "midealan.devices.e3.cloud_report.get_midea_cloud",
+                return_value=cloud,
+            ),
+            pytest.raises(CloudAuthError),
+        ):
+            await client.async_get_report(100)
+
+    async def test_no_credentials(self) -> None:
+        """Raise CloudAuthError when neither token nor account is stored."""
+        client = E3CloudReportClient("美的美居", Mock())
+        with (
+            patch(
+                "midealan.devices.e3.cloud_report.get_midea_cloud",
+            ) as get_cloud,
+            pytest.raises(CloudAuthError),
+        ):
+            await client.async_get_report(100)
+        get_cloud.assert_not_called()
+
+    def test_unsupported_cloud(self) -> None:
+        """Reject a cloud that does not provide usage reports."""
+        with pytest.raises(CloudError):
+            E3CloudReportClient("Invalid", Mock())


### PR DESCRIPTION
E3 gas water heaters report water and gas consumption only in the cloud. Add MideaCloud.get_day_report, requesting the official app's dayReportV2 report through the per-cloud proxy alias with the user access token, and midealan.devices.e3.cloud_report with the parsed E3DayReport, its parser and an E3CloudReportClient that uses a stored token or logs in with an account and refreshes the token when the gateway rejects it.

Add CloudError and CloudAuthError to midealan.exceptions for cloud request and credential failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added cloud usage reports for E3 gas water heaters.
  - Reports include daily, current-month, and previous-month water usage, gas consumption, and operating duration.
  - Added support for authenticated access using stored tokens or account credentials, including automatic reauthentication when needed.
  - Added clear error handling for authentication failures, unavailable services, and invalid report data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->